### PR TITLE
[codex] fix Docker image publishing builds

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set image names
         shell: bash
@@ -31,6 +31,39 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Set up Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler binutils
+
+      - name: Cache cargo dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+            operator/brewfs-operator/target
+          key: ${{ runner.os }}-docker-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-docker-cargo-
+
+      - name: Build BrewFS runtime binary
+        env:
+          BREWFS_CARGO_BUILD_ARGS: --locked
+        run: bash docker/build_brewfs_host_binary.sh
+
+      - name: Build BrewFS operator binary
+        run: |
+          cargo build --locked --release --manifest-path operator/brewfs-operator/Cargo.toml
+          strip --strip-debug --strip-unneeded operator/brewfs-operator/target/release/brewfs-operator \
+            || strip --strip-unneeded operator/brewfs-operator/target/release/brewfs-operator \
+            || strip operator/brewfs-operator/target/release/brewfs-operator
+          chmod 755 operator/brewfs-operator/target/release/brewfs-operator
 
       - name: Log in to GHCR
         uses: docker/login-action@v3

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -1,14 +1,3 @@
-FROM rust:1.96-bookworm AS builder
-
-WORKDIR /workspace
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends binutils protobuf-compiler \
-    && rm -rf /var/lib/apt/lists/*
-
-COPY . .
-RUN cargo build --release -p brewfs \
-    && strip target/release/brewfs
-
 FROM debian:trixie-slim
 
 RUN apt-get update \
@@ -23,7 +12,7 @@ RUN apt-get update \
         util-linux \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /workspace/target/release/brewfs /usr/local/bin/brewfs
+COPY target/release/brewfs /usr/local/bin/brewfs
 COPY docker/entrypoint.sh /usr/local/bin/brewfs-entrypoint
 
 RUN set -e; \

--- a/operator/brewfs-operator/.dockerignore
+++ b/operator/brewfs-operator/.dockerignore
@@ -1,2 +1,6 @@
 target
+target/
+!target/
+!target/release/
+!target/release/brewfs-operator
 *.log

--- a/operator/brewfs-operator/Dockerfile
+++ b/operator/brewfs-operator/Dockerfile
@@ -1,15 +1,4 @@
-FROM rust:1.96-bookworm AS builder
-
-WORKDIR /workspace
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends binutils \
-    && rm -rf /var/lib/apt/lists/*
-
-COPY . .
-RUN cargo build --release \
-    && strip target/release/brewfs-operator
-
 FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
-COPY --from=builder /workspace/target/release/brewfs-operator /usr/local/bin/brewfs-operator
+COPY target/release/brewfs-operator /usr/local/bin/brewfs-operator
 ENTRYPOINT ["/usr/local/bin/brewfs-operator"]

--- a/tests/scripts/test_docker_image_workflow_metadata.sh
+++ b/tests/scripts/test_docker_image_workflow_metadata.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+workflow="$repo_root/.github/workflows/docker-images.yml"
+runtime_dockerfile="$repo_root/docker/Dockerfile.runtime"
+operator_dockerfile="$repo_root/operator/brewfs-operator/Dockerfile"
+operator_dockerignore="$repo_root/operator/brewfs-operator/.dockerignore"
+
+assert_file() {
+  local path="$1"
+  [[ -f "$path" ]] || {
+    echo "Expected file to exist: $path" >&2
+    exit 1
+  }
+}
+
+assert_contains() {
+  local path="$1"
+  local needle="$2"
+  grep -Fq -- "$needle" "$path" || {
+    echo "Expected '$path' to contain: $needle" >&2
+    exit 1
+  }
+}
+
+assert_not_contains() {
+  local path="$1"
+  local needle="$2"
+  if grep -Fq -- "$needle" "$path"; then
+    echo "Expected '$path' not to contain: $needle" >&2
+    exit 1
+  fi
+}
+
+assert_file "$workflow"
+assert_file "$runtime_dockerfile"
+assert_file "$operator_dockerfile"
+assert_file "$operator_dockerignore"
+
+assert_contains "$workflow" "actions-rust-lang/setup-rust-toolchain@v1"
+assert_contains "$workflow" "Build BrewFS runtime binary"
+assert_contains "$workflow" "docker/build_brewfs_host_binary.sh"
+assert_contains "$workflow" "Build BrewFS operator binary"
+assert_contains "$workflow" "cargo build --locked --release --manifest-path operator/brewfs-operator/Cargo.toml"
+
+assert_contains "$runtime_dockerfile" "COPY target/release/brewfs /usr/local/bin/brewfs"
+assert_not_contains "$runtime_dockerfile" "FROM rust:"
+assert_not_contains "$runtime_dockerfile" "cargo build"
+assert_not_contains "$runtime_dockerfile" "COPY --from=builder"
+
+assert_contains "$operator_dockerfile" "COPY target/release/brewfs-operator /usr/local/bin/brewfs-operator"
+assert_not_contains "$operator_dockerfile" "FROM rust:"
+assert_not_contains "$operator_dockerfile" "cargo build"
+assert_not_contains "$operator_dockerfile" "COPY --from=builder"
+
+assert_contains "$operator_dockerignore" "!target/"
+assert_contains "$operator_dockerignore" "!target/release/"
+assert_contains "$operator_dockerignore" "!target/release/brewfs-operator"


### PR DESCRIPTION
## Summary

- Move Docker image Rust compilation out of Dockerfiles and into the GitHub Actions runner.
- Build the BrewFS runtime binary with the existing `docker/build_brewfs_host_binary.sh` helper before `docker/build-push-action` runs.
- Build the BrewFS operator binary before its image build and allow only that release binary back into the operator Docker context.
- Add a metadata regression test so the publishing Dockerfiles do not quietly reintroduce in-container Cargo builds.

## Root Cause

The failed `Docker Images` run did not fail because of the Node 24 warning. It failed while `docker/Dockerfile.runtime` was running `cargo build` inside Docker and re-downloading crates from crates.io. The log showed the `clap` crate download ending with an unexpected EOF. That made image publishing dependent on network-heavy Cargo resolution inside the Docker build step.

## Verification

- `bash tests/scripts/test_docker_image_workflow_metadata.sh`
- `bash -n tests/scripts/test_docker_image_workflow_metadata.sh`
- `git diff --check`
- `docker build -t brewfs-runtime:ci-fix -f docker/Dockerfile.runtime .` with temporary ignored placeholder binary
- `docker build -t brewfs-operator:ci-fix -f operator/brewfs-operator/Dockerfile operator/brewfs-operator` with temporary ignored placeholder binary

Note: I also started a full local `BREWFS_CARGO_BUILD_ARGS=--locked bash docker/build_brewfs_host_binary.sh`, but stopped it because the shared machine was under heavy CPU load from another long-running perf container. The CI workflow itself will still run the real Cargo release builds before packaging.
