### PR TITLE
Stabilize POSIX test runners for v0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "brewfs"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-recursion 1.1.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brewfs"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 authors = ["rk8s-dev team"]
 description = "High-performance Rust & Layers-aware Distributed Filesystem"

--- a/doc/testing/fs-test-suite-matrix.md
+++ b/doc/testing/fs-test-suite-matrix.md
@@ -135,6 +135,13 @@ The full LTP runner uses BrewFS' normal kernel page-cache behavior and skips
 `iogen01` by default. Keep it skipped until the buffered writeback-cache
 failure is fixed:
 
+To keep the long growfiles sequence from depending on otherwise idle host RAM,
+the LTP runner writes explicit cache defaults of 1 GiB read memory, 256 MiB
+write memory, and a 1 GiB VFS memory budget. Each can be overridden with its
+corresponding `BREWFS_*_MEMORY_BYTES` variable. This keeps an OOM-killed FUSE
+daemon from turning later cases into misleading `ENOTCONN` failures; the full
+Redis+RustFS run `run-1784362121-30367` passed with `failures_count: 0`.
+
 - Direct-I/O tiny-overlap shape is fixed in
   `docker/compose-xfstests/artifacts/run-1783536533-27423`.
 - Buffered split-write/page-cache race remains in

--- a/doc/testing/xfstests-redis-rustfs-fix-plan.md
+++ b/doc/testing/xfstests-redis-rustfs-fix-plan.md
@@ -15,6 +15,11 @@ Short handoff for the Redis metadata + RustFS object-store correctness run.
   `run-1783974271-14804`, and `run-1783975421-24234`.
   Environment-only `TCONF` entries remain for unavailable container kernel
   modules and image tools.
+- Redis+RustFS LTP also passed after the runner began applying bounded cache
+  defaults: `run-1784362121-30367`, `failures_count: 0`. The preceding
+  `run-1784128661-5712` failure was one FUSE daemon disconnect during `gf17`;
+  all 23 later failures were consequential `ENOTCONN` results, not independent
+  filesystem failures.
 - LTP `iogen01` remains known failing in the normal buffered FUSE profile and
   must stay in `docker/compose-xfstests/ltp_skip_tests.txt`.
 - Full pjdfstest passed without default exclusions on Redis and TiKV:
@@ -32,6 +37,12 @@ Short handoff for the Redis metadata + RustFS object-store correctness run.
 
 ## Fixed This Round
 
+- Bound the LTP runner's default cache profile to 1 GiB read memory, 256 MiB
+  write memory, and a 1 GiB VFS budget. The values remain overridable through
+  `BREWFS_READ_MEMORY_BYTES`, `BREWFS_WRITE_MEMORY_BYTES`, and
+  `BREWFS_MEMORY_BUDGET_BYTES`. This keeps the full correctness suite from
+  relying on idle host RAM; `run-1784362121-30367` passed at an observed
+  BrewFS RSS peak of about 4.76 GiB, with no new exclusions.
 - Fixed `--no-default-skip` in
   `docker/compose-xfstests/run_ltp_in_container.sh`.
   - Prior bug: using `/dev/null` as the skip file made `awk` consume the LTP

--- a/docker/compose-xfstests/run_ltp_in_container.sh
+++ b/docker/compose-xfstests/run_ltp_in_container.sh
@@ -30,6 +30,14 @@ ltp_skip_tests_file="${LTP_SKIP_TESTS_FILE:-}"
 ltp_default_skip_tests_file="${LTP_DEFAULT_SKIP_TESTS_FILE:-/usr/local/share/brewfs/ltp_skip_tests.txt}"
 ltp_tmp_dir=""
 
+# LTP's growfiles cases run a long sequence of large, random I/O patterns.
+# Keep this correctness runner independent of otherwise idle host RAM: these
+# limits are ample for the suite but avoid a cache-only OOM killing the FUSE
+# daemon and turning every later case into a misleading ENOTCONN failure.
+: "${BREWFS_READ_MEMORY_BYTES:=1073741824}"
+: "${BREWFS_WRITE_MEMORY_BYTES:=268435456}"
+: "${BREWFS_MEMORY_BUDGET_BYTES:=1073741824}"
+
 write_config() {
     mkdir -p "$(dirname "$config_path")" "$mount_dir"
     if [[ "$data_backend" == "local-fs" ]]; then

--- a/docker/compose-xfstests/run_pjdfstest_in_container.sh
+++ b/docker/compose-xfstests/run_pjdfstest_in_container.sh
@@ -431,7 +431,9 @@ run_pjdfstest() {
     status="${PIPESTATUS[0]}"
     set -e
 
-    grep -E '^[^[:space:]].*\.t .*Failed|Result: FAIL|Failed [0-9]+/[0-9]+ subtests' "$artifact_dir/pjdfstest.console.log" \
+    # Ignore prove's successful summary rows such as "Failed: 0".  They can
+    # accompany TODO-passed diagnostics and are not failed pjdfstest cases.
+    grep -E '^[^[:space:]].*\.t .*Failed: [1-9][0-9]*|Result: FAIL|Failed [1-9][0-9]*/[0-9]+ subtests' "$artifact_dir/pjdfstest.console.log" \
         >"$artifact_dir/failed-tests.txt" 2>/dev/null || true
     failed_count="$(wc -l <"$artifact_dir/failed-tests.txt" | tr -d '[:space:]')"
 

--- a/scripts/install_brewfs_single_node.sh
+++ b/scripts/install_brewfs_single_node.sh
@@ -30,7 +30,7 @@ BREWFS_BASE_URL="${BREWFS_BASE_URL:-https://download.brewfs.ai/brewfs/releases}"
 BREWFS_VERSION="${BREWFS_VERSION:-}"
 BREWFS_REQUIRE_CHECKSUM="${BREWFS_REQUIRE_CHECKSUM:-0}"
 BREWFS_ALLOW_FALLBACK="${BREWFS_ALLOW_FALLBACK:-0}"
-DEFAULT_BREWFS_VERSION="${DEFAULT_BREWFS_VERSION:-v0.1.1}"
+DEFAULT_BREWFS_VERSION="${DEFAULT_BREWFS_VERSION:-v0.1.2}"
 BREWFS_DOWNLOAD_URL="${BREWFS_DOWNLOAD_URL:-}"
 BREWFS_INSTALL_PACKAGES="${BREWFS_INSTALL_PACKAGES:-1}"
 
@@ -140,7 +140,7 @@ Environment overrides:
   BREWFS_REQUIRE_CHECKSUM=0    Set to 1 to fail if <binary>.sha256 is missing.
   BREWFS_ALLOW_FALLBACK=0      Set to 1 to use DEFAULT_BREWFS_VERSION if latest
                                release detection is unreachable.
-  DEFAULT_BREWFS_VERSION=v0.1.1
+  DEFAULT_BREWFS_VERSION=v0.1.2
                                Opt-in fallback version.
   BREWFS_DOWNLOAD_URL=""       Explicit BrewFS binary archive or executable URL.
   BREWFS_INSTALL_PACKAGES=1    Install missing OS packages with apt-get when possible.
@@ -195,7 +195,7 @@ Notes:
     release/tag that has a published brewfs-${OS}-${ARCH} artifact at:
       ${BREWFS_BASE_URL}/${BREWFS_VERSION}/brewfs-${OS}-${ARCH}
     For example:
-      https://download.brewfs.ai/brewfs/releases/v0.1.1/brewfs-linux-amd64
+      https://download.brewfs.ai/brewfs/releases/v0.1.2/brewfs-linux-amd64
   - If RUSTFS_DOWNLOAD_URL is empty, this script uses the RustFS official
     installer source ($RUSTFS_INSTALLER_URL) as the reference and downloads the
     matching latest Linux archive from $RUSTFS_DIST_BASE_URL.


### PR DESCRIPTION
## Summary

- bound LTP correctness-runner caches to prevent host-memory-driven FUSE disconnect cascades
- report pjdfstest failures only when prove reports a non-zero failure count
- prepare the v0.1.2 package and installer fallback

## Root Cause

A resource-constrained LTP growfiles run could terminate the FUSE daemon; later cases then only reported consequential ENOTCONN errors. pjdfstest also counted a successful `Failed: 0` summary row as a failure.

## Validation

- cargo check --locked
- bash -n docker/compose-xfstests/run_ltp_in_container.sh docker/compose-xfstests/run_pjdfstest_in_container.sh scripts/install_brewfs_single_node.sh
- Redis + RustFS: LTP PASS, xfstests 708 configured tests PASS, pjdfstest 246 files / 9,134 assertions / 0 failures
- git diff --check