### PR TITLE
[codex] Fix release artifact upload paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ permissions:
 
 env:
   BREWFS_RELEASE_BASE_URL: https://download.brewfs.ai/brewfs/releases
+  BREWFS_RELEASE_R2_PREFIX: brewfs/releases
 
 jobs:
   build-and-upload:
@@ -26,6 +27,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+        with:
+          submodules: recursive
 
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -66,6 +69,7 @@ jobs:
         id: build
         shell: bash
         run: |
+          release_base="${BREWFS_RELEASE_BASE_URL%/}"
           binary_name="${{ matrix.component }}-${{ matrix.target.os }}-${{ matrix.target.arch }}"
           cargo_args=(--locked --release --target "${{ matrix.target.rust }}" --bin "${{ matrix.component }}")
 
@@ -79,11 +83,15 @@ jobs:
           mkdir -p build
           cp "target/${{ matrix.target.rust }}/release/${{ matrix.component }}" "build/${binary_name}"
           chmod +x "build/${binary_name}"
-          (cd build && sha256sum "${binary_name}" > "${binary_name}.sha256")
+          if command -v sha256sum >/dev/null 2>&1; then
+            (cd build && sha256sum "${binary_name}" > "${binary_name}.sha256")
+          else
+            (cd build && shasum -a 256 "${binary_name}" > "${binary_name}.sha256")
+          fi
 
           echo "binary_name=${binary_name}" >> "$GITHUB_OUTPUT"
-          echo "download_url=${BREWFS_RELEASE_BASE_URL}/${{ github.ref_name }}/${binary_name}" >> "$GITHUB_OUTPUT"
-          echo "checksum_url=${BREWFS_RELEASE_BASE_URL}/${{ github.ref_name }}/${binary_name}.sha256" >> "$GITHUB_OUTPUT"
+          echo "download_url=${release_base}/${{ github.ref_name }}/${binary_name}" >> "$GITHUB_OUTPUT"
+          echo "checksum_url=${release_base}/${{ github.ref_name }}/${binary_name}.sha256" >> "$GITHUB_OUTPUT"
           echo "Built binary: ${binary_name}"
 
       - name: Upload to Cloudflare R2
@@ -101,8 +109,19 @@ jobs:
           else
             curl https://rclone.org/install.sh | sudo bash
           fi
-          rclone copy ./build/ r2:${{ secrets.R2_BUCKET_NAME }}/brewfs/releases/${{ github.ref_name }}/ -v
 
+          # R2_BUCKET_NAME is the bucket name only, such as "artifact".
+          # Public download URLs intentionally omit the bucket name.
+          bucket_name="${{ secrets.R2_BUCKET_NAME }}"
+          release_prefix="${BREWFS_RELEASE_R2_PREFIX#/}"
+          release_prefix="${release_prefix%/}"
+          if [[ -z "${bucket_name}" || "${bucket_name}" == */* ]]; then
+            echo "::error::R2_BUCKET_NAME must be the R2 bucket name only; put object directories in BREWFS_RELEASE_R2_PREFIX."
+            exit 1
+          fi
+          rclone copy ./build/ "r2:${bucket_name}/${release_prefix}/${{ github.ref_name }}/" -v
+
+          echo "Uploaded object prefix: ${release_prefix}/${{ github.ref_name }}/"
           echo "Upload completed for ${{ matrix.component }}-${{ matrix.target.os }}-${{ matrix.target.arch }}"
 
       - name: Publish download links

--- a/scripts/install_brewfs_single_node.sh
+++ b/scripts/install_brewfs_single_node.sh
@@ -4,8 +4,8 @@
 #
 # This script installs and maintains a local BrewFS stack managed by systemd:
 # Redis for metadata, RustFS for S3-compatible object storage, and BrewFS as
-# the mounted filesystem. BrewFS release binaries are resolved from the same
-# R2 layout used by the release workflow: brewfs/releases/<version>/brewfs-linux-<arch>.
+# the mounted filesystem. BrewFS release binaries are resolved from the public
+# R2 download layout: brewfs/releases/<version>/brewfs-linux-<arch>.
 
 set -euo pipefail
 

--- a/src/fuse/mod.rs
+++ b/src/fuse/mod.rs
@@ -2519,7 +2519,7 @@ where
         if !matches!(parent_attr.kind, VfsFileType::Dir) {
             return Err(libc::ENOTDIR.into());
         }
-        if (parent_attr.mode & libc::S_ISVTX) == 0 {
+        if (parent_attr.mode & libc::S_ISVTX as u32) == 0 {
             return Ok(());
         }
 


### PR DESCRIPTION
## Summary

- keep public release links under `https://download.brewfs.ai/brewfs/releases/<tag>/...` without exposing the R2 bucket name
- split the R2 object key prefix into `BREWFS_RELEASE_R2_PREFIX=brewfs/releases` and validate that `R2_BUCKET_NAME` is only the bucket name
- make checksum generation portable across Linux and macOS runners
- fix the Darwin build failure from `libc::S_ISVTX` having a narrower type on macOS

## Root cause

The reference workflow treats `R2_BUCKET_NAME` as the bucket only and appends `<project>/releases/<tag>/` as the object key prefix. The previous BrewFS release path mixed the public URL shape with the R2 bucket/object layout, which could produce an extra bucket/internal-prefix layer such as `artifact/artifact/brewfs`. The public download URL should not contain `artifact`; only the R2 remote uses the bucket.

## Validation

- `python3` YAML parse for `.github/workflows/release.yml`
- `bash -n scripts/install_brewfs_single_node.sh`
- `git diff --check`
- `cargo fmt --check`
- `cargo check -p brewfs --no-default-features --features fuse-tokio-runtime`

Note: local Linux-hosted `cargo check --target aarch64-apple-darwin` cannot complete because the local C compiler does not support macOS flags like `-arch arm64` and `-mmacosx-version-min`; the macOS GitHub runner is needed for that target.