### PR TITLE
[codex] Improve small-file metadata and deployment docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
 permissions:
   contents: read
 
+env:
+  BREWFS_RELEASE_BASE_URL: https://download.brewfs.ai/brewfs/releases
+
 jobs:
   build-and-upload:
     runs-on: ${{ matrix.target.runner }}
@@ -60,6 +63,7 @@ jobs:
           key: ${{ runner.os }}-cargo-build-target-${{ matrix.target.rust }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build binary
+        id: build
         shell: bash
         run: |
           binary_name="${{ matrix.component }}-${{ matrix.target.os }}-${{ matrix.target.arch }}"
@@ -77,6 +81,9 @@ jobs:
           chmod +x "build/${binary_name}"
           (cd build && sha256sum "${binary_name}" > "${binary_name}.sha256")
 
+          echo "binary_name=${binary_name}" >> "$GITHUB_OUTPUT"
+          echo "download_url=${BREWFS_RELEASE_BASE_URL}/${{ github.ref_name }}/${binary_name}" >> "$GITHUB_OUTPUT"
+          echo "checksum_url=${BREWFS_RELEASE_BASE_URL}/${{ github.ref_name }}/${binary_name}.sha256" >> "$GITHUB_OUTPUT"
           echo "Built binary: ${binary_name}"
 
       - name: Upload to Cloudflare R2
@@ -97,3 +104,16 @@ jobs:
           rclone copy ./build/ r2:${{ secrets.R2_BUCKET_NAME }}/brewfs/releases/${{ github.ref_name }}/ -v
 
           echo "Upload completed for ${{ matrix.component }}-${{ matrix.target.os }}-${{ matrix.target.arch }}"
+
+      - name: Publish download links
+        shell: bash
+        run: |
+          {
+            echo "### ${{ steps.build.outputs.binary_name }}"
+            echo
+            echo "| Asset | URL |"
+            echo "| --- | --- |"
+            echo "| Binary | \`${{ steps.build.outputs.download_url }}\` |"
+            echo "| SHA256 | \`${{ steps.build.outputs.checksum_url }}\` |"
+            echo
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ meta:
     namespace: tenant-a
 ```
 
-See [doc/operations/configuration.md](doc/operations/configuration.md) and the files under [examples/](examples/) for the full configuration surface.
+See [doc/operations/configuration.md](doc/operations/configuration.md), [doc/operations/binary-deployment.md](doc/operations/binary-deployment.md), and the files under [examples/](examples/) for the full configuration and deployment surface.
 
 ## CLI
 
@@ -1938,6 +1938,7 @@ Start with the [documentation index](doc/README.md).
 Common entry points:
 
 - [Configuration](doc/operations/configuration.md)
+- [Binary deployment](doc/operations/binary-deployment.md)
 - [Architecture](doc/architecture/arch.md)
 - [VFS internals](doc/vfs/README.md)
 - [Testing and CI guides](doc/README.md#testing-and-ci)

--- a/doc/README.md
+++ b/doc/README.md
@@ -10,6 +10,7 @@ plans under `doc/` unless a tool explicitly requires another location.
 |---|---|
 | Architecture overview | [architecture/arch.md](architecture/arch.md) |
 | Configuration | [operations/configuration.md](operations/configuration.md) |
+| Binary deployment | [operations/binary-deployment.md](operations/binary-deployment.md) |
 | Current performance roadmap | [performance/perf-optimization-roadmap.md](performance/perf-optimization-roadmap.md) |
 | BrewFS vs JuiceFS comparison | [performance/brewfs-vs-juicefs-analysis.md](performance/brewfs-vs-juicefs-analysis.md) |
 | Docker and CI test guide | [testing/docker-compose-test-guide.md](testing/docker-compose-test-guide.md) |
@@ -49,6 +50,7 @@ plans under `doc/` unless a tool explicitly requires another location.
 | Topic | Document |
 |---|---|
 | Configuration | [operations/configuration.md](operations/configuration.md) |
+| Binary deployment | [operations/binary-deployment.md](operations/binary-deployment.md) |
 | Control plane | [operations/control-plane.md](operations/control-plane.md) |
 | Observability | [operations/observability.md](operations/observability.md) |
 | Profiling | [operations/profiling.md](operations/profiling.md) |

--- a/doc/operations/README.md
+++ b/doc/operations/README.md
@@ -5,6 +5,7 @@ guidance. Keep user-facing operational behavior here instead of mixing it into
 architecture or performance notes.
 
 - [configuration.md](configuration.md): runtime configuration and tuning knobs.
+- [binary-deployment.md](binary-deployment.md): binary installation, systemd, and single-node deployment.
 - [control-plane.md](control-plane.md): control-plane design and workflows.
 - [observability.md](observability.md): metrics, tracing, and visibility.
 - [profiling.md](profiling.md): profiling workflow.

--- a/doc/operations/binary-deployment.md
+++ b/doc/operations/binary-deployment.md
@@ -1,0 +1,401 @@
+# 二进制部署与安装
+
+本文面向不从源码仓库直接运行的部署方式：下载或构建 `brewfs` 二进制，然后用 systemd、手工命令或容器运行挂载进程。
+
+## 支持范围
+
+- 操作系统：Linux。
+- 架构：release installer 目前按 `linux-amd64` 和 `linux-arm64` 解析二进制。
+- 运行依赖：FUSE 3、`/dev/fuse`、对象存储、元数据后端。
+- 推荐单机栈：Redis 作为元数据后端，RustFS 作为 S3 兼容对象存储。
+
+Debian/Ubuntu 常用依赖：
+
+```bash
+sudo apt-get update
+sudo apt-get install -y ca-certificates curl fuse3 util-linux
+```
+
+RHEL/CentOS/Fedora 常用依赖：
+
+```bash
+sudo dnf install -y ca-certificates curl fuse3 util-linux
+```
+
+非特权挂载需要 `fusermount3`；systemd/root 部署通常直接使用 `--privileged` 访问 `/dev/fuse`。
+
+## 方式一：单机 installer
+
+仓库提供 `scripts/install_brewfs_single_node.sh`，会安装并维护三个 systemd 服务：
+
+| 服务 | 作用 |
+|---|---|
+| `brewfs-redis.service` | Redis 元数据服务。 |
+| `brewfs-rustfs.service` | RustFS S3 兼容对象存储。 |
+| `brewfs.service` | BrewFS FUSE 挂载进程。 |
+
+默认路径：
+
+| 路径 | 说明 |
+|---|---|
+| `/usr/local/bin/brewfs` | BrewFS 二进制。 |
+| `/usr/local/bin/rustfs` | RustFS 二进制。 |
+| `/etc/brewfs/mount.yaml` | BrewFS mount 配置。 |
+| `/etc/default/brewfs*` | systemd 环境变量文件。 |
+| `/var/lib/brewfs` | Redis/RustFS/BrewFS 状态目录。 |
+| `/var/lib/brewfs/cache` | BrewFS 本地缓存目录。 |
+| `/var/log/brewfs` | 服务日志。 |
+| `/mnt/brewfs` | 默认挂载点。 |
+
+安装前需要满足下面任一条件：
+
+- 机器上已有 `redis-server`。
+- 或设置 `REDIS_DOWNLOAD_URL` 指向 redis-server 二进制或压缩包。
+
+同时需要满足下面任一条件：
+
+- `/usr/local/bin/rustfs` 已存在且可执行。
+- 或设置 `RUSTFS_DOWNLOAD_URL` 指向 rustfs 二进制或压缩包。
+
+安装示例：
+
+```bash
+sudo BREWFS_VERSION=v0.1.1 \
+  RUSTFS_DOWNLOAD_URL=https://download.example.invalid/rustfs-linux-amd64 \
+  scripts/install_brewfs_single_node.sh install
+```
+
+如果已经把 RustFS 放在 `/usr/local/bin/rustfs`：
+
+```bash
+sudo BREWFS_VERSION=v0.1.1 \
+  scripts/install_brewfs_single_node.sh install
+```
+
+installer 会从 GitHub release 检测最新 BrewFS 版本；如果环境不能访问 GitHub，显式传 `--version` 或设置 `BREWFS_VERSION`：
+
+```bash
+sudo scripts/install_brewfs_single_node.sh --version v0.1.1 install
+```
+
+tag release 的 GitHub Actions 会把每个产物的下载链接写入 workflow summary。链接规则是：
+
+```text
+https://download.brewfs.ai/brewfs/releases/<version>/brewfs-<os>-<arch>
+https://download.brewfs.ai/brewfs/releases/<version>/brewfs-<os>-<arch>.sha256
+```
+
+Linux installer 会自动选择 `brewfs-linux-amd64` 或 `brewfs-linux-arm64`。
+
+也可以完全指定下载地址：
+
+```bash
+sudo BREWFS_DOWNLOAD_URL=https://download.brewfs.ai/brewfs/releases/v0.1.1/brewfs-linux-amd64 \
+  RUSTFS_DOWNLOAD_URL=https://download.example.invalid/rustfs-linux-amd64 \
+  scripts/install_brewfs_single_node.sh install
+```
+
+常用环境覆盖：
+
+| 变量 | 默认值 | 说明 |
+|---|---:|---|
+| `BREWFS_VERSION` | 最新 release | BrewFS release tag，可写 `v0.1.1` 或 `0.1.1`。 |
+| `BREWFS_BASE_URL` | `https://download.brewfs.ai/brewfs/releases` | BrewFS release mirror。 |
+| `BREWFS_DOWNLOAD_URL` | 自动拼接 | 显式 BrewFS 二进制或压缩包 URL。 |
+| `BREWFS_REQUIRE_CHECKSUM` | `0` | 设为 `1` 时要求 `<url>.sha256` 存在且匹配。 |
+| `RUSTFS_DOWNLOAD_URL` | 空 | RustFS 二进制或压缩包 URL。 |
+| `REDIS_DOWNLOAD_URL` | 空 | redis-server 二进制或压缩包 URL。 |
+| `MOUNT_POINT` | `/mnt/brewfs` | 挂载点。 |
+| `STATE_DIR` | `/var/lib/brewfs` | 状态目录。 |
+| `LOG_DIR` | `/var/log/brewfs` | 日志目录。 |
+| `BREWFS_BUCKET` | `brewfs-data` | RustFS/S3 bucket。 |
+| `REDIS_PORT` | `6379` | Redis 端口。 |
+| `RUSTFS_PORT` | `9000` | RustFS S3 API 端口。 |
+| `RUSTFS_CONSOLE_PORT` | `9001` | RustFS console 端口。 |
+| `RUSTFS_ACCESS_KEY` | `rustfsadmin` | RustFS access key。生产环境必须修改。 |
+| `RUSTFS_SECRET_KEY` | `rustfsadmin` | RustFS secret key。生产环境必须修改。 |
+| `BREWFS_S3_PART_SIZE` | `16777216` | BrewFS S3 multipart part 大小。 |
+| `BREWFS_S3_MAX_CONCURRENCY` | `32` | BrewFS S3 multipart 最大并发。 |
+| `BREWFS_S3_FORCE_PATH_STYLE` | `true` | S3 path-style 访问。 |
+| `BREWFS_S3_DISABLE_PAYLOAD_CHECKSUM` | `true` | 禁用 S3 payload checksum。 |
+| `BREWFS_META_OPEN_FILE_CACHE_TTL_MS` | `30000` | open file attr cache TTL。 |
+| `BREWFS_META_OPEN_FILE_CACHE_CAPACITY` | `65536` | open file attr cache 容量。 |
+| `BREWFS_WRITEBACK_MODE` | `commit_before_upload` | 可改为 `upload_before_commit` 获得更保守的崩溃语义。 |
+| `BREWFS_WRITEBACK_PERSIST_SYNC` | `false` | 是否同步落盘本地 writeback stage。 |
+| `BREWFS_CACHE_TTL_MS` | `1000` | FUSE attr/entry TTL，单位 ms。 |
+| `BREWFS_FUSE_WORKERS` | `1` | FUSE worker 数。 |
+| `BREWFS_FUSE_MAX_BACKGROUND` | `512` | FUSE 最大 in-flight 请求数。 |
+| `BREWFS_FUSE_PRIVILEGED` | `true` | 生成 `fuse.privileged`。 |
+| `BREWFS_LOG_LEVEL` | `RUST_LOG` 或 `brewfs=info` | 写入 systemd 环境文件里的 `RUST_LOG`。 |
+| `BREWFS_USER` | `root` | systemd 服务用户。 |
+| `BREWFS_GROUP` | `root` | systemd 服务组。 |
+
+installer 生成的 BrewFS 配置使用：
+
+```yaml
+data:
+  backend: s3
+  s3:
+    part_size: 16777216
+    max_concurrency: 32
+    force_path_style: true
+    disable_payload_checksum: true
+meta:
+  backend: redis
+  open_file_cache_ttl_ms: 30000
+  open_file_cache_capacity: 65536
+cache:
+  writeback_mode: commit_before_upload
+  writeback_persist_sync: false
+fuse:
+  workers: 1
+  max_background: 512
+  privileged: true
+```
+
+这是面向单机 Redis + RustFS 的高吞吐配置。`commit_before_upload` 会先发布元数据再异步上传对象，依赖本机缓存盘可靠性；如果更关注崩溃后一致性，请把 `/etc/brewfs/mount.yaml` 改为：
+
+```yaml
+cache:
+  writeback_mode: upload_before_commit
+  writeback_persist_sync: true
+```
+
+修改后重启：
+
+```bash
+sudo systemctl restart brewfs.service
+```
+
+维护命令：
+
+```bash
+sudo scripts/install_brewfs_single_node.sh status
+sudo scripts/install_brewfs_single_node.sh restart
+sudo scripts/install_brewfs_single_node.sh upgrade
+sudo scripts/install_brewfs_single_node.sh uninstall
+```
+
+`uninstall` 只删除 unit 和配置文件，保留 `/var/lib/brewfs` 和 `/var/log/brewfs`。
+
+## 方式二：手工安装二进制
+
+从源码构建：
+
+```bash
+cargo build -p brewfs --release
+sudo install -m 0755 target/release/brewfs /usr/local/bin/brewfs
+```
+
+如果用于容器镜像上下文，可运行：
+
+```bash
+bash docker/build_brewfs_host_binary.sh
+```
+
+该脚本会构建 release 二进制，strip 后同步到 `target/docker/brewfs`。
+
+创建目录：
+
+```bash
+sudo install -d -m 0755 /etc/brewfs /var/lib/brewfs/data /var/cache/brewfs /var/log/brewfs /mnt/brewfs
+```
+
+写入本地 SQLite 配置 `/etc/brewfs/mount.yaml`：
+
+```yaml
+mount_point: /mnt/brewfs
+
+data:
+  backend: local-fs
+  localfs:
+    data_dir: /var/lib/brewfs/data
+
+meta:
+  backend: sqlx
+  sqlx:
+    url: "sqlite:///var/lib/brewfs/meta.db?mode=rwc"
+
+cache:
+  root: /var/cache/brewfs
+
+fuse:
+  privileged: true
+```
+
+前台验证：
+
+```bash
+sudo RUST_LOG=brewfs=info brewfs mount --config /etc/brewfs/mount.yaml
+```
+
+另一个终端检查：
+
+```bash
+mount | grep /mnt/brewfs
+brewfs info /mnt/brewfs
+```
+
+卸载：
+
+```bash
+sudo fusermount3 -u /mnt/brewfs || sudo umount /mnt/brewfs
+```
+
+## 手工 systemd unit
+
+写入 `/etc/systemd/system/brewfs.service`：
+
+```ini
+[Unit]
+Description=BrewFS Mount
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+Environment=RUST_LOG=brewfs=info
+Environment=BREWFS_LOG_FILE=/var/log/brewfs/brewfs.log
+ExecStart=/usr/local/bin/brewfs mount --config /etc/brewfs/mount.yaml
+ExecStop=/bin/sh -c 'if command -v fusermount3 >/dev/null 2>&1; then fusermount3 -u /mnt/brewfs; else umount /mnt/brewfs; fi'
+Restart=always
+RestartSec=5s
+LimitNOFILE=1048576
+TasksMax=infinity
+ReadWritePaths=/var/lib/brewfs /var/cache/brewfs /var/log/brewfs /mnt/brewfs
+
+[Install]
+WantedBy=multi-user.target
+```
+
+启用：
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now brewfs.service
+sudo systemctl status brewfs.service --no-pager
+```
+
+日志：
+
+```bash
+sudo journalctl -u brewfs.service -f
+sudo tail -f /var/log/brewfs/brewfs.log
+```
+
+## Redis + S3 手工配置
+
+Redis + RustFS/MinIO/S3 配置示例：
+
+```yaml
+mount_point: /mnt/brewfs
+
+data:
+  backend: s3
+  s3:
+    bucket: brewfs-data
+    endpoint: http://127.0.0.1:9000
+    region: us-east-1
+    force_path_style: true
+    disable_payload_checksum: true
+    part_size: 16777216
+    max_concurrency: 32
+
+meta:
+  backend: redis
+  redis:
+    url: "redis://127.0.0.1:6379/0"
+  open_file_cache_ttl_ms: 30000
+  open_file_cache_capacity: 65536
+
+cache:
+  root: /var/cache/brewfs
+  writeback_mode: upload_before_commit
+
+fuse:
+  privileged: true
+```
+
+systemd 环境文件 `/etc/default/brewfs` 可放 S3 凭据：
+
+```bash
+AWS_ACCESS_KEY_ID=rustfsadmin
+AWS_SECRET_ACCESS_KEY=rustfsadmin
+AWS_DEFAULT_REGION=us-east-1
+AWS_EC2_METADATA_DISABLED=true
+RUST_LOG=brewfs=info
+BREWFS_LOG_FILE=/var/log/brewfs/brewfs.log
+```
+
+然后在 unit 中加入：
+
+```ini
+EnvironmentFile=/etc/default/brewfs
+```
+
+## 容器运行
+
+构建 runtime 镜像：
+
+```bash
+docker build -f docker/Dockerfile.runtime -t brewfs:runtime .
+```
+
+容器内挂载需要 `/dev/fuse` 和合适权限，通常至少需要：
+
+```bash
+docker run --rm -it \
+  --device /dev/fuse \
+  --cap-add SYS_ADMIN \
+  --security-opt apparmor=unconfined \
+  -e BREWFS_DATA_BACKEND=local-fs \
+  -e BREWFS_META_BACKEND=sqlite \
+  -v /var/lib/brewfs:/var/lib/brewfs \
+  -v /mnt/brewfs:/mnt/brewfs:rshared \
+  brewfs:runtime
+```
+
+容器 entrypoint 会根据 `BREWFS_*` 环境变量生成 `/run/brewfs/config.yaml` 并执行：
+
+```bash
+brewfs mount --privileged --config /run/brewfs/config.yaml /mnt/brewfs
+```
+
+## 升级与回滚
+
+systemd 部署建议保留上一个二进制：
+
+```bash
+sudo cp -a /usr/local/bin/brewfs /usr/local/bin/brewfs.prev
+sudo install -m 0755 ./brewfs-linux-amd64 /usr/local/bin/brewfs
+sudo systemctl restart brewfs.service
+```
+
+回滚：
+
+```bash
+sudo install -m 0755 /usr/local/bin/brewfs.prev /usr/local/bin/brewfs
+sudo systemctl restart brewfs.service
+```
+
+升级后检查：
+
+```bash
+brewfs --version
+brewfs info /mnt/brewfs
+cat /mnt/brewfs/.stats 2>/dev/null || true
+```
+
+## 常见问题
+
+| 现象 | 处理 |
+|---|---|
+| `fusermount3: command not found` | 安装 `fuse3`，或使用 root/systemd 加 `--privileged`。 |
+| `permission denied: /dev/fuse` | 检查 `/dev/fuse` 权限、容器 `--device /dev/fuse`、systemd service 用户。 |
+| `mount point must be a directory` | 创建挂载目录并确保不是普通文件。 |
+| S3 bucket 不存在 | 先用对象存储工具创建 bucket；installer 在有 AWS CLI 时会尝试自动创建。 |
+| Redis 连接失败 | 检查 `meta.redis.url`、Redis bind/protected-mode、防火墙和 systemd 启动顺序。 |
+| `mmap` 或文件访问报 `No such device` | 通常表示 FUSE 挂载进程已退出或 mount 已失效；先 `fusermount3 -u /mnt/brewfs`，再检查日志并重新挂载。 |
+| 读到旧属性或目录项 | 默认 FUSE attr/entry TTL 为 1s；强一致调试可设置 `BREWFS_CACHE_TTL_MS=0` 后重启。 |
+
+更完整的配置项见 [configuration.md](configuration.md)。

--- a/doc/operations/configuration.md
+++ b/doc/operations/configuration.md
@@ -1,275 +1,345 @@
-# 配置与部署
+# 配置指南
 
-BrewFS 是单二进制程序，通过 CLI 参数、YAML 配置文件和环境变量控制所有行为。
+BrewFS 是单二进制程序。挂载时主要通过 `brewfs mount` 的命令行参数和 YAML 配置文件控制运行行为；命令行参数优先级高于 YAML。日志、FUSE 调试和部分实验性开关通过环境变量控制。
 
-源码位置：`src/config.rs`、`src/main.rs`
+相关代码入口：
 
-## CLI 命令
+- `src/config.rs`: CLI 参数、YAML schema、默认值合并逻辑。
+- `src/main.rs`: 后端创建、control plane、mount 生命周期。
+- `src/vfs/cache/config.rs`: VFS 读写缓存默认值。
+- `src/meta/config.rs`: meta client cache 和 compaction 默认值。
 
-```
-brewfs <SUBCOMMAND>
-```
+## 快速模板
 
-三个子命令：
+最小配置只需要挂载点。其余字段使用默认值：本地对象目录 `./data`、SQLx 元数据、内存 SQLite、64 MiB chunk、4 MiB block。
 
-| 命令 | 说明 |
-|---|---|
-| `brewfs mount [OPTIONS] [MOUNT_POINT]` | FUSE 挂载 |
-| `brewfs gc [MOUNT_POINT] [--dry-run]` | 触发 GC（与运行中的 daemon 通信） |
-| `brewfs info [MOUNT_POINT]` | 查看挂载信息 |
-
-### mount 参数
-
-```
-brewfs mount [MOUNT_POINT] \
-  --config <FILE>                     # YAML 配置文件
-  --data-backend <local-fs|s3>        # 数据后端
-  --data-dir <DIR>                    # LocalFS 数据目录
-  --s3-bucket <BUCKET>                # S3 桶
-  --s3-endpoint <URL>                 # S3 兼容端点
-  --s3-region <REGION>                # S3 区域
-  --s3-part-size <BYTES>             # S3 multipart 分片大小 (默认 16 MiB)
-  --s3-max-concurrency <N>           # S3 最大并发 (默认 32)
-  --s3-force-path-style              # 强制 path-style 访问
-  --s3-disable-payload-checksum      # 禁用 S3 payload SHA-256 签名
-  --meta-backend <sqlx|etcd|redis>   # 元数据后端
-  --meta-url <URL>                    # 元数据 URL
-  --meta-etcd-urls <URL1,URL2,...>   # Etcd 端点
-  --chunk-size <BYTES>               # Chunk 大小 (默认 64 MiB)
-  --block-size <BYTES>               # Block 大小 (默认 4 MiB)
-  --fuse-workers <N>                  # FUSE worker 数 (默认 1)
-  --fuse-max-background <N>          # FUSE 最大排队请求 (默认 512)
-  --privileged                       # 特权挂载模式 (使用 /dev/fuse)
+```yaml
+mount_point: /mnt/brewfs
 ```
 
-### mount YAML 配置
-
-所有 CLI 参数都可以通过 YAML 文件配置：
+本地开发常用配置：
 
 ```yaml
 mount_point: /mnt/brewfs
 
 data:
-  backend: local-fs    # 或 s3
+  backend: local-fs
   localfs:
-    data_dir: /data/brewfs
-  s3:
-    bucket: my-bucket
-    endpoint: https://s3.example.com
-    region: us-east-1
-    part_size: 16777216        # 16 MiB
-    max_concurrency: 32
-    force_path_style: true
-    disable_payload_checksum: false
+    data_dir: /var/lib/brewfs/data
 
 meta:
-  backend: sqlx         # 或 etcd / redis
+  backend: sqlx
   sqlx:
-    url: "sqlite:///var/lib/brewfs/meta.db"
-  # 或:
-  # etcd:
-  #   urls:
-  #     - http://10.0.0.1:2379
-  #     - http://10.0.0.2:2379
-  # 或:
-  # redis:
-  #   url: "redis://127.0.0.1:6379/0"
-
-layout:
-  chunk_size: 67108864          # 64 MiB
-  block_size: 4194304            # 4 MiB
-
-fuse:
-  workers: 4
-  max_background: 64
-  privileged: false
+    url: "sqlite:///var/lib/brewfs/meta.db?mode=rwc"
 
 cache:
   root: /var/cache/brewfs
-  read_memory_bytes: 4294967296       # 4 GiB
-  read_ssd_bytes: 10737418240         # 10 GiB (磁盘冷缓存)
-  write_memory_bytes: 1073741824      # 1 GiB
-  write_ssd_bytes: 0
-  dirty_slice_target_size: 67108864   # 64 MiB
-  dirty_slice_max_age_ms: 500
-  prefetch_enabled: true
-  prefetch_max_bytes: 268435456       # 256 MiB
-  prefetch_concurrency: 2
-  memory_budget_bytes: 8589934592     # 8 GiB
-  compression: none                   # none / lz4 / zstd
-  zstd_level: 3
-  bandwidth:
-    upload_limit_mibps: 100
-    download_limit_mibps: 200
 ```
 
-CLI 参数优先级高于 YAML 配置。例如配置文件指定了 `chunk_size: 67108864`，但 CLI 传了 `--chunk-size 134217728`，则使用 128 MiB。
+Redis + RustFS/MinIO/S3 兼容对象存储配置：
 
-## 数据后端
+```yaml
+mount_point: /mnt/brewfs
 
-### LocalFS
+data:
+  backend: s3
+  s3:
+    bucket: brewfs-data
+    endpoint: http://127.0.0.1:9000
+    region: us-east-1
+    force_path_style: true
+    disable_payload_checksum: true
+    part_size: 16777216
+    max_concurrency: 32
 
-以本地目录模拟对象存储，适用于单机开发和测试：
+meta:
+  backend: redis
+  redis:
+    url: "redis://127.0.0.1:6379/0"
+  open_file_cache_ttl_ms: 30000
+  open_file_cache_capacity: 65536
+
+cache:
+  root: /var/cache/brewfs
+  writeback_mode: upload_before_commit
+
+fuse:
+  workers: 1
+  max_background: 512
+  privileged: false
+```
+
+运行：
 
 ```bash
-brewfs mount /mnt/brewfs \
-  --data-backend local-fs \
-  --data-dir /tmp/brewfs-data \
-  --meta-url sqlite:///tmp/brewfs/meta.db
-```
-
-Block 数据以 `chunks/{slice_id}/{block_index}` 的目录结构存储在 `data-dir` 下。
-
-### S3
-
-接入任何 S3 兼容的对象存储（AWS S3、MinIO、Ceph RGW 等）：
-
-```bash
-brewfs mount /mnt/brewfs \
-  --data-backend s3 \
-  --s3-bucket my-bucket \
-  --s3-endpoint https://s3.example.com \
-  --meta-backend redis \
-  --meta-url redis://10.0.0.1:6379/0
-```
-
-S3 相关参数说明：
-
-| 参数 | 默认值 | 说明 |
-|---|---|---|
-| `s3-part-size` | 16 MiB | Multipart upload 的 part 大小 |
-| `s3-max-concurrency` | 32 | Multipart upload 的并发 part 数 |
-| `s3-force-path-style` | false | MinIO 等需要 path-style 访问时必须开启 |
-| `s3-disable-payload-checksum` | true | 禁用 SigV4 payload SHA-256 签名（减少 ~20% CPU） |
-
-## 元数据后端
-
-### SQLx (DatabaseMetaStore)
-
-支持 SQLite 和 PostgreSQL：
-
-```bash
-# SQLite (开发/单机)
---meta-backend sqlx --meta-url "sqlite:///path/to/meta.db"
-# SQLite 内存 (测试)
---meta-backend sqlx --meta-url "sqlite::memory:"
-# PostgreSQL (生产)
---meta-backend sqlx --meta-url "postgresql://user:pass@host:5432/meta"
-```
-
-### Etcd (EtcdMetaStore)
-
-用于分布式部署，提供 KV 存储 + watch + 事务：
-
-```bash
---meta-backend etcd --meta-etcd-urls http://etcd-1:2379,http://etcd-2:2379
-```
-
-需要至少一个 etcd 3.x 集群。
-
-### Redis (RedisMetaStore)
-
-高性能 KV 存储，适合对延迟敏感的元数据操作：
-
-```bash
---meta-backend redis --meta-url redis://127.0.0.1:6379/0
-```
-
-使用 Lua CAS 保证并发安全（详见 `doc/architecture/redis-version-cas.md`）。
-
-## FUSE 并发配置
-
-| 参数 | 默认值 | 说明 |
-|---|---|---|
-| `fuse-workers` | 1 | asyncfuse worker pool 大小。0 或 1 使用低开销 session dispatch |
-| `fuse-max-background` | 512 | 排队 + 执行中的 FUSE 请求最大数 |
-
-worker pool 模式（`workers > 1`）下，FUSE 请求由 worker 线程池并发处理，适合需要额外 FUSE 并发的 IO 场景；metadata-heavy workload 默认保留低调度开销路径。
-
-## 挂载模式
-
-### 非特权模式（默认）
-
-使用 `fusermount3`，要求用户在 `fuse` 组中：
-
-```bash
-brewfs mount /mnt/brewfs ...
-```
-
-### 特权模式
-
-直接使用 `/dev/fuse`，需要 root 权限：
-
-```bash
-sudo brewfs mount /mnt/brewfs --privileged ...
-```
-
-## 环境变量
-
-| 变量 | 说明 |
-|---|---|
-| `RUST_LOG` | 日志级别控制（`brewfs=info`, `brewfs=trace` 等） |
-| `BREWFS_LOG_FILE` | 主日志输出文件路径 |
-| `BREWFS_FUSE_LOG_FILE` | FUSE 操作日志单独输出路径 |
-| `BREWFS_TRACE_CHROME` | Chrome trace 输出路径 |
-| `BREWFS_TRACE_FLAME` | tracing-flame 输出路径 |
-| `TOKIO_CONSOLE` | 设为任意值启用 tokio-console |
-| `BREWFS_NOFILE_LIMIT` | 自定义 nofile 限制（默认 1,048,576） |
-
-## 元数据后端测试环境搭建
-
-`doc/testing/docker-compose-test-guide.md` 提供了 Docker Compose 快速搭建测试环境的说明：
-
-```bash
-# 使用仓库中的 docker-compose.yml 启动所有服务
-docker compose up -d
-
-# 运行各后端测试
-cargo test --lib meta::stores::redis_store -- --nocapture
-cargo test --lib meta::stores::etcd_store -- --nocapture
-cargo test --lib meta::stores::database_store -- --nocapture
-
-# 停止
-docker compose down
-```
-
-测试服务使用默认凭据，仅适用于本地开发，不可用于生产环境。
-
-## 构建特性 (Features)
-
-| Feature | 说明 |
-|---|---|
-| `jemalloc` | 使用 jemalloc 作为全局内存分配器（Linux only） |
-| `jemalloc-profiling` | 启用 jemalloc heap profiling |
-| `profiling` | 启用 tracing-flame + tracing-chrome 支持 |
-
-```bash
-# 生产构建（含 jemalloc）
-cargo build --release --features jemalloc
-
-# 性能分析构建
-cargo build --release --features jemalloc-profiling
-```
-
-## Daemon 控制面 (Control Plane)
-
-运行中的 brewfs 进程通过 Unix domain socket 提供控制面接口：
-
-```
-/run/brewfs/<mount_hash>/control.sock
-```
-
-`brewfs gc` 和 `brewfs info` 命令通过此 socket 与 daemon 通信：
-
-```bash
-# 查看挂载信息
+brewfs mount --config /etc/brewfs/mount.yaml
 brewfs info /mnt/brewfs
-
-# 触发 GC (扫描)
 brewfs gc /mnt/brewfs --dry-run
-
-# 触发 GC (实际删除)
-brewfs gc /mnt/brewfs
 ```
 
-源码：`src/control/` — 定义了请求/响应协议、任务生命周期管理和 socket 通信。
+如果同时传入 CLI 参数和 YAML，例如：
+
+```bash
+brewfs mount --config /etc/brewfs/mount.yaml --s3-bucket other-bucket
+```
+
+则 `--s3-bucket` 会覆盖 YAML 中的 `data.s3.bucket`。
+
+## CLI
+
+```bash
+brewfs mount [OPTIONS] [MOUNT_POINT]
+brewfs info [MOUNT_POINT]
+brewfs gc [MOUNT_POINT] [--dry-run]
+brewfs console [OPTIONS]
+```
+
+主要 `mount` 参数：
+
+| 参数 | 说明 |
+|---|---|
+| `--config <FILE>` | YAML 配置文件。 |
+| `[MOUNT_POINT]` | 挂载点；覆盖 `mount_point`。 |
+| `--data-backend <local-fs|s3>` | 对象数据后端。 |
+| `--data-dir <DIR>` | `local-fs` 数据目录。 |
+| `--s3-bucket <BUCKET>` | S3 bucket。 |
+| `--s3-endpoint <URL>` | S3 兼容端点；AWS S3 可不填。 |
+| `--s3-region <REGION>` | S3 region。 |
+| `--s3-part-size <BYTES>` | multipart part 大小，默认 16 MiB。 |
+| `--s3-max-concurrency <N>` | S3 multipart 最大并发，默认 32。 |
+| `--s3-force-path-style <true|false>` | path-style S3 访问。MinIO/RustFS 通常设为 `true`。 |
+| `--s3-disable-payload-checksum <true|false>` | 禁用 SigV4 payload SHA-256，默认 `true`。 |
+| `--meta-backend <sqlx|redis|etcd|tikv>` | 元数据后端。 |
+| `--meta-url <URL>` | SQLx 或 Redis URL。 |
+| `--meta-etcd-urls <URLS>` | 逗号分隔的 Etcd endpoint。 |
+| `--meta-tikv-pd-endpoints <URLS>` | 逗号分隔的 TiKV PD endpoint。 |
+| `--meta-tikv-namespace <NAMESPACE>` | TiKV key namespace，默认 `brewfs`。 |
+| `--chunk-size <BYTES>` | chunk 大小，默认 64 MiB。 |
+| `--block-size <BYTES>` | block 大小，默认 4 MiB。 |
+| `--fuse-workers <N>` | FUSE worker 数；`0` 或 `1` 使用低开销 session dispatch。 |
+| `--fuse-max-background <N>` | FUSE 最大 in-flight 请求数，默认 512。 |
+| `--privileged` | 直接打开 `/dev/fuse`，适合 systemd/root/container。 |
+
+`console` 子命令：
+
+| 参数 | 默认值 | 说明 |
+|---|---:|---|
+| `--listen <ADDR>` | `127.0.0.1:8080` | HTTP listen 地址。 |
+| `--state-dir <DIR>` | 自动 | console 状态目录。 |
+| `--runtime-dir <DIR>` | 自动 | BrewFS runtime registry 目录。 |
+| `--static-dir <DIR>` | 自动 | 预构建前端静态资源目录。 |
+| `--auth-token-file <FILE>` | 无 | Bearer token 文件。 |
+| `--dev-no-auth` | `false` | 本地开发免认证；只允许 loopback listener。 |
+| `--enable-csi-dashboard` | `false` | 开启只读 Kubernetes CSI dashboard API。 |
+| `--kubeconfig <FILE>` | 自动 | Kubernetes config。 |
+| `--csi-driver-name <NAME>` | `csi.brewfs.io` | CSI driver 名称。 |
+
+## YAML Schema
+
+顶层字段：
+
+```yaml
+mount_point: /mnt/brewfs
+data: {}
+meta: {}
+layout: {}
+fuse: {}
+cache: {}
+compact: {}
+```
+
+### data
+
+| 字段 | 默认值 | 说明 |
+|---|---:|---|
+| `data.backend` | `local-fs` | `local-fs` 或 `s3`。 |
+| `data.localfs.data_dir` | `./data` | 本地对象数据目录。 |
+| `data.s3.bucket` | 无 | S3 bucket；`backend=s3` 时必填。 |
+| `data.s3.endpoint` | 无 | S3 兼容端点。 |
+| `data.s3.region` | 无 | S3 region；自建对象存储常用 `us-east-1`。 |
+| `data.s3.part_size` | `16777216` | multipart part 大小，单位 bytes。 |
+| `data.s3.max_concurrency` | `32` | S3 multipart 最大并发。 |
+| `data.s3.force_path_style` | `false` | MinIO/RustFS/Ceph RGW 常需要 `true`。 |
+| `data.s3.disable_payload_checksum` | `true` | 自建 S3 通常建议 `true` 以降低写路径 CPU。 |
+
+S3 凭据走 AWS SDK 标准环境变量和配置文件，例如：
+
+```bash
+export AWS_ACCESS_KEY_ID=rustfsadmin
+export AWS_SECRET_ACCESS_KEY=rustfsadmin
+export AWS_DEFAULT_REGION=us-east-1
+export AWS_EC2_METADATA_DISABLED=true
+```
+
+### meta
+
+| 字段 | 默认值 | 说明 |
+|---|---:|---|
+| `meta.backend` | `sqlx` | `sqlx`、`redis`、`etcd` 或 `tikv`。 |
+| `meta.sqlx.url` | `sqlite::memory:` | SQLite 或 PostgreSQL URL。 |
+| `meta.redis.url` | 无 | Redis URL；`backend=redis` 时必须显式配置。 |
+| `meta.etcd.urls` | `[]` | Etcd endpoint 列表。 |
+| `meta.tikv.pd_endpoints` | `[]` | TiKV PD endpoint 列表。 |
+| `meta.tikv.namespace` | `brewfs` | TiKV key namespace。 |
+| `meta.open_file_cache_ttl_ms` | 关闭 | 只读 open 文件属性缓存 TTL，单位 ms。 |
+| `meta.open_file_cache_capacity` | 默认值 | open file cache 容量。 |
+
+示例：
+
+```yaml
+meta:
+  backend: sqlx
+  sqlx:
+    url: "postgres://brewfs:secret@postgres:5432/brewfs"
+```
+
+```yaml
+meta:
+  backend: etcd
+  etcd:
+    urls:
+      - "http://10.0.0.11:2379"
+      - "http://10.0.0.12:2379"
+```
+
+```yaml
+meta:
+  backend: tikv
+  tikv:
+    pd_endpoints:
+      - "10.0.0.21:2379"
+    namespace: tenant-a
+```
+
+内部 meta client 的 inode/path cache 会按后端选择默认 TTL：SQLite 10s、PostgreSQL 500ms、Redis 500ms、Etcd 2s、TiKV 1s。FUSE 返回给内核的 attr/entry TTL 是独立配置，见下方环境变量 `BREWFS_CACHE_TTL_MS`。
+
+### layout
+
+| 字段 | 默认值 | 说明 |
+|---|---:|---|
+| `layout.chunk_size` | `67108864` | chunk 大小，默认 64 MiB。 |
+| `layout.block_size` | `4194304` | block/object 粒度，默认 4 MiB。 |
+
+`chunk_size` 必须大于等于 `block_size`。提高 `chunk_size` 可以减少大文件元数据提交频率，但会增加单个 chunk 的管理跨度。
+
+### fuse
+
+| 字段 | 默认值 | 说明 |
+|---|---:|---|
+| `fuse.workers` | `1` | `0` 或 `1` 使用低开销 session dispatch；大于 `1` 开启 worker pool。 |
+| `fuse.max_background` | `512` | asyncfuse worker 模式下最大 queued/running 请求数。 |
+| `fuse.privileged` | `false` | 直接使用 `/dev/fuse`，通常用于 root/systemd/container。 |
+
+非特权挂载依赖 `fusermount3`；特权挂载依赖进程有权限访问 `/dev/fuse`。
+
+### cache
+
+| 字段 | 默认值 | 说明 |
+|---|---:|---|
+| `cache.root` / `cache.cache_root` | `$XDG_CACHE_HOME/brewfs` 或 `/tmp/brewfs` | 本地缓存根目录。 |
+| `cache.read_memory_bytes` | `4294967296` | 读缓存内存预算，默认 4 GiB。 |
+| `cache.read_ssd_bytes` | `21474836480` | 读缓存磁盘预算，默认 20 GiB。 |
+| `cache.write_memory_bytes` | `402653184` | 写缓存内存预算，默认 384 MiB。 |
+| `cache.write_ssd_bytes` | `21474836480` | 写缓存磁盘预算，默认 20 GiB。 |
+| `cache.dirty_slice_target_size` | `33554432` | 脏 slice 聚合目标，默认 32 MiB。 |
+| `cache.dirty_slice_max_age_ms` | `2000` | 脏 slice 最大聚合时间。 |
+| `cache.upload_concurrency` | `10` | 单 writer 内 block upload 并发。 |
+| `cache.prefetch_enabled` | `true` | VFS 顺序预取开关。 |
+| `cache.prefetch_max_bytes` | `67108864` | 最大预读距离，默认 64 MiB。 |
+| `cache.prefetch_concurrency` | `64` | 预取并发。 |
+| `cache.range_background_prefetch` | `true` | range miss 后后台补全 block。 |
+| `cache.populate_write_cache_after_upload` | `true` | 上传后把写入 block 放入读缓存。 |
+| `cache.persist_write_cache_after_upload` | `false` | 上传后是否持久化到磁盘读缓存。 |
+| `cache.memory_budget_bytes` | `1342177280` | VFS reader/writer buffer 总预算，默认 1280 MiB。 |
+| `cache.compression` | `lz4` | 对象压缩：`none`、`lz4`、`zstd`。 |
+| `cache.zstd_level` | `3` | `compression=zstd` 时的 level。 |
+| `cache.verify_cache_checksum` | `full` | 本地缓存校验：`full` 或 `none`。 |
+| `cache.writeback_mode` | `upload_before_commit` | 可选 `upload_before_commit` 或 `commit_before_upload`。 |
+| `cache.writeback_persist_sync` | `true` | staged writeback 同步落盘后再继续。 |
+| `cache.writeback_require_stage_before_commit` | `true` | 发布元数据前要求本地 stage sealed。 |
+| `cache.writeback_recent_pending_soft_bytes` | `0` | commit-before-upload 待上传软限制，0 为关闭。 |
+| `cache.writeback_recent_pending_hard_bytes` | `0` | commit-before-upload 待上传硬限制，0 跟随软限制。 |
+| `cache.bandwidth.upload_limit_mibps` | 无 | 上传限速，单位 MiB/s。 |
+| `cache.bandwidth.download_limit_mibps` | 无 | 下载限速，单位 MiB/s。 |
+
+`writeback_mode` 语义：
+
+- `upload_before_commit`: 默认安全模式。先上传对象，再提交元数据；`fsync`/`close` 成功后数据已在对象存储和元数据中可见。
+- `commit_before_upload`: 高性能 S3 writeback 模式。先提交元数据，再异步上传对象；只允许 `data.backend=s3`。本地缓存盘损坏或进程异常退出时，已发布但未上传的对象可能丢失，其他客户端也可能暂时看到缺失对象。
+
+### compact
+
+`compact` 控制 slice compaction 和锁 TTL：
+
+```yaml
+compact:
+  min_slice_count: 3
+  min_fragment_ratio: 0.1
+  async_threshold: 100
+  sync_threshold: 200
+  interval:
+    secs: 600
+    nanos: 0
+  max_chunks_per_run: 1000
+  max_concurrent_tasks: 4
+  light_enabled: true
+  light_threshold: 2
+  heavy_enabled: true
+  heavy_fragment_threshold: 0.3
+  heavy_slice_threshold: 30
+  heavy_force_fragment_threshold: 0.5
+  lock_ttl:
+    async_ttl_secs: 10
+    sync_ttl_secs: 30
+    ttl_per_slice_ms: 50
+    min_ttl_secs: 5
+    max_ttl_secs: 300
+```
+
+`interval` 使用 Rust `Duration` 的 YAML 表示，即 `secs` 和 `nanos`。
+
+## FUSE 和运行时环境变量
+
+| 环境变量 | 默认值 | 说明 |
+|---|---:|---|
+| `RUST_LOG` | `brewfs=info` | tracing filter，例如 `brewfs=debug,asyncfuse=info`。 |
+| `BREWFS_LOG_FILE` | stderr | 主日志输出文件。 |
+| `BREWFS_FUSE_LOG_FILE` | 无 | 单独输出 asyncfuse op 日志；会屏蔽主日志里的 `asyncfuse::raw::logfs`。 |
+| `BREWFS_NOFILE_LIMIT` | `1048576` | 启动时尝试提升 `RLIMIT_NOFILE`。 |
+| `BREWFS_CACHE_TTL_MS` | `1000` | FUSE attr/entry TTL。设为 `0` 可严格绕过内核 attr/entry cache。新建文件 create reply 的 attr TTL 固定为 0。 |
+| `BREWFS_FUSE_DIRECT_IO` | 无 | 对所有 open reply 启用或关闭 direct IO。 |
+| `BREWFS_FUSE_READ_DIRECT_IO` | `false` | 只对只读 open 启用 direct IO。 |
+| `BREWFS_FUSE_WRITE_DIRECT_IO` | `false` | 只对只写 open 启用 direct IO。 |
+| `BREWFS_FUSE_KEEP_CACHE` | `false` | open reply 加 `FOPEN_KEEP_CACHE`。 |
+| `BREWFS_FUSE_COPY_FILE_RANGE` | `true` | 控制 FUSE `copy_file_range` 支持。 |
+| `BREWFS_CACHED_BLOCK_ASSEMBLER` | `false` | 实验性 cached block assembler。 |
+| `BREWFS_TRACE_CHROME` | 无 | profiling build 下输出 Chrome trace。 |
+| `BREWFS_TRACE_FLAME` | 无 | profiling build 下输出 tracing-flame folded stack。 |
+| `TOKIO_CONSOLE` | 无 | profiling build 下启用 tokio-console。 |
+| `BREWFS_CONSOLE_TOKEN` | 无 | console API bearer token；也可用 `--auth-token-file`。 |
+
+## 部署建议
+
+单机开发：
+
+- `data.backend=local-fs`
+- `meta.backend=sqlx`
+- SQLite URL 使用持久文件，例如 `sqlite:///var/lib/brewfs/meta.db?mode=rwc`
+
+单机生产或性能测试：
+
+- `data.backend=s3` 指向本机 RustFS/MinIO
+- `meta.backend=redis`
+- `data.s3.force_path_style=true`
+- `data.s3.disable_payload_checksum=true`
+- cache root 放到可靠 SSD
+- 如启用 `commit_before_upload`，必须理解本地写回缓存丢失风险
+
+多节点或分布式部署：
+
+- 使用 Redis、Etcd 或 TiKV 作为元数据后端。
+- 所有客户端必须使用同一个对象 bucket 和元数据 namespace。
+- 默认 FUSE TTL 为 1s。需要更强多客户端可见性时，把 `BREWFS_CACHE_TTL_MS=0` 放进 systemd environment；需要更高 metadata-heavy 性能时保留默认值。
+- 每个客户端使用独立 `cache.root`，不要共享本地缓存目录。
+
+更多可直接运行的样例见 `examples/mount-config*.yaml`。

--- a/scripts/install_brewfs_single_node.sh
+++ b/scripts/install_brewfs_single_node.sh
@@ -53,6 +53,21 @@ RUSTFS_CONSOLE_PORT="${RUSTFS_CONSOLE_PORT:-9001}"
 RUSTFS_ACCESS_KEY="${RUSTFS_ACCESS_KEY:-rustfsadmin}"
 RUSTFS_SECRET_KEY="${RUSTFS_SECRET_KEY:-rustfsadmin}"
 
+BREWFS_S3_PART_SIZE="${BREWFS_S3_PART_SIZE:-16777216}"
+BREWFS_S3_MAX_CONCURRENCY="${BREWFS_S3_MAX_CONCURRENCY:-32}"
+BREWFS_S3_FORCE_PATH_STYLE="${BREWFS_S3_FORCE_PATH_STYLE:-true}"
+BREWFS_S3_DISABLE_PAYLOAD_CHECKSUM="${BREWFS_S3_DISABLE_PAYLOAD_CHECKSUM:-true}"
+BREWFS_META_OPEN_FILE_CACHE_TTL_MS="${BREWFS_META_OPEN_FILE_CACHE_TTL_MS:-30000}"
+BREWFS_META_OPEN_FILE_CACHE_CAPACITY="${BREWFS_META_OPEN_FILE_CACHE_CAPACITY:-65536}"
+BREWFS_WRITEBACK_MODE="${BREWFS_WRITEBACK_MODE:-commit_before_upload}"
+BREWFS_WRITEBACK_PERSIST_SYNC="${BREWFS_WRITEBACK_PERSIST_SYNC:-false}"
+BREWFS_PREFETCH_ENABLED="${BREWFS_PREFETCH_ENABLED:-true}"
+BREWFS_CACHE_TTL_MS="${BREWFS_CACHE_TTL_MS:-1000}"
+BREWFS_FUSE_WORKERS="${BREWFS_FUSE_WORKERS:-1}"
+BREWFS_FUSE_MAX_BACKGROUND="${BREWFS_FUSE_MAX_BACKGROUND:-512}"
+BREWFS_FUSE_PRIVILEGED="${BREWFS_FUSE_PRIVILEGED:-true}"
+BREWFS_LOG_LEVEL="${BREWFS_LOG_LEVEL:-${RUST_LOG:-brewfs=info}}"
+
 BREWFS_USER="${BREWFS_USER:-root}"
 BREWFS_GROUP="${BREWFS_GROUP:-root}"
 
@@ -95,7 +110,7 @@ Environment overrides:
   DEFAULT_BREWFS_VERSION=v0.1.1
                                Opt-in fallback version.
   BREWFS_DOWNLOAD_URL=""       Explicit BrewFS binary archive or executable URL.
-  RUSTFS_DOWNLOAD_URL=""      RustFS binary archive or executable URL.
+  RUSTFS_DOWNLOAD_URL=""       RustFS binary archive or executable URL.
   REDIS_DOWNLOAD_URL=""       Redis binary archive or executable URL.
   MOUNT_POINT=/mnt/brewfs
   STATE_DIR=/var/lib/brewfs
@@ -106,6 +121,21 @@ Environment overrides:
   RUSTFS_CONSOLE_PORT=9001
   RUSTFS_ACCESS_KEY=rustfsadmin
   RUSTFS_SECRET_KEY=rustfsadmin
+  BREWFS_S3_PART_SIZE=16777216
+  BREWFS_S3_MAX_CONCURRENCY=32
+  BREWFS_S3_FORCE_PATH_STYLE=true
+  BREWFS_S3_DISABLE_PAYLOAD_CHECKSUM=true
+  BREWFS_META_OPEN_FILE_CACHE_TTL_MS=30000
+  BREWFS_META_OPEN_FILE_CACHE_CAPACITY=65536
+  BREWFS_WRITEBACK_MODE=commit_before_upload
+                               Use upload_before_commit for safer crash behavior.
+  BREWFS_WRITEBACK_PERSIST_SYNC=false
+  BREWFS_PREFETCH_ENABLED=true
+  BREWFS_CACHE_TTL_MS=1000     FUSE attr/entry TTL in milliseconds.
+  BREWFS_FUSE_WORKERS=1
+  BREWFS_FUSE_MAX_BACKGROUND=512
+  BREWFS_FUSE_PRIVILEGED=true
+  BREWFS_LOG_LEVEL=brewfs=info
 
 Notes:
   - Redis is maintained as brewfs-redis.service. If redis-server already exists
@@ -116,7 +146,7 @@ Notes:
     script downloads brewfs-${OS}-${ARCH} from:
       ${BREWFS_BASE_URL}/${BREWFS_VERSION}/brewfs-${OS}-${ARCH}
     For example:
-      https://download.brewfs.ai/brewfs/releases/v0.1.1/brewfs-darwin-arm64
+      https://download.brewfs.ai/brewfs/releases/v0.1.1/brewfs-linux-amd64
   - Put an existing RustFS binary at /usr/local/bin/rustfs, or set
     RUSTFS_DOWNLOAD_URL.
   - Uninstall removes services and config files, but keeps data and logs.
@@ -148,6 +178,59 @@ normalize_version() {
     v*|"") printf '%s' "$version" ;;
     *) printf 'v%s' "$version" ;;
   esac
+}
+
+normalize_bool_var() {
+  local name="$1"
+  local value="${!name}"
+  case "${value,,}" in
+    1|true|yes|on) printf -v "$name" '%s' "true" ;;
+    0|false|no|off) printf -v "$name" '%s' "false" ;;
+    *) err "$name must be a boolean value: true/false, 1/0, yes/no, or on/off." ;;
+  esac
+}
+
+normalize_writeback_mode() {
+  local normalized
+  normalized="${BREWFS_WRITEBACK_MODE,,}"
+  normalized="${normalized//-/_}"
+  case "$normalized" in
+    upload_before_commit|upload_first|safe|default)
+      BREWFS_WRITEBACK_MODE="upload_before_commit"
+      ;;
+    commit_before_upload|commit_first|writeback|s3_writeback)
+      BREWFS_WRITEBACK_MODE="commit_before_upload"
+      ;;
+    *)
+      err "BREWFS_WRITEBACK_MODE must be upload_before_commit or commit_before_upload."
+      ;;
+  esac
+}
+
+require_uint_var() {
+  local name="$1"
+  local min="$2"
+  local value="${!name}"
+  if ! [[ "$value" =~ ^[0-9]+$ ]] || (( value < min )); then
+    err "$name must be an integer >= $min."
+  fi
+}
+
+validate_runtime_config() {
+  normalize_bool_var BREWFS_S3_FORCE_PATH_STYLE
+  normalize_bool_var BREWFS_S3_DISABLE_PAYLOAD_CHECKSUM
+  normalize_bool_var BREWFS_WRITEBACK_PERSIST_SYNC
+  normalize_bool_var BREWFS_PREFETCH_ENABLED
+  normalize_bool_var BREWFS_FUSE_PRIVILEGED
+  normalize_writeback_mode
+
+  require_uint_var BREWFS_S3_PART_SIZE 1
+  require_uint_var BREWFS_S3_MAX_CONCURRENCY 1
+  require_uint_var BREWFS_META_OPEN_FILE_CACHE_TTL_MS 0
+  require_uint_var BREWFS_META_OPEN_FILE_CACHE_CAPACITY 1
+  require_uint_var BREWFS_CACHE_TTL_MS 0
+  require_uint_var BREWFS_FUSE_WORKERS 0
+  require_uint_var BREWFS_FUSE_MAX_BACKGROUND 1
 }
 
 detect_release_platform() {
@@ -196,6 +279,7 @@ resolve_brewfs_release_version() {
 
 preflight() {
   need_root
+  validate_runtime_config
 
   local required=(systemctl mktemp find grep chmod mkdir install sed)
   local missing=()
@@ -474,7 +558,8 @@ AWS_REGION="$BREWFS_REGION"
 AWS_DEFAULT_REGION="$BREWFS_REGION"
 AWS_CONFIG_FILE="$AWS_CONFIG_FILE"
 AWS_EC2_METADATA_DISABLED=true
-RUST_LOG=info
+BREWFS_CACHE_TTL_MS="$BREWFS_CACHE_TTL_MS"
+RUST_LOG="$BREWFS_LOG_LEVEL"
 EOF
 }
 
@@ -487,23 +572,25 @@ data:
     bucket: $BREWFS_BUCKET
     endpoint: http://$RUSTFS_HOST:$RUSTFS_PORT
     region: $BREWFS_REGION
-    force_path_style: true
-    disable_payload_checksum: true
+    part_size: $BREWFS_S3_PART_SIZE
+    max_concurrency: $BREWFS_S3_MAX_CONCURRENCY
+    force_path_style: $BREWFS_S3_FORCE_PATH_STYLE
+    disable_payload_checksum: $BREWFS_S3_DISABLE_PAYLOAD_CHECKSUM
 meta:
   backend: redis
   redis:
     url: redis://$REDIS_HOST:$REDIS_PORT/0
-  open_file_cache_ttl_ms: 30000
-  open_file_cache_capacity: 65536
+  open_file_cache_ttl_ms: $BREWFS_META_OPEN_FILE_CACHE_TTL_MS
+  open_file_cache_capacity: $BREWFS_META_OPEN_FILE_CACHE_CAPACITY
 cache:
   root: $BREWFS_CACHE_DIR
-  writeback_mode: commit_before_upload
-  writeback_persist_sync: false
-  prefetch_enabled: true
+  writeback_mode: $BREWFS_WRITEBACK_MODE
+  writeback_persist_sync: $BREWFS_WRITEBACK_PERSIST_SYNC
+  prefetch_enabled: $BREWFS_PREFETCH_ENABLED
 fuse:
-  workers: 1
-  max_background: 512
-  privileged: true
+  workers: $BREWFS_FUSE_WORKERS
+  max_background: $BREWFS_FUSE_MAX_BACKGROUND
+  privileged: $BREWFS_FUSE_PRIVILEGED
 EOF
 }
 
@@ -568,7 +655,7 @@ EOF
   cat >"$SYSTEMD_DIR/$BREWFS_SERVICE" <<EOF
 [Unit]
 Description=BrewFS Single Node Mount
-Documentation=https://github.com/slayerfs/brewfs
+Documentation=https://github.com/brewfs/brewfs
 After=network-online.target $REDIS_SERVICE $RUSTFS_SERVICE
 Wants=network-online.target $REDIS_SERVICE $RUSTFS_SERVICE
 Requires=$REDIS_SERVICE $RUSTFS_SERVICE

--- a/src/meta/client/cache.rs
+++ b/src/meta/client/cache.rs
@@ -458,11 +458,11 @@ impl OpenFileEntry {
 
 /// JuiceFS-style metadata cache scoped to files that are recently active.
 ///
-/// This cache is created only when explicitly enabled by configuration. It is
-/// intentionally narrower than `InodeCache`: it is used for close-to-open
-/// refresh avoidance on repeated non-append opens and is invalidated on local
-/// metadata mutations. Entries expire after an idle window, matching JuiceFS'
-/// `openfiles.lastCheck` behavior more closely than a fixed lifetime.
+/// This cache is enabled when the configured TTL is non-zero. It is intentionally
+/// narrower than `InodeCache`: it is used for close-to-open refresh avoidance on
+/// repeated readonly opens and is invalidated on local metadata mutations.
+/// Entries expire after an idle window, matching JuiceFS' `openfiles.lastCheck`
+/// behavior more closely than a fixed lifetime.
 pub(crate) struct OpenFileCache {
     entries: Arc<DashMap<i64, Arc<OpenFileEntry>>>,
     ttl_manager: Cache<i64, Arc<OpenFileEntry>>,

--- a/src/meta/client/mod.rs
+++ b/src/meta/client/mod.rs
@@ -1575,10 +1575,24 @@ impl<T: MetaStore + ?Sized + 'static> MetaClient<T> {
     }
 
     async fn touch_cached_parent_after_namespace_mutation(&self, parent_ino: i64) {
+        self.adjust_cached_parent_after_namespace_mutation(parent_ino, 0)
+            .await;
+    }
+
+    async fn adjust_cached_parent_after_namespace_mutation(
+        &self,
+        parent_ino: i64,
+        nlink_delta: i32,
+    ) {
         let parent_ino = self.check_root(parent_ino);
         if let Some(node) = self.inode_cache.get_node(parent_ino).await {
             let now = Self::current_time_nanos();
             let mut attr = node.attr.write().await;
+            if nlink_delta > 0 {
+                attr.nlink = attr.nlink.saturating_add(nlink_delta as u32);
+            } else if nlink_delta < 0 {
+                attr.nlink = attr.nlink.saturating_sub((-nlink_delta) as u32);
+            }
             attr.mtime = now;
             attr.ctime = now;
         }
@@ -1734,6 +1748,13 @@ impl<T: MetaStore + ?Sized + 'static> MetaClient<T> {
             Some(dest_ino) => dest_ino.map(|ino| self.check_root(ino)),
             None => self.cached_lookup(new_parent, &new_name).await?,
         };
+        if dest_ino == Some(src_ino) {
+            return Ok(());
+        }
+        let dest_attr = match dest_ino {
+            Some(dest) => self.cached_stat(dest).await?,
+            None => None,
+        };
 
         // Execute the store-level rename with atomic cache updates.
         self.store
@@ -1778,11 +1799,27 @@ impl<T: MetaStore + ?Sized + 'static> MetaClient<T> {
             }
 
             // Keep an overwritten destination inode addressable while it may
-            // still be held open by the kernel, but expose it as unlinked.
+            // still be held open by the kernel, but refresh the link count from
+            // the store.  A replaced inode may still have other hard links.
             if let Some(dest) = dest_ino {
                 if let Some(dest_node) = self.inode_cache.get_node(dest).await {
-                    dest_node.attr.write().await.nlink = 0;
-                    dest_node.clear_parent().await;
+                    match self.store.stat(dest).await {
+                        Ok(Some(attr)) => {
+                            *dest_node.attr.write().await = attr;
+                            dest_node.clear_parent().await;
+                        }
+                        Ok(None) => {
+                            self.inode_cache.invalidate_inode(dest).await;
+                        }
+                        Err(err) => {
+                            warn!(
+                                "MetaClient: failed to refresh replaced inode {} after rename: {}",
+                                dest, err
+                            );
+                            dest_node.attr.write().await.nlink = 0;
+                            dest_node.clear_parent().await;
+                        }
+                    }
                 } else {
                     self.inode_cache.invalidate_inode(dest).await;
                 }
@@ -1790,21 +1827,36 @@ impl<T: MetaStore + ?Sized + 'static> MetaClient<T> {
 
             // Precise path cache invalidation while retaining the updated child
             // maps for subsequent lookups on the same hot directory.
-            let needs_parent_nlink_refresh =
-                matches!(src_attr.as_ref().map(|attr| attr.kind), Some(FileType::Dir))
-                    && old_parent != new_parent;
-            if needs_parent_nlink_refresh {
-                self.invalidate_parent_after_namespace_mutation(old_parent)
-                    .await;
-                self.invalidate_parent_after_namespace_mutation(new_parent)
-                    .await;
+            let src_is_dir = matches!(src_attr.as_ref().map(|attr| attr.kind), Some(FileType::Dir));
+            let dest_is_dir = matches!(
+                dest_attr.as_ref().map(|attr| attr.kind),
+                Some(FileType::Dir)
+            );
+            let old_parent_delta = if src_is_dir && old_parent != new_parent {
+                -1
             } else {
-                self.touch_cached_parent_after_namespace_mutation(old_parent)
+                0
+            };
+            let mut new_parent_delta = if src_is_dir && old_parent != new_parent {
+                1
+            } else {
+                0
+            };
+            if dest_is_dir {
+                new_parent_delta -= 1;
+            }
+
+            if old_parent == new_parent {
+                self.adjust_cached_parent_after_namespace_mutation(
+                    old_parent,
+                    old_parent_delta + new_parent_delta,
+                )
+                .await;
+            } else {
+                self.adjust_cached_parent_after_namespace_mutation(old_parent, old_parent_delta)
                     .await;
-                if old_parent != new_parent {
-                    self.touch_cached_parent_after_namespace_mutation(new_parent)
-                        .await;
-                }
+                self.adjust_cached_parent_after_namespace_mutation(new_parent, new_parent_delta)
+                    .await;
             }
 
             Ok::<(), MetaError>(())
@@ -2310,7 +2362,7 @@ impl<T: MetaStore + ?Sized + 'static> MetaLayer for MetaClient<T> {
         }
         self.inode_cache.add_child(parent, name, ino).await;
 
-        self.touch_cached_parent_after_namespace_mutation(parent)
+        self.adjust_cached_parent_after_namespace_mutation(parent, 1)
             .await;
 
         Ok(ino)
@@ -2338,7 +2390,7 @@ impl<T: MetaStore + ?Sized + 'static> MetaLayer for MetaClient<T> {
             child_node.attr.write().await.nlink = 0;
             child_node.clear_parent().await;
         }
-        self.invalidate_parent_after_namespace_mutation(parent)
+        self.adjust_cached_parent_after_namespace_mutation(parent, -1)
             .await;
 
         Ok(())
@@ -3335,6 +3387,59 @@ mod tests {
         assert_eq!(
             path, "/dir2/moved_file.txt",
             "get_path should return new path"
+        );
+    }
+
+    #[tokio::test]
+    async fn rename_over_linked_destination_refreshes_replaced_inode_nlink() {
+        let client = create_test_client().await;
+
+        let src = client.create_file(1, "src".to_string()).await.unwrap();
+        let dst = client.create_file(1, "dst".to_string()).await.unwrap();
+        client.link(dst, 1, "dstlnk").await.unwrap();
+
+        let linked_before = client
+            .lookup_with_attr(1, "dstlnk")
+            .await
+            .unwrap()
+            .unwrap()
+            .1;
+        assert_eq!(linked_before.nlink, 2);
+
+        client.rename(1, "src", 1, "dst".to_string()).await.unwrap();
+
+        assert_eq!(client.lookup(1, "dst").await.unwrap(), Some(src));
+        let linked_after = client
+            .lookup_with_attr(1, "dstlnk")
+            .await
+            .unwrap()
+            .unwrap()
+            .1;
+        assert_eq!(linked_after.ino, dst);
+        assert_eq!(linked_after.nlink, 1);
+    }
+
+    #[tokio::test]
+    async fn directory_namespace_mutations_keep_cached_parent_nlink_current() {
+        let client = create_test_client().await;
+
+        let src_parent = client.mkdir(1, "src-parent".to_string()).await.unwrap();
+        let dst_parent = client.mkdir(1, "dst-parent".to_string()).await.unwrap();
+        let child = client.mkdir(src_parent, "child".to_string()).await.unwrap();
+
+        assert_eq!(client.stat(src_parent).await.unwrap().unwrap().nlink, 3);
+        assert_eq!(client.stat(dst_parent).await.unwrap().unwrap().nlink, 2);
+
+        client
+            .rename(src_parent, "child", dst_parent, "moved".to_string())
+            .await
+            .unwrap();
+
+        assert_eq!(client.stat(src_parent).await.unwrap().unwrap().nlink, 2);
+        assert_eq!(client.stat(dst_parent).await.unwrap().unwrap().nlink, 3);
+        assert_eq!(
+            client.lookup(dst_parent, "moved").await.unwrap(),
+            Some(child)
         );
     }
 

--- a/src/meta/client/mod.rs
+++ b/src/meta/client/mod.rs
@@ -29,7 +29,7 @@ use moka::future::Cache;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use std::{collections::HashSet, process};
 use tokio::sync::{Mutex, mpsc};
 use tracing::{Instrument, debug, info, trace, warn};
@@ -54,7 +54,7 @@ const ROOT_INODE: i64 = 1;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OpenFileCacheConfig {
-    /// Attribute reuse window for repeated non-append opens. `Duration::ZERO`
+    /// Attribute reuse window for repeated readonly opens. `Duration::ZERO`
     /// disables this cache and preserves strict close-to-open refresh.
     pub ttl: Duration,
     /// Maximum number of recently opened inodes retained by the cache.
@@ -70,7 +70,7 @@ impl OpenFileCacheConfig {
 impl Default for OpenFileCacheConfig {
     fn default() -> Self {
         Self {
-            ttl: Duration::ZERO,
+            ttl: Duration::from_secs(1),
             capacity: 8192,
         }
     }
@@ -99,7 +99,9 @@ pub struct MetaClientOptions {
     pub max_symlinks: usize,
     /// Batch attribute prefetch configuration
     pub batch_prefetch: BatchPrefetchConfig,
-    /// Opt-in JuiceFS-style cache scoped to recently opened files.
+    /// JuiceFS-style cache scoped to recently active files. Reuse is limited
+    /// to readonly opens; close may seed the final attr for a later readonly
+    /// open without allowing write opens to skip their fresh stat.
     pub open_file_cache: OpenFileCacheConfig,
 }
 
@@ -929,6 +931,10 @@ impl<T: MetaStore + ?Sized + 'static> MetaClient<T> {
     }
 
     fn open_file_cache_eligible(read: bool, write: bool, append: bool) -> bool {
+        read && !write && !append
+    }
+
+    fn open_file_cache_refresh_on_close(read: bool, write: bool, append: bool) -> bool {
         (read || write) && !append
     }
 
@@ -1427,7 +1433,8 @@ impl<T: MetaStore + ?Sized + 'static> MetaClient<T> {
 
     async fn invalidate_parent_after_namespace_mutation(&self, parent_ino: i64) {
         let parent_ino = self.check_root(parent_ino);
-        self.inode_cache.invalidate_inode(parent_ino).await;
+        self.refresh_cached_attr_after_namespace_mutation(parent_ino)
+            .await;
         self.invalidate_parent_path(parent_ino).await;
     }
 
@@ -1558,6 +1565,24 @@ impl<T: MetaStore + ?Sized + 'static> MetaClient<T> {
                 );
             }
         }
+    }
+
+    fn current_time_nanos() -> i64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos() as i64
+    }
+
+    async fn touch_cached_parent_after_namespace_mutation(&self, parent_ino: i64) {
+        let parent_ino = self.check_root(parent_ino);
+        if let Some(node) = self.inode_cache.get_node(parent_ino).await {
+            let now = Self::current_time_nanos();
+            let mut attr = node.attr.write().await;
+            attr.mtime = now;
+            attr.ctime = now;
+        }
+        self.invalidate_parent_path(parent_ino).await;
     }
 
     #[tracing::instrument(level = "trace", skip(self), fields(parent, name))]
@@ -1763,16 +1788,23 @@ impl<T: MetaStore + ?Sized + 'static> MetaClient<T> {
                 }
             }
 
-            // Precise path cache invalidation.
-            self.invalidate_parent_path(old_parent).await;
-            if old_parent != new_parent {
-                self.invalidate_parent_path(new_parent).await;
-            }
-
-            // Invalidate directory stat caches (mtime/ctime changed).
-            self.inode_cache.invalidate_inode(old_parent).await;
-            if old_parent != new_parent {
-                self.inode_cache.invalidate_inode(new_parent).await;
+            // Precise path cache invalidation while retaining the updated child
+            // maps for subsequent lookups on the same hot directory.
+            let needs_parent_nlink_refresh =
+                matches!(src_attr.as_ref().map(|attr| attr.kind), Some(FileType::Dir))
+                    && old_parent != new_parent;
+            if needs_parent_nlink_refresh {
+                self.invalidate_parent_after_namespace_mutation(old_parent)
+                    .await;
+                self.invalidate_parent_after_namespace_mutation(new_parent)
+                    .await;
+            } else {
+                self.touch_cached_parent_after_namespace_mutation(old_parent)
+                    .await;
+                if old_parent != new_parent {
+                    self.touch_cached_parent_after_namespace_mutation(new_parent)
+                        .await;
+                }
             }
 
             Ok::<(), MetaError>(())
@@ -2121,7 +2153,7 @@ impl<T: MetaStore + ?Sized + 'static> MetaLayer for MetaClient<T> {
     ) -> Result<(), MetaError> {
         let inode = self.check_root(ino);
         if let Some(cache) = &self.open_file_cache {
-            if Self::open_file_cache_eligible(read, write, append) {
+            if Self::open_file_cache_refresh_on_close(read, write, append) {
                 cache.refresh_idle_attr(inode, attr).await;
             }
             cache.close(inode).await;
@@ -2277,10 +2309,8 @@ impl<T: MetaStore + ?Sized + 'static> MetaLayer for MetaClient<T> {
             self.inode_cache.mark_children_complete_empty(ino).await;
         }
         self.inode_cache.add_child(parent, name, ino).await;
-        self.refresh_cached_attr_after_namespace_mutation(parent)
-            .await;
 
-        self.invalidate_parent_after_namespace_mutation(parent)
+        self.touch_cached_parent_after_namespace_mutation(parent)
             .await;
 
         Ok(ino)
@@ -2351,10 +2381,8 @@ impl<T: MetaStore + ?Sized + 'static> MetaLayer for MetaClient<T> {
                 .await;
         }
         self.inode_cache.add_child(parent, name, ino).await;
-        self.refresh_cached_attr_after_namespace_mutation(parent)
-            .await;
 
-        self.invalidate_parent_after_namespace_mutation(parent)
+        self.touch_cached_parent_after_namespace_mutation(parent)
             .await;
 
         Ok(created)
@@ -2437,10 +2465,8 @@ impl<T: MetaStore + ?Sized + 'static> MetaLayer for MetaClient<T> {
         self.inode_cache
             .add_child(parent, name.to_string(), inode)
             .await;
-        self.refresh_cached_attr_after_namespace_mutation(parent)
-            .await;
 
-        self.invalidate_parent_after_namespace_mutation(parent)
+        self.touch_cached_parent_after_namespace_mutation(parent)
             .await;
 
         Ok(attr)
@@ -2481,10 +2507,8 @@ impl<T: MetaStore + ?Sized + 'static> MetaLayer for MetaClient<T> {
         self.inode_cache
             .add_child(parent, name.to_string(), ino)
             .await;
-        self.refresh_cached_attr_after_namespace_mutation(parent)
-            .await;
 
-        self.invalidate_parent_after_namespace_mutation(parent)
+        self.touch_cached_parent_after_namespace_mutation(parent)
             .await;
 
         Ok((ino, attr))
@@ -2513,7 +2537,7 @@ impl<T: MetaStore + ?Sized + 'static> MetaLayer for MetaClient<T> {
         if let Some(ino) = target_ino {
             self.invalidate_open_file_cache_inode(ino).await;
         }
-        self.invalidate_parent_after_namespace_mutation(parent)
+        self.touch_cached_parent_after_namespace_mutation(parent)
             .await;
 
         Ok(())
@@ -2609,18 +2633,17 @@ impl<T: MetaStore + ?Sized + 'static> MetaLayer for MetaClient<T> {
 
         // Update cache to reflect the exchange
         let cache_result = async {
-            // Invalidate all affected caches
+            // Invalidate replaced child caches while preserving the parent child
+            // maps we rebuild below.
             self.inode_cache.invalidate_inode(old_ino).await;
             self.inode_cache.invalidate_inode(new_ino).await;
-            self.inode_cache.invalidate_inode(old_parent).await;
-            if old_parent != new_parent {
-                self.inode_cache.invalidate_inode(new_parent).await;
-            }
 
             // Invalidate path caches
-            self.invalidate_parent_path(old_parent).await;
+            self.invalidate_parent_after_namespace_mutation(old_parent)
+                .await;
             if old_parent != new_parent {
-                self.invalidate_parent_path(new_parent).await;
+                self.invalidate_parent_after_namespace_mutation(new_parent)
+                    .await;
             }
 
             // Update directory entries
@@ -3412,6 +3435,77 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_namespace_create_keeps_parent_child_cache_for_lookup_with_attr() {
+        let client = create_test_client().await;
+        let parent = client.mkdir(1, "cached-parent".to_string()).await.unwrap();
+
+        let ino = client
+            .create_file(parent, "created-child.txt".to_string())
+            .await
+            .unwrap();
+        let before = client.metrics().snapshot();
+
+        let (found, attr) = client
+            .lookup_with_attr(parent, "created-child.txt")
+            .await
+            .unwrap()
+            .expect("created child should be visible through parent cache");
+
+        assert_eq!(found, ino);
+        assert_eq!(attr.ino, ino);
+
+        let after = client.metrics().snapshot();
+        assert_eq!(after.lookup_cache_hit, before.lookup_cache_hit + 1);
+        assert_eq!(
+            after.lookup_attr_fused_hit,
+            before.lookup_attr_fused_hit + 1
+        );
+        assert_eq!(
+            after.lookup_attr_fused_miss, before.lookup_attr_fused_miss,
+            "lookup_with_attr after a local create should not go back to the store"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_rename_keeps_parent_child_cache_for_followup_lookup() {
+        let client = create_test_client().await;
+        let parent = client
+            .mkdir(1, "rename-cache-parent".to_string())
+            .await
+            .unwrap();
+        let ino = client
+            .create_file(parent, "before.txt".to_string())
+            .await
+            .unwrap();
+
+        client
+            .rename(parent, "before.txt", parent, "after.txt".to_string())
+            .await
+            .unwrap();
+        let before = client.metrics().snapshot();
+
+        let (found, attr) = client
+            .lookup_with_attr(parent, "after.txt")
+            .await
+            .unwrap()
+            .expect("renamed child should be visible through parent cache");
+
+        assert_eq!(found, ino);
+        assert_eq!(attr.ino, ino);
+
+        let after = client.metrics().snapshot();
+        assert_eq!(after.lookup_cache_hit, before.lookup_cache_hit + 1);
+        assert_eq!(
+            after.lookup_attr_fused_hit,
+            before.lookup_attr_fused_hit + 1
+        );
+        assert_eq!(
+            after.lookup_attr_fused_miss, before.lookup_attr_fused_miss,
+            "lookup_with_attr after a local rename should not go back to the store"
+        );
+    }
+
+    #[tokio::test]
     async fn test_meta_client_lookup_only_does_not_count_lookup_attr_fused_path() {
         let client = create_test_client().await;
         let ino = client
@@ -3437,7 +3531,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_open_file_cache_disabled_preserves_fresh_open_stat() {
-        let client = create_test_client().await;
+        let options = MetaClientOptions {
+            open_file_cache: OpenFileCacheConfig {
+                ttl: Duration::ZERO,
+                capacity: 128,
+            },
+            ..Default::default()
+        };
+        let client = create_test_client_with_options(options).await;
         let ino = client
             .create_file(1, "open-cache-disabled.txt".to_string())
             .await
@@ -3509,15 +3610,39 @@ mod tests {
         assert_eq!(metrics.open_file_cache_miss, 1);
         assert_eq!(metrics.open_file_cache_hit, 1);
 
-        let rdwr_cached = client
+        let rdwr_fresh = client
             .stat_for_open(ino, true, true, false)
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(rdwr_cached.size, first.size);
+        assert_eq!(rdwr_fresh.size, first.size);
+        client
+            .record_open(ino, rdwr_fresh, true, true, false)
+            .await
+            .unwrap();
+        client.record_close(ino).await.unwrap();
+
         let metrics = client.metrics().snapshot();
-        assert_eq!(metrics.open_fresh_stat, 1);
-        assert_eq!(metrics.open_file_cache_hit, 2);
+        assert_eq!(metrics.open_fresh_stat, 2);
+        assert_eq!(metrics.open_file_cache_hit, 1);
+        assert_eq!(metrics.open_file_cache_miss, 1);
+
+        let reopened = client
+            .stat_for_open(ino, true, false, false)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(reopened.size, first.size);
+        client
+            .record_open(ino, reopened, true, false, false)
+            .await
+            .unwrap();
+        client.record_close(ino).await.unwrap();
+
+        let metrics = client.metrics().snapshot();
+        assert_eq!(metrics.open_fresh_stat, 3);
+        assert_eq!(metrics.open_file_cache_hit, 1);
+        assert_eq!(metrics.open_file_cache_miss, 2);
 
         client
             .set_attr(
@@ -3539,9 +3664,9 @@ mod tests {
         assert_eq!(refreshed.size, first.size + 4096);
 
         let metrics = client.metrics().snapshot();
-        assert_eq!(metrics.open_fresh_stat, 2);
-        assert_eq!(metrics.open_file_cache_hit, 2);
-        assert_eq!(metrics.open_file_cache_miss, 2);
+        assert_eq!(metrics.open_fresh_stat, 4);
+        assert_eq!(metrics.open_file_cache_hit, 1);
+        assert_eq!(metrics.open_file_cache_miss, 3);
     }
 
     #[tokio::test]

--- a/src/vfs/fs/mod.rs
+++ b/src/vfs/fs/mod.rs
@@ -111,7 +111,7 @@ use crate::vfs::cache::config::CacheConfig;
 use crate::vfs::chunk_id_for;
 use crate::vfs::config::VFSConfig;
 use crate::vfs::error::{PathHint, VfsError};
-use crate::vfs::handles::{DirHandle, FileHandle, HandleFlags};
+use crate::vfs::handles::{DirHandle, FileHandle, HandleFlags, WriteDirtyState};
 use crate::vfs::io::{DataReader, DataWriter, split_chunk_spans};
 use crate::vfs::memory::MemoryBudget;
 
@@ -178,21 +178,21 @@ where
         true
     }
 
-    fn take_write_dirty_for_inode(&self, ino: i64) -> bool {
-        let mut dirty = false;
+    fn take_write_dirty_for_inode(&self, ino: i64) -> WriteDirtyState {
+        let mut state = WriteDirtyState::clean();
         for fh in self.handles_for(ino) {
             if let Some(handle) = self.handles.get(&fh) {
-                dirty |= handle.take_write_dirty();
+                state.merge(handle.take_write_dirty());
             }
         }
-        dirty
+        state
     }
 
-    fn take_write_dirty(&self, fh: u64) -> bool {
+    fn take_write_dirty(&self, fh: u64) -> WriteDirtyState {
         self.handles
             .get(&fh)
             .map(|handle| handle.take_write_dirty())
-            .unwrap_or(false)
+            .unwrap_or_default()
     }
 
     fn handles_for(&self, ino: i64) -> Vec<u64> {
@@ -1445,6 +1445,13 @@ where
         }
 
         Ok(())
+    }
+
+    fn flush_needs_mtime_ctime_update(dirty_state: WriteDirtyState, flushed_pending: bool) -> bool {
+        if !dirty_state.dirty {
+            return flushed_pending;
+        }
+        dirty_state.needs_timestamp_update
     }
 
     /// List directory entries by inode
@@ -3006,10 +3013,14 @@ where
             {
                 handle.update_offset(append_end);
                 handle.extend_size(append_end);
-                handle.mark_write_dirty();
+                handle.mark_write_dirty_extending_size();
                 data.len()
             } else {
-                handle.write_unlocked(append_offset, data).await?
+                let written = handle.write_unlocked(append_offset, data).await?;
+                if written > 0 {
+                    handle.mark_write_dirty_extending_size();
+                }
+                written
             };
             tracing::debug!(
                 fh,
@@ -3033,10 +3044,23 @@ where
             {
                 handle.update_offset(write_end);
                 handle.extend_size(write_end);
-                handle.mark_write_dirty();
+                if write_end > visible_size {
+                    handle.mark_write_dirty_extending_size();
+                } else {
+                    handle.mark_write_dirty();
+                }
                 data.len()
             } else {
-                handle.write_unlocked(offset, data).await?
+                let written = handle.write_unlocked(offset, data).await?;
+                if written > 0 {
+                    let new_end = offset + written as u64;
+                    if new_end > visible_size {
+                        handle.mark_write_dirty_extending_size();
+                    } else {
+                        handle.mark_write_dirty();
+                    }
+                }
+                written
             };
             (offset, written)
         };
@@ -3444,8 +3468,8 @@ where
         if handle.flags.write {
             let _handle_guard = handle.lock_write().await;
 
-            let had_write = self.state.handles.take_write_dirty(fh);
-            let flushed_pending = if had_write {
+            let dirty_state = self.state.handles.take_write_dirty(fh);
+            let flushed_pending = if dirty_state.dirty {
                 self.state
                     .writer
                     .flush_for_close(handle.ino as u64)
@@ -3454,10 +3478,10 @@ where
             } else {
                 false
             };
-            if (had_write || flushed_pending)
+            if Self::flush_needs_mtime_ctime_update(dirty_state, flushed_pending)
                 && let Err(err) = self.update_mtime_ctime(handle.ino).await
             {
-                if had_write {
+                if dirty_state.dirty {
                     handle.mark_write_dirty();
                 }
                 return Err(err);
@@ -3527,8 +3551,8 @@ where
             "vfs.flush_dirty_handle_snapshot"
         );
 
-        let had_write = self.state.handles.take_write_dirty(fh);
-        if !had_write {
+        let dirty_state = self.state.handles.take_write_dirty(fh);
+        if !dirty_state.dirty {
             return Ok(());
         }
 
@@ -3539,7 +3563,7 @@ where
             .await
             .map_err(VfsError::from)?;
 
-        if (had_write || flushed_pending)
+        if Self::flush_needs_mtime_ctime_update(dirty_state, flushed_pending)
             && let Err(err) = self.update_mtime_ctime(handle.ino).await
         {
             handle.mark_write_dirty();
@@ -3558,7 +3582,7 @@ where
         let handle = self.file_handle_required(fh)?;
 
         tracing::info!(fh, ino = handle.ino, "vfs.flush_handle_start");
-        let had_write = self.state.handles.take_write_dirty_for_inode(handle.ino);
+        let dirty_state = self.state.handles.take_write_dirty_for_inode(handle.ino);
         let flushed_pending = self
             .state
             .writer
@@ -3567,10 +3591,10 @@ where
             .map_err(VfsError::from)?;
         tracing::trace!(fh, ino = handle.ino, "vfs.flush_handle_done");
 
-        if (had_write || flushed_pending)
+        if Self::flush_needs_mtime_ctime_update(dirty_state, flushed_pending)
             && let Err(err) = self.update_mtime_ctime(handle.ino).await
         {
-            if had_write {
+            if dirty_state.dirty {
                 handle.mark_write_dirty();
             }
             return Err(err);
@@ -3630,7 +3654,7 @@ where
         );
 
         tracing::info!(fh, ino = handle.ino, "vfs.flush_handle_start");
-        let had_write = self.state.handles.take_write_dirty_for_inode(handle.ino);
+        let dirty_state = self.state.handles.take_write_dirty_for_inode(handle.ino);
         let flushed_pending = self
             .state
             .writer
@@ -3639,10 +3663,10 @@ where
             .map_err(VfsError::from)?;
         tracing::trace!(fh, ino = handle.ino, "vfs.flush_handle_done");
 
-        if (had_write || flushed_pending)
+        if Self::flush_needs_mtime_ctime_update(dirty_state, flushed_pending)
             && let Err(err) = self.update_mtime_ctime(handle.ino).await
         {
-            if had_write {
+            if dirty_state.dirty {
                 handle.mark_write_dirty();
             }
             return Err(err);

--- a/src/vfs/fs/tests.rs
+++ b/src/vfs/fs/tests.rs
@@ -592,11 +592,11 @@ mod basic_tests {
             .unwrap();
         let attr = fs.stat_ino(file_ino).await.unwrap();
 
-        let write_fh = fs
-            .open_with_cached_attr(file_ino, attr, false, true, false)
+        let read_fh = fs
+            .open_with_cached_attr(file_ino, attr, true, false, false)
             .await
             .unwrap();
-        fs.close(write_fh).await.unwrap();
+        fs.close(read_fh).await.unwrap();
 
         let before = fs.meta_layer().metrics().snapshot();
         let read_fh = fs
@@ -608,7 +608,7 @@ mod basic_tests {
 
         assert_eq!(
             after.open_fresh_stat, before.open_fresh_stat,
-            "cached-attr opens should warm the open-file cache for the next open"
+            "readonly cached-attr opens should warm the open-file cache for the next open"
         );
         assert_eq!(
             after.open_file_cache_hit,
@@ -618,7 +618,7 @@ mod basic_tests {
     }
 
     #[tokio::test]
-    async fn test_close_refreshes_open_cache_with_final_attr() {
+    async fn test_write_close_warms_readonly_open_cache_with_final_attr() {
         let layout = ChunkLayout::default();
         let store = InMemoryBlockStore::new();
         let meta_handle = create_meta_store_from_url("sqlite::memory:").await.unwrap();
@@ -659,6 +659,19 @@ mod basic_tests {
 
         assert_eq!(after.open_fresh_stat, before.open_fresh_stat);
         assert_eq!(after.open_file_cache_hit, before.open_file_cache_hit + 1);
+
+        let second_read_fh = fs
+            .open_fresh_ino(file_ino, true, false, false)
+            .await
+            .unwrap();
+        fs.close(second_read_fh).await.unwrap();
+        let after_second_read = fs.meta_layer().metrics().snapshot();
+
+        assert_eq!(after_second_read.open_fresh_stat, after.open_fresh_stat);
+        assert_eq!(
+            after_second_read.open_file_cache_hit,
+            after.open_file_cache_hit + 1
+        );
         assert_eq!(
             fs.handle_attr(read_fh).map(|attr| attr.size),
             None,

--- a/src/vfs/handles.rs
+++ b/src/vfs/handles.rs
@@ -8,7 +8,7 @@ use crate::vfs::io::{FileReader, FileWriter};
 use anyhow::anyhow;
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::time::SystemTime;
 
 fn current_time_secs() -> i64 {
@@ -26,6 +26,32 @@ use tokio::task::JoinHandle;
 /// Keep this comfortably below the kernel FUSE reply buffer while avoiding
 /// excessive userspace pagination for large directory scans.
 const MAX_READDIR_ENTRIES: usize = 256;
+const WRITE_DIRTY_DATA: u8 = 0b0000_0001;
+const WRITE_DIRTY_NEEDS_TIMESTAMP: u8 = 0b0000_0010;
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct WriteDirtyState {
+    pub(crate) dirty: bool,
+    pub(crate) needs_timestamp_update: bool,
+}
+
+impl WriteDirtyState {
+    pub(crate) fn clean() -> Self {
+        Self::default()
+    }
+
+    fn from_bits(bits: u8) -> Self {
+        Self {
+            dirty: bits & WRITE_DIRTY_DATA != 0,
+            needs_timestamp_update: bits & WRITE_DIRTY_NEEDS_TIMESTAMP != 0,
+        }
+    }
+
+    pub(crate) fn merge(&mut self, other: Self) {
+        self.dirty |= other.dirty;
+        self.needs_timestamp_update |= other.needs_timestamp_update;
+    }
+}
 
 struct GateState {
     readers: u32,
@@ -194,7 +220,7 @@ where
     pub(crate) ino: i64,
     pub(crate) opened_at: Instant,
     pub(crate) flags: HandleFlags,
-    write_dirty: AtomicBool,
+    write_dirty: AtomicU8,
     gate: Arc<HandleGate>,
     state: StdMutex<FileHandleState<B, M>>,
 }
@@ -213,7 +239,7 @@ where
             ino,
             opened_at: Instant::now(),
             flags,
-            write_dirty: AtomicBool::new(false),
+            write_dirty: AtomicU8::new(0),
             gate: Arc::new(HandleGate::new()),
             state: StdMutex::new(FileHandleState {
                 attr,
@@ -302,15 +328,23 @@ where
     }
 
     pub(crate) fn mark_write_dirty(&self) {
-        self.write_dirty.store(true, Ordering::Release);
+        self.write_dirty.fetch_or(
+            WRITE_DIRTY_DATA | WRITE_DIRTY_NEEDS_TIMESTAMP,
+            Ordering::AcqRel,
+        );
+    }
+
+    pub(crate) fn mark_write_dirty_extending_size(&self) {
+        self.write_dirty
+            .fetch_or(WRITE_DIRTY_DATA, Ordering::AcqRel);
     }
 
     pub(crate) fn has_write_dirty(&self) -> bool {
-        self.write_dirty.load(Ordering::Acquire)
+        self.write_dirty.load(Ordering::Acquire) & WRITE_DIRTY_DATA != 0
     }
 
-    pub(crate) fn take_write_dirty(&self) -> bool {
-        self.write_dirty.swap(false, Ordering::AcqRel)
+    pub(crate) fn take_write_dirty(&self) -> WriteDirtyState {
+        WriteDirtyState::from_bits(self.write_dirty.swap(0, Ordering::AcqRel))
     }
 
     #[allow(dead_code)]
@@ -353,7 +387,11 @@ where
 
     pub(crate) async fn write(&self, offset: u64, data: &[u8]) -> anyhow::Result<usize> {
         let _guard = self.gate.write_lock().await;
-        self.write_unlocked(offset, data).await
+        let written = self.write_unlocked(offset, data).await?;
+        if written > 0 {
+            self.mark_write_dirty();
+        }
+        Ok(written)
     }
 
     /// Write while the caller already holds the required handle write locks.
@@ -367,9 +405,6 @@ where
         };
         let written = writer.write_at(offset, data).await?;
         self.update_offset(offset + written as u64);
-        if written > 0 {
-            self.mark_write_dirty();
-        }
         Ok(written)
     }
 
@@ -493,5 +528,29 @@ impl Drop for DirHandle {
                 task.abort();
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_dirty_state_tracks_extending_writes_without_timestamp_update() {
+        let state = WriteDirtyState::from_bits(WRITE_DIRTY_DATA);
+
+        assert!(state.dirty);
+        assert!(!state.needs_timestamp_update);
+    }
+
+    #[test]
+    fn write_dirty_state_merge_keeps_timestamp_requirement() {
+        let mut state = WriteDirtyState::from_bits(WRITE_DIRTY_DATA);
+        state.merge(WriteDirtyState::from_bits(
+            WRITE_DIRTY_DATA | WRITE_DIRTY_NEEDS_TIMESTAMP,
+        ));
+
+        assert!(state.dirty);
+        assert!(state.needs_timestamp_update);
     }
 }


### PR DESCRIPTION
## Summary

This PR improves small-file and metadata-heavy workloads without changing the external API:

- enable a short JuiceFS-style open-file metadata cache by default, limited to readonly opens so write opens still perform a fresh stat
- seed the readonly open cache with final attributes on close, allowing close-to-open read paths to avoid redundant metadata round trips
- preserve hot parent child caches after local namespace mutations while locally touching cached parent timestamps
- track write dirtiness more precisely so size-extending writes can avoid redundant mtime/ctime updates at flush/close

This PR also refreshes the release/deployment path before tagging:

- document the full mount configuration surface, including Redis/RustFS, TiKV, cache, FUSE TTL, writeback, and compaction knobs
- add a binary deployment guide for release binaries, the single-node installer, systemd, Redis + RustFS, containers, upgrades, and rollback
- make the single-node installer expose S3, writeback, FUSE, TTL, and logging defaults as validated environment overrides
- make the release workflow print the generated R2 binary and SHA256 download URLs in the GitHub Actions summary

## Why

The previous Redis + RustFS correctness work made the suite stable, but metadata-heavy tests still paid avoidable round trips after creates, renames, readonly reopen, and extending writes. These paths are hot in small-file benchmarks, build workloads, and directory stress tests.

Before cutting a tag, operators also need a documented and repeatable way to install the generated binaries and understand the URL scheme produced by the release workflow.

## Validation

- `cargo fmt -- --check`
- `cargo test --lib -- --nocapture` passed: 513 passed, 159 ignored
- Full default BrewFS performance suite passed:
  - `/mnt/brewfs/docker/compose-xfstests/artifacts/perf-run-1783255306-13625`
- Full default JuiceFS comparison suite passed:
  - `/mnt/brewfs/docker/compose-xfstests/artifacts/juicefs-perf-run-1783255886-16455`
- `bash -n scripts/install_brewfs_single_node.sh`
- YAML parse check for `.github/workflows/release.yml`
- `git diff --check`
- installer dry-run render of `mount.yaml` with `BREWFS_WRITEBACK_MODE=safe` and `BREWFS_FUSE_PRIVILEGED=no`

Selected latest comparison results:

| Area | BrewFS | JuiceFS | Delta |
| --- | ---: | ---: | ---: |
| dirperf stat ops/sec | 55,742.5 | 36,158.6 | +54.2% |
| metaperf stat ops/sec | 13,515.9 | 9,243.1 | +46.2% |
| metaperf rename ops/sec | 1,845.0 | 1,345.5 | +37.1% |
| dirstress ops/sec | 2,603.2 | 2,392.2 | +8.8% |
| fio seqwrite MiB/s | 199.6 | 204.1 | -2.2% |
| fio randwrite MiB/s | 201.7 | 205.5 | -1.8% |
| looptest ops/sec | 298.2 | 321.8 | -7.3% |
