### PR TITLE
[codex] Fix bucket-scoped R2 release uploads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,16 +110,16 @@ jobs:
             curl https://rclone.org/install.sh | sudo bash
           fi
 
-          # R2_BUCKET_NAME is the bucket name only, such as "artifact".
-          # Public download URLs intentionally omit the bucket name.
-          bucket_name="${{ secrets.R2_BUCKET_NAME }}"
+          # The rclone R2 remote is already scoped to the Cloudflare bucket.
+          # Do not add the bucket name here, or it becomes an object prefix
+          # such as artifacts/brewfs/releases instead of brewfs/releases.
           release_prefix="${BREWFS_RELEASE_R2_PREFIX#/}"
           release_prefix="${release_prefix%/}"
-          if [[ -z "${bucket_name}" || "${bucket_name}" == */* ]]; then
-            echo "::error::R2_BUCKET_NAME must be the R2 bucket name only; put object directories in BREWFS_RELEASE_R2_PREFIX."
+          if [[ -z "${release_prefix}" || "${release_prefix}" == */../* || "${release_prefix}" == ../* ]]; then
+            echo "::error::BREWFS_RELEASE_R2_PREFIX must be a non-empty object prefix."
             exit 1
           fi
-          rclone copy ./build/ "r2:${bucket_name}/${release_prefix}/${{ github.ref_name }}/" -v
+          rclone copy ./build/ "r2:${release_prefix}/${{ github.ref_name }}/" -v
 
           echo "Uploaded object prefix: ${release_prefix}/${{ github.ref_name }}/"
           echo "Upload completed for ${{ matrix.component }}-${{ matrix.target.os }}-${{ matrix.target.arch }}"


### PR DESCRIPTION
## Summary

- upload release assets to the bucket-scoped rclone remote at `r2:brewfs/releases/<tag>/`
- stop inserting `R2_BUCKET_NAME` into the object path, because it becomes an extra `artifacts/` folder in Cloudflare R2
- keep public download links unchanged at `https://download.brewfs.ai/brewfs/releases/<tag>/...`

## Root cause

The v0.0.1 test release succeeded, but Cloudflare R2 showed the objects under `artifacts/artifacts/brewfs/releases/v0.0.1`. That means the configured `r2` remote is already scoped to the `artifacts` bucket. The workflow then used `r2:${bucket_name}/${release_prefix}/...`, so the bucket name was interpreted as an object prefix.

With this change, the object key is `brewfs/releases/<tag>/...`, which should appear in the UI as `artifacts/brewfs/releases/<tag>/...`.

## Validation

- inspected the v0.0.1 release logs from run 28801555500
- verified the previous command was `rclone copy ./build/ "r2:${bucket_name}/${release_prefix}/v0.0.1/"`
- `python3` YAML parse for `.github/workflows/release.yml`
- `git diff --check`
- local string assertions that release upload no longer uses `R2_BUCKET_NAME` in the remote path