### PR TITLE
docs: specify clustered frozen metadata and resumable ingestion

### DIFF
--- a/doc/superpowers/specs/2026-08-24-brewfs-clustered-frozen-metadata-v2.md
+++ b/doc/superpowers/specs/2026-08-24-brewfs-clustered-frozen-metadata-v2.md
@@ -1,0 +1,1280 @@
+# BrewFS Clustered Frozen Metadata v2
+
+Status: Proposed implementation specification
+
+Scope: immutable committed base metadata, file-cluster ingestion, S3 persistence, progressive loading,
+and private agent overlays
+
+This document supersedes the single-image BRFI v1 design. It is normative for new code.
+
+## 1. Goals
+
+The design must provide all of the following:
+
+1. split a very large committed filesystem into independently managed **file clusters**;
+2. allow several clusters to contribute entries to the same mounted directory;
+3. keep each committed cluster immutable and independently content-addressable;
+4. expose parent directories and their entries before deeper metadata during sequential streaming;
+5. load an arbitrary metadata batch without loading all preceding batches;
+6. evict decoded cold metadata and reload it without changing inode or directory semantics;
+7. keep one private mutable `MemLayer` per agent while sharing all committed cluster caches;
+8. build and upload one cluster from a local directory or supported archive;
+9. upload cluster metadata before uploading file data;
+10. resume safely after process crash, power loss, or a partially completed S3 multipart upload;
+11. publish no cluster or snapshot until every referenced data object is durably verified.
+
+The design does not provide in-place mutation of a committed cluster, cross-cluster directory
+hardlinks, or visibility of a partially uploaded cluster.
+
+## 2. Terms and object model
+
+```text
+WorkspaceHead (CAS mutable pointer)
+        |
+        v
+ClusteredSnapshotManifest (.brfsm, immutable)
+        |
+        +-- MountTrie
+        +-- MergeRouteIndex
+        +-- ClusterDescriptor[...]
+                 |
+                 +-- FrozenClusterMetadata (.brfc, uploaded first)
+                 +-- DataSeal             (.brfds, uploaded last)
+                             |
+                             +-- DataPack / large data objects (.brfdp)
+```
+
+Definitions:
+
+- **file cluster**: one immutable namespace fragment plus the data referenced by that fragment;
+- **cluster contribution**: one cluster-local representation of a logical directory and some of its
+  entries;
+- **virtual directory**: the union of one or more cluster contributions with the same `DirKey`;
+- **metadata batch**: the independently authenticated, fetched, decoded, and evicted unit;
+- **snapshot manifest**: the immutable object that selects clusters and defines their mount points;
+- **Data Seal**: the immutable mapping from logical `SliceId`s in metadata to verified S3 data ranges;
+- **resident**: decoded metadata is currently in RAM; absence from RAM never means logical absence.
+
+The mounted committed view is one snapshot, not a precedence stack:
+
+```text
+private agent MemLayer
+          |
+          v
+union(snapshot clusters selected by one manifest)
+```
+
+Cluster union is defined in section 5. A cluster never shadows another committed cluster.
+
+## 3. Immutable publication boundary
+
+A committed snapshot is identified by:
+
+```rust
+pub struct SnapshotRef {
+    pub manifest_hash: [u8; 32],
+    pub superblock_digest: [u8; 32],
+    pub object_len: u64,
+}
+```
+
+The workspace head stores `SnapshotRef` and is updated with compare-and-swap. The manifest references
+only sealed clusters. A sealed cluster is:
+
+```rust
+pub struct SealedClusterRef {
+    pub cluster_id: ClusterId,
+    pub metadata: ObjectRef,
+    pub data_seal: ObjectRef,
+    pub combined_semantic_hash: [u8; 32],
+}
+```
+
+`combined_semantic_hash` authenticates both namespace structure and file contents:
+
+```text
+BLAKE3("BrewFS.SealedCluster.v2" || metadata.semantic_hash || data_seal.semantic_hash)
+```
+
+Uploading metadata does not make a cluster mountable. Uploading data does not make it mountable. Only
+a verified Data Seal followed by inclusion in a manifest crosses the publication boundary.
+
+No object is rewritten after publication. A new grouping, mount layout, file value, or directory entry
+produces new immutable objects and a new manifest.
+
+## 4. Identities
+
+### 4.1 ClusterId and local NodeId
+
+`ClusterId` is 128 bits. It is assigned when the local ingestion session is created and is permanently
+recorded in the cluster metadata.
+
+Within one cluster, `LocalNodeId` is a dense non-zero `u32`; root is 1. Dense IDs keep local tables and
+varints compact and remove the former whole-snapshot `u32` node limit.
+
+```rust
+pub struct NodeRef {
+    pub cluster_slot: u32,
+    pub local_node_id: u32,
+}
+```
+
+`cluster_slot` is the descriptor ordinal in one snapshot manifest. It is runtime/snapshot-local and is
+not persisted inside a `.brfc` object.
+
+All directory entries for one hardlinked non-directory inode must be placed in the same cluster.
+Cross-cluster file hardlinks are rejected by the builder. Directory hardlinks remain invalid.
+
+### 4.2 DirKey
+
+The same logical directory may have a local NodeId in many clusters. `DirKey` is its global merge key:
+
+```rust
+#[repr(transparent)]
+pub struct DirKey([u8; 16]);
+```
+
+For a directory reached through a normal name:
+
+```text
+DirKey = BLAKE3-128(
+  "BrewFS.DirKey.v2" || volume_id || parent_DirKey || u32_le(name_len) || raw_name
+)
+```
+
+The volume root key is derived from `volume_id` and a fixed root tag. Raw POSIX name bytes are used;
+locale and Unicode normalization are not applied.
+
+Every contribution for one `DirKey` must encode identical directory hot attributes, xattrs, ACLs, and
+symlink-invalid status. Repeating directory attributes in the normally small number of contributions
+is intentional: any contribution can be loaded independently. A mismatch is snapshot corruption.
+
+A v2 cluster is built for one mount target and cannot be rebound to another path, because descendant
+DirKeys include the mounted parent key.
+
+### 4.3 Runtime FUSE inode
+
+FUSE inode identity must not require a ten-billion-row interner. v2 uses collision-free snapshot-local
+packing:
+
+```text
+bit 63 = 1  private MemLayer inode
+
+bit 63 = 0  committed inode
+bits 62..61 committed tag:
+  00 non-directory: bits 60..32 cluster_slot (29 bits), bits 31..0 LocalNodeId
+  01 virtual directory backed by clusters: canonical contributor in the same 29+32 packing
+  10 manifest-only mount directory: bits 31..0 MountTrieNodeId, upper payload bits zero
+  11 reserved
+```
+
+The manifest is limited to fewer than `2^29` cluster slots. For a merged directory, the canonical
+contributor is the lowest unsigned `(cluster_slot, LocalNodeId)` in its authenticated route record.
+For a single-contributor directory, that contributor is canonical. A MountTrie node takes precedence
+as the identity when the directory is explicitly represented by the manifest. These choices are
+deterministic for one SnapshotRef and require no hash or collision table.
+
+An active kernel lookup entry may copy `InodeHot` and a reloadable `RecordLocator`; it never contains a
+raw pointer into an evictable batch. It is released after the kernel sends FORGET and all open-handle
+references reach zero. Readdir can emit deterministic inode numbers without permanently retaining all
+visited files.
+
+## 5. Namespace union semantics
+
+### 5.1 Contributions
+
+The manifest may attach many cluster roots to the same virtual mount directory. Each attached root is
+a contributor. Descending into a child directory carries forward every matching directory
+contribution.
+
+Example:
+
+```text
+cluster A at /workspace: src/a.rs, data/a.parquet
+cluster B at /workspace: src/b.rs, models/m.bin
+
+mounted result:
+/workspace/src/a.rs
+/workspace/src/b.rs
+/workspace/data/a.parquet
+/workspace/models/m.bin
+```
+
+Both `src` entries have the same `DirKey`, so they form one virtual directory.
+
+### 5.2 Collision rules
+
+For the same `(parent DirKey, raw name)`:
+
+- zero matches means absent;
+- exactly one non-directory match selects that file;
+- one or more directory matches with the same derived child `DirKey` merge;
+- two non-directory matches are invalid, even if their data bytes are equal;
+- directory plus non-directory is invalid;
+- differing directory attributes or child DirKeys are invalid.
+
+There is no cluster priority and no last-writer-wins rule. This makes grouping independent of visible
+filesystem semantics. The private MemLayer may intentionally replace or delete the merged result.
+
+The snapshot builder performs a complete conflict validation before publication. Runtime repeats the
+relevant check when lazily materializing a merged name and returns `EIO`, never an arbitrary winner, if
+the authenticated objects disagree.
+
+### 5.3 Ancestor skeletons
+
+If a cluster contributes `/a/b/file`, it must contain directory contribution records for its mounted
+root, `a`, and `b`. These skeleton records make contributor discovery recursive and remove the need for
+a global entry-per-file routing database.
+
+The cluster packer should minimize duplicated skeletons, but they are semantically required.
+
+## 6. Merge routing without per-file duplication
+
+Querying every root cluster for every filename is correct but can become expensive. The manifest has a
+paged `MergeRouteIndex` only for virtual directories with more than one contributor.
+
+```rust
+pub struct MergeRouteRecord {
+    pub dir_key: DirKey,
+    pub contributors: Vec<DirContributor>,
+    pub route_bucket_bits: u8,       // 0..=12
+    pub bucket_offsets: Vec<u32>,
+    pub candidate_ordinals: Vec<u16_or_u32>,
+}
+
+pub struct DirContributor {
+    pub cluster_slot: u32,
+    pub local_dir_node_id: u32,
+}
+```
+
+The route hash is:
+
+```text
+low_bits(BLAKE3("BrewFS.Route.v2" || snapshot_route_seed || raw_name))
+```
+
+For each hash bucket, the record contains every contributor that owns at least one name in that
+bucket. It is an exact candidate set at bucket granularity, not a probabilistic filter, so it cannot
+create false negatives. Hash collisions may create extra cluster lookups but never incorrect results.
+
+Rules:
+
+- a multi-contributor directory must have one authenticated route record;
+- contributor lists in the route record must equal contributor discovery from the cluster data;
+- a single-contributor directory uses the contributor directly and has no route record;
+- `route_bucket_bits=0` means query all contributors;
+- the default is 8 bits; a builder may choose up to 12 bits for high fan-out directories;
+- the route index is derived acceleration data and is included in the manifest physical hash;
+- collision validation still runs independently of routing.
+
+For large merged directories, the packer should assign names to clusters by contiguous route-hash
+bucket ranges. Then a lookup normally selects one cluster while related directory paths can still be
+distributed across different cluster objects. Arbitrary cluster grouping remains correct but can
+degrade to fan-out reads.
+
+The route index stores one record per merged directory, not one record per file.
+
+## 7. Cluster planning and placement
+
+The packing unit is an inode equivalence class, not an individual pathname. All hardlinks, inode hot
+attributes, extents, and cold attributes for one file move together.
+
+Default planner objectives:
+
+- target 256 MiB to 2 GiB of stored metadata per cluster;
+- cap local nodes below `u32::MAX - 1`;
+- cap one cluster's page-index height and batch count;
+- preserve subtree locality when requested;
+- use route-hash ranges for very large shared directories;
+- avoid placing all hot roots into one oversized cluster;
+- keep directory skeleton overhead below a configured fraction, default 5%;
+- create a new cluster rather than violate a hard limit.
+
+Planner modes:
+
+```text
+Subtree        keep subtrees together until the target size
+HashRange      partition names in selected directories by route hash
+SizeBalanced   distribute inode groups by estimated metadata/data size
+Explicit       caller supplies include rules and mount root
+```
+
+The planner writes a deterministic `ClusterPlan` before encoding. Repeated builds with identical
+source inventory, options, and ClusterIds produce identical metadata bytes.
+
+## 8. Snapshot manifest format (`.brfsm`)
+
+Magic: `BRFSM002`
+
+The manifest contains:
+
+```text
+4096-byte superblock
+MountTrieIndexRoot
+ClusterTableIndexRoot
+MergeRouteIndexRoot
+paged MountTrie
+paged ClusterTable
+paged MergeRouteIndex
+footer
+```
+
+The superblock includes:
+
+```rust
+pub struct SnapshotSuperblock {
+    pub volume_id: [u8; 16],
+    pub snapshot_id: [u8; 16],
+    pub semantic_hash: [u8; 32],
+    pub route_seed: [u8; 16],
+    pub cluster_count: u32,
+    pub mount_count: u32,
+    pub merged_directory_count: u64,
+    pub root_dir_key: DirKey,
+    pub index_roots: [MerkleRootRef; 3],
+}
+```
+
+Each cluster descriptor records:
+
+```rust
+pub struct ClusterDescriptor {
+    pub cluster_id: ClusterId,
+    pub metadata_ref: ObjectRef,
+    pub data_seal_ref: ObjectRef,
+    pub combined_semantic_hash: [u8; 32],
+    pub mount_dir_key: DirKey,
+    pub root_local_node_id: u32,       // always 1 in v2
+    pub flags: u32,
+}
+```
+
+The mount trie maps raw path components to an ordered, duplicate-free list of cluster slots. Its root
+record is small and pinned for the mount lifetime. Deeper trie pages load on demand.
+
+Object key:
+
+```text
+brewfs-meta/v2/volumes/{volume_id}/snapshots/{manifest_hash[0]:02x}/{manifest_hash}.brfsm
+```
+
+## 9. Frozen cluster metadata format (`.brfc`)
+
+Magic: `BRFCL002`
+
+One `.brfc` object contains no file data and no final S3 data locations. Extents refer only to
+cluster-local `SliceId`s.
+
+Physical order:
+
+```text
++--------------------------------------+ offset 0
+| 4096-byte ClusterSuperblock          |
++--------------------------------------+
+| Merkle index nodes                   | small roots first
++--------------------------------------+
+| Namespace batches                    | BFS parent-first
++--------------------------------------+
+| Extent batches                       | LocalNodeId order
++--------------------------------------+
+| Attribute batches                    | LocalNodeId order
++--------------------------------------+
+| Footer                               |
++--------------------------------------+
+```
+
+The superblock includes:
+
+```rust
+pub struct ClusterSuperblock {
+    pub format_major: u16,             // 2
+    pub format_minor: u16,
+    pub cluster_id: ClusterId,
+    pub volume_id: [u8; 16],
+    pub mount_dir_key: DirKey,
+    pub metadata_semantic_hash: [u8; 32],
+    pub build_options_digest: [u8; 32],
+    pub node_count: u32,
+    pub directory_contribution_count: u32,
+    pub dentry_count: u64,
+    pub extent_count: u64,
+    pub slice_count: u64,
+    pub namespace_batch_count: u32,
+    pub extent_batch_count: u32,
+    pub attribute_batch_count: u32,
+    pub chunk_size: u64,
+    pub index_roots: [MerkleRootRef; 4],
+}
+```
+
+The four Merkle indexes are:
+
+1. namespace `(parent LocalNodeId, raw name) -> BatchLocator`;
+2. node introduction `LocalNodeId range -> namespace BatchLocator`;
+3. extent `LocalNodeId range -> BatchLocator`;
+4. attribute `LocalNodeId range -> BatchLocator`.
+
+Object key:
+
+```text
+brewfs-meta/v2/clusters/{cluster_id}/metadata/{object_hash[0]:02x}/{object_hash}.brfc
+```
+
+## 10. Merkle indexes
+
+An entire index must not be loaded to open a cluster. Every index is a 4096-byte-node immutable B+
+tree. The superblock stores the root offset, length, level, key kind, and BLAKE3 digest. Each internal
+entry authenticates its child node's offset, length, first/last key, and digest.
+
+Index properties:
+
+- root nodes are pinned while the cluster handle is open;
+- internal and leaf nodes are cached independently;
+- names in namespace leaf nodes use restart-point prefix compression;
+- a restart point occurs at least every 16 entries;
+- one node can be decoded without its previous sibling;
+- leaf sibling offsets permit sequential scan but are not trusted without their parent digest;
+- all lengths and offsets are checked before allocation or Range GET;
+- root-to-leaf validation is sufficient to trust one `BatchLocator` without loading other leaves.
+
+`BatchLocator` contains:
+
+```rust
+pub struct BatchLocator {
+    pub kind: BatchKind,
+    pub batch_id: u32,
+    pub stream_ordinal: u32,
+    pub object_offset: u64,
+    pub total_stored_len: u32,       // 128-byte header plus stored payload
+    pub raw_payload_len: u32,
+    pub first_new_node_id: u32,
+    pub new_node_count: u32,
+    pub digest: [u8; 32],
+}
+```
+
+For namespace leaves, the logical range also includes full first and last `(parent, name)` keys. For
+extent and attribute leaves, it is a LocalNodeId range.
+
+## 11. Metadata batch format
+
+A batch is the S3 fetch, authentication, decompression, decoded-cache, and eviction unit. It is not a
+database page and never changes after upload.
+
+Default raw targets:
+
+| Batch kind | Default target | Hard maximum |
+|---|---:|---:|
+| Namespace | 1 MiB | 16 MiB |
+| Extent | 1 MiB | 16 MiB |
+| Attribute | 512 KiB | 16 MiB |
+
+Each batch has a 128-byte header:
+
+| Offset | Size | Field |
+|---:|---:|---|
+| 0 | 8 | magic `BRFCBT02` |
+| 8 | 2 | batch kind |
+| 10 | 2 | batch version |
+| 12 | 4 | flags |
+| 16 | 16 | ClusterId |
+| 32 | 4 | batch ID within kind |
+| 36 | 4 | physical stream ordinal |
+| 40 | 4 | predecessor ordinal or `0xffffffff` |
+| 44 | 4 | logical record/group count |
+| 48 | 8 | raw payload length |
+| 56 | 8 | stored payload length |
+| 64 | 4 | first newly introduced LocalNodeId |
+| 68 | 4 | newly introduced node count |
+| 72 | 1 | codec: None=0, Zstd=1 |
+| 73 | 7 | reserved zero |
+| 80 | 4 | stored payload CRC32C |
+| 84 | 4 | header CRC32C over bytes `[0,84)` |
+| 88 | 8 | first logical-key fingerprint |
+| 96 | 32 | BLAKE3 of header `[0,96)` plus stored payload |
+
+The authenticated index contains the complete logical boundary; the header fingerprints catch wrong
+range responses cheaply. Decoders verify index digest, header CRC, payload CRC, decompressed length,
+and complete payload consumption before publication.
+
+Every batch is self-contained:
+
+- integer delta state resets at batch start;
+- filename prefix compression resets at batch start and at restart points;
+- the full parent LocalNodeId appears in the first directory segment;
+- a namespace batch declares its exact new-node range;
+- targeted decode does not require the predecessor batch;
+- predecessor is required only to advance a sequential streaming frontier.
+
+Large directory segments may continue in adjacent batches. A targeted segment carries its parent,
+first name, entry count, continuation flags, and the directory's total entry count or authenticated
+unknown marker. It can answer indexed lookup without materializing earlier name ranges.
+
+## 12. Namespace encoding and parent-first order
+
+Within one cluster, LocalNodeIds and directory groups are assigned breadth-first:
+
+1. root contribution is LocalNodeId 1 and is the first logical record;
+2. directory groups are processed in LocalNodeId order;
+3. names are raw-byte sorted within each contribution;
+4. a new child inode record immediately follows its introducing dentry;
+5. a child directory group occurs after its parent dentry;
+6. hardlinks refer only to an earlier introduced local node;
+7. all segments of one local directory are physically contiguous;
+8. each batch boundary resets its compact decoding state.
+
+A directory inode record includes its `DirKey`. Non-directory inode records do not.
+
+```text
+directory_segment:
+  parent_local_node_id  uvarint
+  parent_dir_key        16 bytes
+  flags                 u8       // START, END, CONTINUATION
+  total_entry_count     uvarint   // on START
+  first_name            bytes
+  entry_count           uvarint
+
+  repeated entries:
+    shared_name_bytes   uvarint
+    name_suffix         bytes
+    entry_tag           u8
+    if NEW_NODE:
+      inode_record      bytes
+    else:
+      existing_local_node_id uvarint
+```
+
+For a new directory, `inode_record` contains the derived child DirKey and complete directory
+attributes. The loader verifies derivation from the parent DirKey and raw name.
+
+The namespace stream is useful immediately:
+
+```text
+cluster root
+root name prefixes + inline child attributes
+depth-1 contribution prefixes
+depth-2 contribution prefixes
+...
+```
+
+Parent-first is a physical streaming property, not a residency promise. Previously streamed batches
+may later be evicted.
+
+## 13. Extent and attribute encoding
+
+Extent groups remain complete final file maps ordered by LocalNodeId:
+
+```text
+file_group:
+  local_node_id
+  extent_count
+  repeated:
+    gap_from_previous_end
+    logical_length
+    slice_id
+    slice_offset
+```
+
+Gaps are holes. No layer, transaction, Whiteout, or historical overwrite is stored. An extent cannot
+cross the configured BrewFS logical chunk boundary. `SliceId` is cluster-local, non-zero, and resolved
+through the Data Seal only after publication.
+
+Attribute groups contain symlink target, xattrs, and ACLs in LocalNodeId order. Directory cold
+attributes are repeated in each contribution and must compare equal during snapshot validation.
+
+Extent and attribute batches are independently indexed and may be loaded or evicted without their
+namespace batch. Namespace hot inode records state whether a corresponding cold group exists.
+
+## 14. Streaming and arbitrary batch loading
+
+The loader exposes two complementary paths over the same format.
+
+### 14.1 Sequential stream path
+
+Used for mount warm-up, root-first traversal, prefetch, and full scans:
+
+1. open the manifest and root contributors;
+2. open selected cluster superblocks and index roots;
+3. Range-stream namespace batches in physical ordinal order;
+4. validate a batch before exposing any of it;
+5. publish sorted directory prefixes;
+6. continue while the warm-up byte, depth, or time budget remains;
+7. optionally stream extent/attribute batches for nodes selected by the prefetch policy.
+
+For a virtual directory with several contributors, its globally publishable prefix frontier is the
+minimum raw name frontier reached by all contributors. A sequential warm-up must not return negative
+answers beyond that global frontier.
+
+### 14.2 Targeted batch path
+
+Used for cache misses and random lookup:
+
+1. use `DirKey` to obtain the merge route record when needed;
+2. hash the name and select exact candidate contributors;
+3. traverse each cluster's pageable namespace index;
+4. fetch the indicated batch through one Range GET;
+5. validate and decode the complete batch;
+6. resolve a matching dentry or authoritative absence in that indexed name interval;
+7. load an introduction batch if a hardlink target's hot inode is not resident;
+8. insert the decoded batch into the shared cache.
+
+Targeted loading never advances an unrelated stream frontier. Sequential and targeted loads use the
+same singleflight cache key, so they cannot decode duplicate copies concurrently.
+
+### 14.3 Residency is not readiness
+
+The old `Introduced/Streaming/Complete` state is replaced with separate concepts:
+
+```rust
+pub struct DirectoryKnowledge {
+    pub contributors: Arc<[DirContributor]>,
+    pub authenticated_route: Option<RouteLocator>,
+    pub stream_frontiers: FrontierSet,
+}
+
+pub enum BatchState {
+    Absent,
+    Loading(SharedWait),
+    Resident(Arc<DecodedBatch>),
+    Failed(RetryableError),
+}
+```
+
+An immutable directory is logically complete as soon as its authenticated index and contributor set
+are known. Its contents need not be resident. `Complete` must never be used as a synonym for “all
+batches are in RAM.”
+
+## 15. Lookup, readdir, and getattr algorithms
+
+### 15.1 Lookup
+
+```text
+1. consult the private MemLayer (including Whiteout)
+2. resolve the virtual directory's contributors
+3. consult MergeRouteIndex if contributor count > 1
+4. load the target namespace batch from every exact route candidate
+5. zero matches after all candidates were checked => ENOENT
+6. one file match => intern NodeRef and return it
+7. one or more matching directories => verify equality, intern DirKey, return merged directory
+8. any committed collision => EIO
+```
+
+An authenticated empty candidate set is an immediate negative answer. Otherwise negative lookup is
+cached only after all candidates for that hash bucket were checked. The negative cache key includes
+`SnapshotRef`, so entries remain valid for that immutable snapshot and cannot leak across head changes.
+
+### 15.2 Readdir
+
+Each contributor supplies a sorted batch cursor. Readdir performs a k-way merge by raw name:
+
+- equal directory names collapse into one result after equality validation;
+- equal file names or file/directory pairs are corruption;
+- private MemLayer additions/replacements/Whiteouts are merged last according to overlay semantics;
+- only current and next contributor batches are pinned;
+- batches behind all cursors are immediately eligible for eviction;
+- reaching an unloaded boundary fetches the next indexed batch.
+
+A FUSE directory handle stores a stable bookmark `(last_raw_name, tie_state)` rather than an arena
+offset. Handle-local cookies map to bookmarks. After eviction or retry, the cursor resumes by indexed
+lower-bound search. The namespace is immutable, so a bookmark cannot be invalidated during the mount.
+
+### 15.3 Getattr and read
+
+The mount inode table copies the small `InodeHot` record for identities already returned to FUSE.
+Therefore getattr for an active inode does not pin its namespace batch. The inode table also retains a
+`RecordLocator` for revalidation and cold attributes.
+
+Read resolves `SliceId` through the pinned Data Seal index root, loads only extent batches needed for
+the requested file/range, creates a bounded read plan, and releases the extent batch pin after the plan
+has copied its spans.
+
+## 16. Shared runtime structures
+
+```rust
+pub struct ClusteredSnapshot {
+    pub identity: SnapshotIdentity,
+    pub manifest: Arc<SnapshotManifest>,
+    pub clusters: ClusterRegistry,
+    pub batch_cache: Arc<MetadataBatchCache>,
+    pub index_cache: Arc<MerkleIndexCache>,
+    pub data_seals: DataSealRegistry,
+}
+
+pub struct ClusterHandle {
+    pub descriptor: ClusterDescriptor,
+    pub superblock: Arc<ClusterSuperblock>,
+    pub index_roots: ClusterIndexRoots,
+}
+
+pub struct RecordLocator {
+    pub cluster_slot: u32,
+    pub batch_kind: BatchKind,
+    pub batch_id: u32,
+    pub record_ordinal: u32,
+}
+```
+
+All agents using the same SnapshotRef share `Arc<ClusteredSnapshot>`, cluster handles, index nodes,
+decoded batches, Data Seal nodes, and S3 singleflight requests. Only `MemLayer`, active kernel
+lookup/open-handle state, and private dirty data are agent-specific.
+
+No long-lived structure points directly into a decoded batch without holding its `Arc` pin. Stable
+references are IDs and locators.
+
+## 17. Memory tiers and cold-data replacement
+
+Metadata uses four tiers:
+
+```text
+L0 pinned RAM: manifest roots, mount root, open cluster superblocks, active kernel inode hot records
+L1 RAM cache: decoded Merkle nodes and decoded metadata batches
+L2 local disk cache: authenticated compressed batch bytes
+L3 S3: immutable source objects
+```
+
+L1 has separate accounting for namespace, extent, attribute, route, and index data. Default soft
+shares are 55%, 25%, 10%, 5%, and 5%; unused capacity is borrowable. Operators configure a single hard
+byte budget plus optional per-class floors.
+
+Eviction uses size-aware segmented LRU:
+
+- a first demand hit enters probationary;
+- a second hit promotes to protected;
+- sequential scan/prefetch batches enter probationary and do not promote merely because the scanner
+  touched them;
+- index roots and current directory cursor batches are pinned;
+- an entry is evictable only when no operation/handle owns an `Arc` pin and no load waiter exists;
+- eviction drops decoded data but retains its compact locator and optional L2 bytes;
+- dropping a batch never changes route knowledge, inode identity, or negative-answer validity;
+- failed entries have bounded exponential retry state and are not retained as permanent negatives.
+
+L2 is an optional byte-bounded clock/LRU cache keyed by `(object hash, offset, stored length, digest)`.
+Files are written to a temporary name, fsynced when configured, verified, then atomically renamed. A
+torn cache file is a miss, not corruption of the snapshot.
+
+Admission control prevents one large readdir or background scrub from evicting the active working set.
+Background reads stop when either the RAM cache or S3 concurrency budget is saturated.
+
+## 18. Agent overlay boundary
+
+Every agent sees:
+
+```text
+private MemLayer -> immutable ClusteredSnapshot
+```
+
+The MemLayer may add and delete names, replace a merged base entry, override inode fields and cold
+attributes, and add Data/Hole extents. It does not mutate a cluster cache or manifest.
+
+Committing an agent view freezes its MemLayer, resolves the effective namespace, replans affected file
+clusters, uploads new sealed clusters, creates a new snapshot manifest, and finally CAS-switches the
+workspace head. Unchanged sealed cluster descriptors are reused byte-for-byte.
+
+The entire clustered implementation remains behind a dedicated Cargo feature and module boundary; the
+existing BrewFS metadata path is unchanged when the feature is disabled.
+
+## 19. Metadata/data split and the Data Seal
+
+Metadata-first upload is possible because `.brfc` extents refer to logical `SliceId`, not an S3 key or
+physical pack offset. After data upload, `.brfds` binds every SliceId to verified bytes.
+
+Magic: `BRFDS002`
+
+```rust
+pub struct SliceDescriptor {
+    pub slice_id: u64,
+    pub logical_len: u64,
+    pub spans: Vec<DataSpan>,
+}
+
+pub struct DataSpan {
+    pub frame_ordinal: u32,
+    pub raw_offset_in_frame: u32,
+    pub raw_len: u32,
+}
+
+pub struct FrameDescriptor {
+    pub object_ordinal: u32,
+    pub object_offset: u64,
+    pub stored_len: u32,
+    pub raw_len: u32,
+    pub codec: u8,
+    pub frame_checksum: [u8; 16],
+}
+```
+
+The Data Seal contains a pageable Merkle index from SliceId to compact span lists, a pageable frame
+table, and an object table:
+
+```rust
+pub struct DataObjectDescriptor {
+    pub object_key: bytes,
+    pub object_len: u64,
+    pub object_checksum: [u8; 32],
+    pub etag: bytes,                 // diagnostic, not trusted as content hash
+}
+```
+
+The seal validates:
+
+- every SliceId referenced by `.brfc` exists exactly once;
+- no unreferenced SliceId is present unless explicitly marked shared;
+- logical lengths agree with extents;
+- spans are ordered, in frame bounds, and sum to logical length;
+- object and frame checksums are present;
+- all data objects passed remote verification before seal creation.
+
+A checksum is stored once per DataPack object and once per independently readable frame, not once per
+file. Slice spans inherit frame authentication. An optional per-slice content hash may be enabled for a
+deduplication workflow, but it is absent in the compact default because 32 bytes per small file would
+add 32 GB for one billion files.
+
+The final snapshot semantic hash includes Data Seal semantic hashes. Metadata-only identity is not
+treated as file-content identity.
+
+## 20. Single-cluster local ingestion interface
+
+All sources implement:
+
+```rust
+#[async_trait]
+pub trait ClusterSource {
+    async fn inventory(&mut self, sink: &mut dyn InventorySink) -> Result<SourceFingerprint>;
+    async fn open_range(&self, token: &ReopenToken, offset: u64, len: u64)
+        -> Result<Box<dyn AsyncRead + Unpin + Send>>;
+    async fn revalidate(&self, token: &ReopenToken, expected: &EntryFingerprint)
+        -> Result<()>;
+}
+```
+
+The inventory stream produces raw path bytes, inode kind, mode/uid/gid/timestamps, size, hardlink key,
+symlink target, sparse ranges, xattrs/ACLs according to policy, and a durable reopen token.
+
+Built-in adapters:
+
+```text
+LocalFsSource       local directory tree
+TarSource           uncompressed seekable tar
+ZipSource           seekable ZIP using its central directory
+TarZstdSource       seekable-zstd when an index is present; otherwise spool mode
+TarGzipSource       sequential compressed archive; spool mode by default
+```
+
+The first implementation must support local directory, tar, tar.gz, tar.zst, and ZIP. Encrypted
+archives, multi-volume archives, device-node payloads, and archive formats without a safe bounded
+decoder are rejected in v2.
+
+The local command surface is:
+
+```text
+brewfs cluster ingest --source <dir-or-archive> --mount <path> --session-dir <dir>
+brewfs cluster resume --session-dir <dir>
+brewfs cluster status --session-dir <dir>
+brewfs cluster verify --session-dir <dir>
+brewfs cluster publish --session-dir <dir> --workspace <id>
+```
+
+`ingest` stops at a complete sealed but unpublished cluster unless `--publish` is explicitly supplied.
+
+## 21. Local filesystem inventory rules
+
+Local filesystem ingestion uses descriptor-relative traversal (`openat` style on Unix) and does not
+follow symlinks by default. It records a fingerprint sufficient to detect mutation between inventory
+and data read:
+
+```text
+device, inode, type, size, mtime_ns, ctime_ns, generation when available
+```
+
+Rules:
+
+- read raw filename bytes and reject only NUL, slash within a component, `.` and `..`;
+- group hardlinks by `(device, inode, generation)`;
+- record sparse ranges using `SEEK_DATA/SEEK_HOLE` where supported;
+- re-stat before and after reading each regular file;
+- abort sealing if the fingerprint changes;
+- preserve symlink text without following it;
+- reject sockets; device/FIFO handling is disabled unless explicitly allowed;
+- cap xattr, ACL, path depth, and single-value sizes before allocation;
+- prefer a filesystem snapshot as source for a large production ingest.
+
+Metadata-first requires an inventory pass before any data PUT. Reading file bytes for optional
+prehashing is allowed during the inventory phase, but no data object may be uploaded until remote
+metadata verification succeeds.
+
+## 22. Archive inventory and safe extraction
+
+Archive ingestion reads metadata directly from headers; it does not materialize the original directory
+tree. Paths are normalized as raw relative components and validated before insertion:
+
+- reject absolute paths, drive prefixes, NUL, and any `..` escape;
+- define an explicit duplicate-path policy; the default is reject, not last entry wins;
+- resolve archive hardlinks only within the same archive and cluster;
+- do not follow archive symlinks while scanning;
+- enforce maximum entries, logical bytes, path depth, name length, expansion ratio, and decoder memory;
+- verify archive checksums/CRC where provided;
+- reject encrypted entries unless a future authenticated adapter implements them;
+- preserve ZIP UTF-8 names; non-UTF-8 ZIP names require an explicit decoding policy recorded in build
+  options.
+
+Metadata-first plus crash-resumable data upload requires every file payload to have a durable
+`ReopenToken` after inventory:
+
+- uncompressed tar uses archive byte offset and length;
+- ZIP uses central-directory entry plus local-header validation;
+- seekable zstd uses frame/checkpoint plus uncompressed offset;
+- non-seekable tar.gz/tar.zst uses a local durable spool by default;
+- `--no-spool` may deterministically replay from archive start, but resume cost is O(compressed prefix)
+  and is not the production default.
+
+Spool mode writes normalized data frames into the session directory while scanning. Frames are
+checksummed and fsynced before their reopen token is committed to the upload journal. This is still
+metadata-first with respect to S3: local spooling is preparation, not remote data publication.
+
+## 23. Local session layout
+
+```text
+<session-dir>/
+  session.header                 fixed identity and source fingerprint
+  cluster.brfc                   complete local metadata object
+  upload.plan                    deterministic SliceId/DataPack plan
+  upload.snapshot               compact journal checkpoint
+  upload.wal                    append-only framed journal
+  spool/                        optional archive/data frames
+  parts/                        optional reconstructed multipart parts
+```
+
+The session directory is never the source directory. Creation requires an empty dedicated directory.
+Every durable file is written through temp-file + flush + optional fsync + atomic rename. The parent
+directory is fsynced on platforms that support it.
+
+`upload.wal` records are:
+
+```text
+magic | record_len | sequence | record_kind | payload | CRC32C
+```
+
+Replay stops at the first torn or invalid tail record. A compact snapshot is written atomically, then a
+new WAL generation begins. The uploader never edits a previous record in place.
+
+## 24. Metadata-first upload state machine
+
+```text
+NEW
+  -> INVENTORY_COMPLETE
+  -> METADATA_LOCAL_VERIFIED
+  -> METADATA_REMOTE_VERIFIED
+  -> DATA_UPLOADING
+  -> DATA_REMOTE_VERIFIED
+  -> SEAL_LOCAL_VERIFIED
+  -> SEAL_REMOTE_VERIFIED
+  -> CLUSTER_SEALED
+  -> SNAPSHOT_PUBLISHED (optional)
+```
+
+Transitions are monotonic and journaled. `DATA_UPLOADING` is illegal before
+`METADATA_REMOTE_VERIFIED`.
+
+Detailed pipeline:
+
+1. allocate UploadSessionId, ClusterId, SliceIds, source options, and a session directory;
+2. inventory/revalidate namespace metadata and create the deterministic ClusterPlan;
+3. build `cluster.brfc` locally, fully scrub it, and fsync it;
+4. PUT `.brfc` with create-only semantics, using the resumable multipart engine when it exceeds the
+   single-PUT threshold;
+5. HEAD/range-read the remote footer, superblock, index roots, and sampled/all batches according to
+   verification policy;
+6. only then begin DataPack or large-object multipart uploads;
+7. verify every completed data object against its strong checksum;
+8. build and scrub `.brfds` from the completed object table;
+9. PUT and remotely verify `.brfds` create-only, also using resumable multipart when needed;
+10. construct `SealedClusterRef` and mark the local session `CLUSTER_SEALED`;
+11. when requested, build a conflict-validated new snapshot manifest and CAS-publish WorkspaceHead.
+
+If any phase fails, no manifest references the incomplete cluster. Uploaded immutable metadata and
+data remain staging/orphan candidates until resumed or garbage-collected.
+
+## 25. Data packing and upload
+
+Small files and file ranges are packed into immutable DataPack objects. Large files may use dedicated
+objects but use the same frame and seal model.
+
+Magic: `BRFDP002`
+
+Defaults:
+
+| Item | Default |
+|---|---:|
+| DataPack target size | 4 GiB |
+| raw frame target | 8 MiB |
+| multipart part target | 64 MiB |
+| small-file threshold | 8 MiB |
+| compression | per-frame adaptive Zstd/None |
+
+Each frame is independently checksummed and optionally compressed. A file may span frames; one frame
+may contain many small files. The Data Seal, rather than an in-object global index, supplies the exact
+SliceId-to-frame ranges needed for reads.
+
+Packing is deterministic from `upload.plan`:
+
+- SliceIds and logical lengths are assigned before metadata upload;
+- pack/object ordinals and input order are fixed before data upload;
+- stored frame offsets and checksums are learned while encoding and placed in the later Data Seal;
+- a multipart part is reproducible from source reopen tokens and the deterministic codec options;
+- frames do not cross multipart part boundaries unless a single frame exceeds the target;
+- a sparse hole emits no data bytes and remains a metadata gap.
+
+Two object-key modes are supported:
+
+```text
+SessionKey    one-pass upload under UploadSessionId; Data Seal provides content checksums
+ContentHash   prehash/spool first, deduplicate with HEAD, upload under content hash
+```
+
+`SessionKey` is the default for PB-scale local ingestion because it avoids reading all data twice.
+Objects remain immutable and are permanently authenticated by the seal. S3 ETag is never used as the
+sole content checksum, especially for multipart uploads.
+
+## 26. Power-loss and multipart resume protocol
+
+For every remotely uploaded object, including `.brfc`, every DataPack/large object, and `.brfds`, the
+journal stores the same multipart state. Metadata and seal objects use their local immutable file as
+the deterministic part source:
+
+```rust
+pub struct MultipartState {
+    pub object_ordinal: u32,
+    pub object_key: bytes,
+    pub upload_id: bytes,
+    pub deterministic_plan_digest: [u8; 32],
+    pub completed_parts: Vec<CompletedPart>,
+}
+
+pub struct CompletedPart {
+    pub part_number: u32,
+    pub raw_source_digest: [u8; 32],
+    pub stored_len: u64,
+    pub strong_checksum: [u8; 32],
+    pub etag: bytes,
+}
+```
+
+Resume procedure:
+
+1. replay the last valid local snapshot and WAL;
+2. verify session identity, build options, `.brfc` hash, and source/archive fingerprint;
+3. HEAD the metadata object; upload/verify it again if the previous phase was not durable;
+4. call `ListParts` for every open multipart upload;
+5. merge remote parts with locally journaled parts by part number, length, ETag, and strong checksum;
+6. accept a remote-only part only after its deterministic source/encoded checksum is reconstructed or
+   verified through S3 checksum metadata;
+7. re-upload missing or ambiguous parts; multipart PUT is idempotent by part number;
+8. after all parts exist, journal completion intent, call CompleteMultipartUpload, then HEAD and verify
+   the final object;
+9. if power failed after remote completion but before local acknowledgement, HEAD reconstructs the
+   completed state;
+10. continue seal construction/publication from the first incomplete monotonic state.
+
+If power fails before `INVENTORY_COMPLETE`, resume discards any uncommitted derived metadata records,
+revalidates the source root/archive, and resumes from the last durable inventory/spool checkpoint or
+restarts inventory. No data PUT can exist at this point. If the local source fingerprint has changed,
+the old session cannot be sealed and a new session is required.
+
+The local WAL is sufficient for ordinary power loss where the session disk survives. To survive loss
+of the uploader host, the uploader periodically writes immutable remote checkpoint objects:
+
+```text
+brewfs-upload/v2/sessions/{upload_session_id}/checkpoints/{sequence}.checkpoint
+```
+
+The checkpoint contains no credentials and is authenticated by the session secret/digest. A new host
+loads the greatest valid sequence, then reconciles S3 multipart state. Checkpoints are advisory; the
+final truth is immutable objects plus S3 multipart/HEAD state.
+
+An expired session is not automatically aborted by a normal resume path. A separate GC policy may
+abort multipart uploads and delete unreferenced SessionKey objects only after a configured retention
+window and a manifest reachability check.
+
+## 27. Source consistency and failure behavior
+
+- Source mutation before sealing aborts the affected cluster; it is never silently accepted.
+- A remote metadata mismatch permanently fails that object key and requires a new ClusterId/session.
+- A corrupt batch is never published to readers or inserted into L1/L2 as valid.
+- A missing cold batch blocks only operations that require it.
+- Cancellation releases pins but does not discard a valid shared load needed by other waiters.
+- Partial directory decoding never creates an authoritative negative outside the validated key range.
+- A Data Seal whose object HEAD/checksum validation fails cannot enter a snapshot manifest.
+- After publication, loss of a referenced S3 object is an I/O integrity failure, not an empty file.
+- The loader never falls back to a mutable KV metadata backend for a clustered snapshot.
+
+## 28. Resource limits
+
+Defaults are configurable; hard limits are decoder safety boundaries.
+
+| Item | Default | Hard limit |
+|---|---:|---:|
+| nodes per cluster | planner target | `u32::MAX - 1` |
+| cluster slots per snapshot | planner target | `2^29 - 1` |
+| contributors per merged directory | 16 target | 65,535 |
+| route bucket bits | 8 | 12 |
+| metadata batch raw bytes | kind default | 16 MiB |
+| Merkle index node | 4096 B | 64 KiB |
+| raw name bytes | platform limit | 64 KiB format limit |
+| path depth | 1,024 | 65,535 |
+| xattr value | policy | 16 MiB |
+| archive expansion ratio | 100:1 | configured mandatory limit |
+| concurrent S3 GET | 64 | configured |
+| concurrent multipart PUT | 16 | configured |
+
+The builder estimates route and skeleton overhead before accepting a plan. Decoders perform checked
+integer arithmetic and bound all allocations before decompression.
+
+## 29. Required implementation modules
+
+```text
+src/workspace_overlay/clustered_snapshot/
+  mod.rs
+  identity.rs
+  snapshot_manifest.rs
+  mount_trie.rs
+  merge_route.rs
+  cluster_format.rs
+  batch.rs
+  merkle_index.rs
+  namespace.rs
+  extent.rs
+  attribute.rs
+  data_seal.rs
+  data_pack.rs
+  stream_loader.rs
+  targeted_loader.rs
+  batch_cache.rs
+  disk_cache.rs
+  fuse_inode.rs
+  union_directory.rs
+  reader.rs
+  scrub.rs
+  error.rs
+
+src/workspace_overlay/cluster_ingest/
+  mod.rs
+  source.rs
+  local_fs.rs
+  archive_tar.rs
+  archive_zip.rs
+  archive_compressed.rs
+  inventory.rs
+  planner.rs
+  metadata_builder.rs
+  pack_builder.rs
+  upload_plan.rs
+  upload_wal.rs
+  multipart.rs
+  resume.rs
+  publisher.rs
+```
+
+Both modules are behind dedicated Cargo features. Format parsing uses checked safe byte access. Source
+adapters are isolated from namespace publication and cannot bypass validation.
+
+## 30. Required tests
+
+### Format and determinism
+
+- golden manifest, cluster superblock, batch header, index node, Data Seal, and DataPack bytes;
+- deterministic metadata and plan across repeated identical builds;
+- independent targeted batch decode with no predecessor resident;
+- parent-first physical namespace order;
+- exact DirKey derivation from raw names;
+- per-cluster LocalNodeId density and backward-only hardlinks.
+
+### Cluster union
+
+- two roots mounted at the same path;
+- directory-directory merge at several depths;
+- file-file and file-directory collision rejection;
+- mismatched directory attributes rejection;
+- route buckets contain every true contributor;
+- arbitrary grouping produces the same visible namespace;
+- hash-range planning avoids O(cluster_count) lookup in large merged directories;
+- cross-cluster hardlinks rejected or co-located by planner.
+
+### Streaming and cold replacement
+
+- root visible before deeper directories;
+- global merged prefix never advances past the slowest contributor;
+- targeted lookup beyond stream frontier is correct;
+- one-billion-entry synthetic directory uses bounded resident memory;
+- readdir pins only cursor windows and survives eviction/refetch;
+- active FUSE inode survives eviction of its source namespace batch;
+- ten billion emitted deterministic inode numbers require no global inode interner;
+- scan traffic does not evict protected hot lookup batches;
+- no false ENOENT during load, eviction, retry, or head replacement.
+
+### Ingestion and archives
+
+- local directory with raw names, hardlinks, symlinks, sparse files, xattrs, and ACLs;
+- tar, tar.gz, tar.zst, and ZIP inventory without extracting a tree;
+- archive path traversal, duplicates, bombs, corrupt CRC, and unsupported encryption rejected;
+- non-seekable compressed archive resumes from durable spool;
+- source mutation between inventory and upload prevents sealing.
+
+### Upload and crash injection
+
+Inject process/power failure before and after every WAL fsync, metadata PUT, UploadPart, ListParts,
+CompleteMultipartUpload, data HEAD, seal PUT, manifest PUT, and head CAS. For every injection point:
+
+- resume reaches exactly one correct sealed result or a clear unrecoverable source-change error;
+- no incomplete cluster becomes visible;
+- an acknowledged part is reused or safely re-uploaded;
+- torn WAL tails are ignored;
+- remote-only parts reconcile correctly;
+- repeated resume is idempotent;
+- orphan GC never deletes an object reachable from any manifest.
+
+### Equivalence and isolation
+
+For generated effective trees:
+
+```text
+resolve(single logical tree)
+  == resolve(arbitrarily clustered snapshot)
+  == resolve(streamed/evicted/reloaded clustered snapshot)
+```
+
+Run with many agents sharing one snapshot and independent MemLayers. Verify no committed mutation,
+cross-agent visibility, KV access, or unbounded cache growth occurs.
+
+## 31. Implementation order
+
+1. Scalar codec, batch header, 4096-byte Merkle index node, and arbitrary-byte fuzzing.
+2. DirKey/LocalNodeId assignment and one-cluster parent-first namespace builder.
+3. Targeted namespace index lookup plus independently decodable batches.
+4. Snapshot manifest, same-directory multi-cluster union, and strict collision validation.
+5. Route records and hash-range cluster planner.
+6. Deterministic FUSE inode packing, readdir merge cursor, and bounded L1 batch cache with eviction.
+7. Extent/attribute batches, Data Seal reader, and data-range planning.
+8. Local filesystem inventory and deterministic `.brfc` builder.
+9. DataPack encoder, metadata-first S3 uploader, append-only WAL, and multipart resume.
+10. tar/ZIP adapters, compressed-archive spool mode, and security limits.
+11. Shared caches across agents, private MemLayer integration, and feature gating.
+12. Snapshot publication, crash injection, full scrub, POSIX, scale, and performance gates.
+
+Milestone 1 is one independently uploaded sealed cluster mounted read-only with bounded batch caching.
+Milestone 2 is collision-safe union of several clusters at one directory. Milestone 3 is resumable local
+and archive ingestion followed by private agent overlays.
+
+## 32. Normative decisions summary
+
+- A file cluster is an immutable namespace fragment, not a mutable database shard.
+- Multiple clusters union by `DirKey`; they do not form an override stack.
+- Directory-directory duplicates merge; all other committed name collisions are errors.
+- The manifest routes only merged directories and does not duplicate every file entry.
+- Metadata is physically parent-first but every batch is independently decodable.
+- RAM residency is replaceable; IDs and locators remain stable across eviction.
+- `.brfc` metadata is uploaded and remotely verified before any data PUT begins.
+- `.brfc` refers to SliceIds; the post-data `.brfds` seal binds them to verified S3 bytes.
+- A cluster is invisible until its seal is complete and a manifest references it.
+- Local WAL plus S3 multipart reconciliation makes upload restartable after power loss.
+- Existing BrewFS behavior remains unchanged when the clustered feature is disabled.

--- a/doc/superpowers/specs/2026-08-24-brewfs-compact-layer-pack-format-v1.md
+++ b/doc/superpowers/specs/2026-08-24-brewfs-compact-layer-pack-format-v1.md
@@ -1,0 +1,779 @@
+# BrewFS Compact Layer Pack Format v1
+
+Status: Superseded for immutable committed bases by `2026-08-24-brewfs-frozen-metadata-image-v1.md`;
+retained as the delta-pack alternative
+
+File suffix: `.brlp`
+
+Magic: `BRLPM001`
+
+## 1. Storage model
+
+A BRLP file stores one sealed layer as a minimal semantic delta relative to one immutable parent.
+It is not a dump of mutable metadata rows and it is not a mutation log.
+
+The seal pipeline first reduces the writable state:
+
+```text
+mutation history
+    -> final effective private state
+    -> difference against effective parent
+    -> normalized grouped tables
+    -> compact BRLP blocks
+```
+
+The pack contains five core tables:
+
+```text
+1  InodePatch
+2  Dentry
+3  Xattr
+4  ACL
+5  Extent
+```
+
+The layer ID, parent reference and hashes occur once in the file header. They are never repeated per
+record. Mutable sequence numbers and transaction IDs do not appear in a sealed pack.
+
+## 2. Redundancy eliminated at seal
+
+The pack builder MUST perform these reductions before encoding:
+
+### 2.1 Key collapse
+
+For Dentry, Xattr and ACL, retain only the final operation for each logical key. Earlier Put/Whiteout
+operations disappear.
+
+### 2.2 Inode patching
+
+The writable layer may keep a full effective inode for simple mutation handling. The pack stores only
+fields whose final values differ from the parent inode. A one-bit field mask replaces a full copied-up
+`FileAttr`.
+
+### 2.3 Extent normalization
+
+For every `(ino, chunk_index)`, apply all private writes in sequence order, then emit sorted,
+non-overlapping final Data/Hole intervals. Adjacent compatible intervals are merged. Sequence numbers
+are unnecessary after this normalization.
+
+### 2.4 Parent no-op elimination
+
+After normalization:
+
+- Put equal to the parent value is omitted;
+- Whiteout for a key absent from the parent is omitted;
+- an inode patch with an empty field mask is omitted;
+- a Data interval with the same visible physical slice mapping as the parent is omitted; seal does not
+  read or compare file payload bytes;
+- a Hole over an already absent/hole parent range is omitted;
+- create followed by delete before seal leaves no inode/dentry record;
+- data slices no longer referenced by the normalized result are not included and become GC candidates.
+
+No-op elimination compares logical values, not their physical encoding.
+
+## 3. Scalar encoding
+
+All variable-width scalar encodings are canonical:
+
+```text
+uvarint(x)  unsigned LEB128, shortest representation
+svarint(x)  ZigZag signed i64 followed by uvarint
+bytes(x)    uvarint(byte_length) || raw bytes
+bool        0x00 or 0x01
+enum        stable u8 discriminant
+```
+
+Fixed-width integers in headers, directories, checksums and ordered keys use big-endian byte order.
+
+Decoder requirements:
+
+- reject overlong/non-shortest varints;
+- reject a `u64` varint longer than ten bytes;
+- reject overflow before allocation or conversion;
+- reject lengths beyond both object bounds and configured limits;
+- reject unknown required enum values and non-zero reserved bits;
+- never use unchecked archived-struct access.
+
+## 4. File layout
+
+```text
++------------------------------------+ 0
+| PackHeader, 256 bytes              |
++------------------------------------+
+| InodePatch data blocks             |
+| optional filter block              |
+| index block                        |
++------------------------------------+
+| Dentry data blocks                 |
+| optional filter block              |
+| index block                        |
++------------------------------------+
+| Xattr data blocks                  |
+| optional filter block              |
+| index block                        |
++------------------------------------+
+| ACL data blocks                    |
+| optional filter block              |
+| index block                        |
++------------------------------------+
+| Extent data blocks                 |
+| optional filter block              |
+| index block                        |
++------------------------------------+
+| TableDirectory, 584 bytes          |
++------------------------------------+
+| PackFooter, 72 bytes               |
++------------------------------------+ object length
+```
+
+Every region begins at an 8-byte-aligned offset. Alignment padding is zero and is excluded from table
+digests but included in `pack_hash`.
+
+Tables occur in stable tag order. Every table is present even when empty. An empty table has zero data
+blocks and a zero first-data offset, but still has a valid empty index block. Its group, record and
+raw-byte counts are zero.
+
+## 5. PackHeader
+
+`PackHeader` is exactly 256 bytes:
+
+| Offset | Size | Field |
+|---:|---:|---|
+| 0 | 8 | magic: ASCII `BRLPM001` |
+| 8 | 2 | format major: `1` |
+| 10 | 2 | format minor: `0` |
+| 12 | 4 | header length: `256` |
+| 16 | 8 | flags |
+| 24 | 16 | volume ID |
+| 40 | 16 | layer ID |
+| 56 | 16 | parent layer ID, zero for root |
+| 72 | 4 | logical layer schema version: `1` |
+| 76 | 4 | layer depth |
+| 80 | 8 | BrewFS chunk size |
+| 88 | 32 | parent pack hash, zero for root |
+| 120 | 32 | parent root hash, zero for root |
+| 152 | 32 | this layer delta digest |
+| 184 | 32 | this layer root hash |
+| 216 | 8 | table-directory offset |
+| 224 | 8 | table-directory length: `584` |
+| 232 | 8 | total uncompressed logical table bytes |
+| 240 | 8 | creation time, signed Unix nanoseconds |
+| 248 | 2 | table count: `5` |
+| 250 | 1 | default block codec |
+| 251 | 1 | name restart interval, default `16` |
+| 252 | 4 | CRC32C over bytes `[0, 252)` |
+
+Header flags:
+
+```text
+bit 0 HAS_PARENT
+bit 1 HAS_ZSTD_BLOCKS
+bit 2 HAS_FILTERS
+bit 3 EXTENTS_NORMALIZED
+bit 4 INODES_ARE_PATCHES
+bits 5..63 reserved
+```
+
+Flags 3 and 4 are required in v1. For a root layer, `HAS_PARENT` is zero and all parent fields are
+zero. For a non-root layer, the parent layer ID, pack hash and root hash must all be non-zero.
+
+## 6. TableDirectory
+
+The directory is exactly 584 bytes:
+
+```text
+magic             [8] = BRLTDIR1
+directory_version u16 = 1
+entry_size        u16 = 112
+entry_count       u16 = 5
+reserved          u16 = 0
+entries           [TableEntry; 5]
+directory_crc32c  u32
+reserved          u32
+```
+
+CRC32C covers the first 576 bytes. `TableEntry` is exactly 112 bytes:
+
+| Offset | Size | Field |
+|---:|---:|---|
+| 0 | 2 | table kind |
+| 2 | 2 | table format version: `1` |
+| 4 | 4 | table flags |
+| 8 | 8 | first data-block offset |
+| 16 | 8 | total data-block bytes including alignment |
+| 24 | 4 | data-block count |
+| 28 | 4 | logical group count |
+| 32 | 8 | logical record count |
+| 40 | 8 | index-block offset |
+| 48 | 8 | index-block length |
+| 56 | 8 | filter-block offset, zero when absent |
+| 64 | 8 | filter-block length, zero when absent |
+| 72 | 8 | uncompressed logical bytes |
+| 80 | 32 | BLAKE3 table digest |
+
+Table flags:
+
+```text
+bit 0 HAS_FILTER
+bit 1 GROUPED
+bit 2 PREFIX_COMPRESSED
+bits 3..31 reserved
+```
+
+The table digest covers every non-padding byte belonging to its data, filter and index blocks in
+physical order.
+
+## 7. Physical blocks
+
+Every data, index and filter block has a self-contained 32-byte header followed by `stored_len` bytes:
+
+| Offset | Size | Field |
+|---:|---:|---|
+| 0 | 4 | magic: ASCII `BRLB` |
+| 4 | 1 | table kind |
+| 5 | 1 | codec: None=0, Zstd=1 |
+| 6 | 2 | block flags |
+| 8 | 4 | block ordinal |
+| 12 | 4 | group count |
+| 16 | 4 | logical record count |
+| 20 | 4 | raw payload length |
+| 24 | 4 | stored payload length |
+| 28 | 4 | CRC32C of stored payload |
+
+Block flags:
+
+```text
+bit 0 DATA
+bit 1 INDEX
+bit 2 FILTER
+bit 3 GROUP_CONTINUATION
+bits 4..15 reserved
+```
+
+Exactly one of DATA, INDEX or FILTER is set. `codec=None` requires `raw_len == stored_len`. Zstd output
+must decode to exactly `raw_len`, consume the complete input and remain within the 16 MiB raw-block
+hard limit.
+
+Block headers allow an object-store range response or RPC message to carry the block unchanged. No
+enclosing JSON/protobuf object is needed on the metadata hot path.
+
+## 8. Index blocks
+
+Each table has one uncompressed index block. Its payload is a prefix-compressed sequence:
+
+```text
+entry_count uvarint
+
+repeated entry_count times:
+  shared_first_key_bytes uvarint
+  first_key_suffix_len   uvarint
+  first_key_suffix       bytes without length prefix
+  shared_last_key_bytes  uvarint  // relative to full first key
+  last_key_suffix_len    uvarint
+  last_key_suffix        bytes without length prefix
+  block_offset_delta     uvarint  // relative to previous data block
+  block_total_len        uvarint  // header + stored bytes, excluding padding
+  block_ordinal_delta    uvarint
+
+restart offsets [u32_be]
+restart_count   u32_be
+```
+
+Every 16th index entry is a restart: both shared lengths reset to zero and `block_offset_delta` is
+encoded as an absolute object offset. Non-restart offsets are relative to the preceding data block.
+First and last keys are inclusive. Block key ranges are ordered and do not overlap.
+
+Canonical index keys:
+
+| Table | Key |
+|---|---|
+| InodePatch | `ino:u64_be` |
+| Dentry | `parent_ino:u64_be || name` |
+| Xattr | `ino:u64_be || name` |
+| ACL | `ino:u64_be || acl_type:u8 || ordered_acl_id:u64_be` |
+| Extent | `ino:u64_be || chunk_index:u64_be || logical_offset:u64_be` |
+
+A point lookup loads one index block, binary-searches restart keys, then reads at most one candidate
+data block. Very large logical groups may continue into several blocks; their full-key ranges remain
+distinct in the index.
+
+## 9. Filter blocks
+
+Filters are optional because a fully memory-loaded pack does not need them. Cold packs SHOULD include
+filters for InodePatch and Dentry and MAY include them for Xattr, ACL and Extent.
+
+The filter payload is:
+
+```text
+algorithm       u8      // BlockedBloomV1=1
+probes          u8      // default 7
+bits_per_key    u8      // default 10
+reserved        u8
+logical_keys    uvarint
+filter_bytes    bytes
+```
+
+Hash input is the complete canonical key. Extent filters hash `(ino, chunk_index)` rather than each
+logical interval. Filter negatives are authoritative; positives still require index lookup.
+
+Filters duplicate a small amount of information for remote negative-lookup performance. They can be
+disabled to produce the minimum-size archival pack.
+
+## 10. Group framing
+
+Dentry, Xattr, ACL and Extent tables group records by their shared filesystem key. A data block begins:
+
+```text
+group_segment_count uvarint
+
+repeated group_segment_count times:
+  group_key_delta    table-specific compact key
+  group_flags        u8
+  group_payload_len  uvarint
+  group_payload      [group_payload_len]
+```
+
+Group flag bit 0 is CONTINUATION. A group is kept in one block when its raw encoding fits the block
+target. A group larger than the target is segmented only at entry boundaries; every segment repeats
+the compact group key and has its own entry restart table. One segment may grow to the 16 MiB limit.
+
+Within name-keyed groups, entries use:
+
+```text
+entry_count uvarint
+
+repeated entries:
+  shared_name_bytes uvarint
+  name_suffix_len   uvarint
+  name_suffix       [name_suffix_len]
+  compact value
+
+restart offsets [u32_be]
+restart_count   u32_be
+```
+
+Every header-configured `restart_interval` entry has `shared_name_bytes=0`. The previous name resets
+at each group segment.
+
+## 11. InodePatch table
+
+The table is sorted by inode. A data block payload is:
+
+```text
+inode_count uvarint
+
+repeated inode_count times:
+  ino_delta     uvarint  // previous inode is zero at block start
+  inode_op      u8
+  field_mask    uvarint
+  selected fields in stable bit order
+```
+
+Inode operations:
+
+```text
+Create=0
+Patch=1
+Delete=2
+```
+
+Field-mask bits:
+
+```text
+0  kind            u8
+1  size            uvarint
+2  mode            uvarint
+3  uid             uvarint
+4  gid             uvarint
+5  rdev            uvarint
+6  nlink           uvarint
+7  atime_ns        svarint delta from PackHeader.creation_time
+8  mtime_ns        svarint delta from PackHeader.creation_time
+9  ctime_ns        svarint delta from PackHeader.creation_time
+10 parent_hint     option<uvarint>: tag u8, then value when Some
+11 data_version    uvarint
+12 symlink_target  option<bytes>: tag u8, then bytes when Some
+13..63 reserved
+```
+
+Create requires the fields needed to construct a valid inode for its kind. Patch requires a non-zero
+mask and contains only fields different from the effective parent inode. Delete requires a zero mask.
+A hardlink removal emits Delete only when the effective inode reaches zero links and has no remaining
+visible dentry. Otherwise it emits the required `nlink`/parent patch and dentry Whiteout only.
+
+Resolving an inode walks newest to oldest, filling fields not already supplied by newer patches. It
+stops at Delete or once a Create/base inode supplies all required fields. A patch whose parent cannot
+supply missing required fields is corrupt.
+
+This representation turns a chmod-only layer into approximately:
+
+```text
+ino delta + Patch tag + one-byte mask + mode varint
+```
+
+rather than another complete inode row.
+
+## 12. Dentry table
+
+The group key is `parent_ino`, delta-encoded from the previous group in the block. Entries are sorted
+by raw filename bytes.
+
+Each compact value starts with one byte:
+
+```text
+0x00           Whiteout
+0x80 | kind    Put; followed by child_ino uvarint
+```
+
+Bits 4..6 in a Put tag are reserved; `kind` occupies the low four bits. Put requires a valid child
+inode and inode kind. The hint must match the resolved child inode kind. Whiteout has no payload.
+
+Parent inode, layer ID, filename length field names and sequence are not repeated per database-style
+row. Filename prefixes are shared within the directory group.
+
+## 13. Xattr table
+
+The group key is inode, delta-encoded from the previous group in the block. Names use the group entry
+prefix encoding.
+
+Value encoding:
+
+```text
+op u8              // Put=0, Whiteout=1
+if Put:
+  value bytes
+```
+
+Empty Put values are valid. Whiteout carries no value. No sequence or repeated inode is stored.
+
+## 14. ACL table
+
+The group key is inode. Entries are sorted by `(acl_type, acl_id)`. Each entry is:
+
+```text
+acl_type       u8
+acl_id_delta   svarint  // previous ID for the same acl_type, otherwise from zero
+op             u8       // Put=0, Whiteout=1
+if Put:
+  value        bytes
+```
+
+ACL values remain opaque to the pack codec but are size-bounded and validated by the BrewFS ACL
+adapter.
+
+## 15. Extent table
+
+Extents are grouped first by inode and then by chunk:
+
+```text
+inode_group_count uvarint
+
+repeated inode groups:
+  ino_delta          uvarint
+  chunk_group_count  uvarint
+
+  repeated chunk groups:
+    chunk_index_delta  uvarint
+    interval_count     uvarint
+
+    repeated intervals:
+      gap_from_previous_end uvarint
+      length                uvarint
+      kind                  u8  // Data=0, Hole=1
+      if Data:
+        slice_id            uvarint
+        slice_offset        uvarint
+```
+
+At the start of each chunk, `previous_end=0`. For every interval:
+
+```text
+logical_offset = previous_end + gap
+end            = logical_offset + length
+previous_end   = end
+```
+
+Required invariants:
+
+- intervals are non-overlapping and strictly ordered;
+- `length > 0` and all additions are checked;
+- interval end is at most the header chunk size;
+- Hole has no slice payload;
+- Data uses a non-zero slice ID and a valid slice range;
+- adjacent Hole intervals are merged;
+- adjacent Data intervals are merged when they reference the same slice with contiguous slice offsets.
+
+A gap means inherit from the parent. A Hole explicitly hides parent data. Because intervals already
+represent the final private result, no write sequence is stored.
+
+## 16. Optional GC reference sidecar
+
+BRLP v1 has no SliceRef table: GC can stream the Extent table and read every Data slice ID. This avoids
+storing the same slice IDs twice and keeps the core directory fixed at five entries.
+
+Deployments that require faster GC may create an optional derived `.brlg` sidecar keyed by the pack
+hash. Its payload begins with the source pack hash followed by sorted unique slice IDs encoded as:
+
+```text
+count          uvarint
+first_slice_id uvarint
+following ID deltas as uvarint
+```
+
+The sidecar is not referenced by filesystem reads and is excluded from both `pack_hash` and
+`delta_digest`. GC validates its source pack hash before use and falls back to streaming Extent when
+the sidecar is absent or corrupt. It is always safe to regenerate or delete.
+
+## 17. PackFooter
+
+The footer is exactly 72 bytes:
+
+| Offset | Size | Field |
+|---:|---:|---|
+| 0 | 8 | magic: ASCII `BRLPEND1` |
+| 8 | 8 | complete object length |
+| 16 | 8 | table-directory offset |
+| 24 | 8 | table-directory length |
+| 32 | 32 | BLAKE3 pack hash over all bytes before footer |
+| 64 | 4 | CRC32C over bytes `[0, 64)` |
+| 68 | 4 | reserved, zero |
+
+A cold reader opens a pack with three range reads at most: footer, directory and header. It validates
+their duplicate offsets, lengths, IDs and hashes before trusting indexes.
+
+## 18. Logical digest stream
+
+The logical digest identifies the minimal semantic layer, not its compression. It is encoded in this
+order:
+
+```text
+magic "BRLPDEL1"
+logical schema version u32_be
+parent root hash [32]
+
+for table in InodePatch, Dentry, Xattr, ACL, Extent:
+  table tag u8
+  logical record count uvarint
+  canonical decoded records in logical-key order
+```
+
+Canonical decoded values use CompactCodecV1 without block/group prefix compression. The digest stream
+does not contain indexes, filters, padding, codecs, timestamps from the physical header or an optional
+GC reference table.
+
+```text
+delta_digest = BLAKE3(logical digest stream)
+root_hash    = BLAKE3("BRLPROOT1" || parent_root_hash || delta_digest)
+```
+
+Two packs with different block sizes, zstd levels, filters or GC indexes therefore describe the same
+revision when their logical records and parent are equal.
+
+## 19. Builder algorithm
+
+```text
+Input: immutable MemLayer snapshot + parent ReadonlyLayer
+
+1. Collapse each logical key to its final operation.
+2. Resolve parent values required for comparison.
+3. Convert full in-memory inodes to Create/Patch/Delete records.
+4. Normalize each dirty (ino, chunk) interval map.
+5. Remove values and ranges equal to parent.
+6. Sort/group the five table streams.
+7. Feed decoded records to the logical digest encoder.
+8. Encode grouped data blocks, flushing near the target block size.
+9. Build each table index and optional filter.
+10. Write TableDirectory and finalize PackHeader.
+11. fsync staging bytes and perform a full local reopen/scrub.
+12. Hash pre-footer bytes, append PackFooter and fsync again.
+13. Return a closed, immutable LayerPackArtifact.
+```
+
+The builder streams output and does not assemble the pack in one `Vec<u8>`. Extent normalization may
+use an interval map per dirty chunk. Very large tables use sorted paged iterators or an external sort.
+
+The builder returns no artifact when parent lookup fails, no-op comparison is incomplete, a required
+inode field is unresolved or the reconstructed effective view differs from the frozen input view.
+
+## 20. Read algorithms
+
+### Inode
+
+Bloom test `ino`, index-search candidate block, find the inode delta, then merge InodePatch records
+newest to oldest until complete or deleted.
+
+### Lookup
+
+For each layer newest-first: Bloom test `(parent,name)`, find the directory group/block, binary-search
+its name restart table, return Put/Whiteout. Stop at the first result.
+
+### Readdir
+
+Open the directory group stream from every layer containing `parent_ino`, then perform a k-way merge
+by name. For equal names, the newest layer wins; Whiteout is not returned.
+
+### Xattr and ACL
+
+Use the inode group and merge keys newest-first. Put supplies the value; Whiteout terminates lookup for
+that key.
+
+### Extents
+
+Open `(ino, chunk)` groups newest-first. Fill uncovered logical ranges from each normalized group.
+Data produces slice-backed reads; Hole marks covered zero/absent ranges; gaps continue to lower layers.
+
+## 21. Memory loading
+
+For a frequently used base pack, decode into arena-backed structures:
+
+```rust
+pub struct HotFrozenLayer {
+    inode_patches: SortedArena<InodePatch>,
+    directory_groups: SortedGroupArena<u64, DentryValue>,
+    xattr_groups: SortedGroupArena<u64, XattrValue>,
+    acl_groups: SortedGroupArena<u64, AclValue>,
+    extent_groups: SortedExtentArena,
+    byte_arena: Arc<[u8]>,
+}
+```
+
+Names, symlink targets and xattr/ACL values are stored once in `byte_arena`; indexes contain offsets
+and lengths rather than separate heap allocations. The resulting `Arc<HotFrozenLayer>` is shared by
+all agents based on the same pack hash.
+
+Cold mode retains header, directory, filter and index blocks and caches decoded data blocks by
+`(pack_hash, table, ordinal)`.
+
+## 22. Binary transport
+
+A metadata server may return complete physical blocks unchanged:
+
+```text
+BatchHeader:
+  magic            BRLPBAT1
+  version          u16
+  pack_hash        [32]
+  table_kind       u8
+  first_ordinal    u32
+  block_count      u32
+  payload_len      u64
+  header_crc32c    u32
+
+Payload:
+  one or more 8-byte-aligned BRLB blocks
+```
+
+The client verifies each BRLB header and CRC, optionally decompresses, and inserts decoded blocks into
+the same cache used for S3 range reads. There is no per-record JSON, field-name repetition or
+encode/decode through a second RPC schema.
+
+## 23. Space characteristics
+
+The compact format removes the following common row/KV costs:
+
+| KV-style cost | BRLP representation |
+|---|---|
+| layer ID in every key/row | once in header |
+| parent inode in every dentry | once per directory group/segment |
+| inode in every xattr/ACL | once per inode group/segment |
+| `(ino, chunk)` in every extent | once per extent group |
+| full inode copy-up | changed-field bitmap patch |
+| mutation sequence in sealed rows | removed after normalization |
+| overwritten extent history | reduced to final non-overlapping intervals |
+| repeated filename prefixes | prefix-compressed with restart points |
+| textual field names and JSON numbers | stable tags and varints |
+| database page/index overhead | one compact table/index per layer |
+| deleted temporary files | eliminated when parent has no corresponding object |
+
+Filters, indexes and the four-bit dentry type hint are the intentional lookup redundancies. They are
+bounded; filters can be disabled, and the dentry hint avoids loading an inode merely to return a
+directory-entry type.
+
+## 24. Validation limits
+
+| Item | Default | Hard limit |
+|---|---:|---:|
+| raw data-block target | 64 KiB | 16 MiB |
+| decoded record | — | 16 MiB |
+| group segment | 64 KiB target | 16 MiB |
+| restart interval | 16 | 256 |
+| table count | 5 | 16 with recognized feature flags |
+| layer depth | soft 8 | 32 |
+| filename | current BrewFS/POSIX limit | current limit |
+| xattr value | current BrewFS limit | current limit |
+
+Every `offset + length`, delta reconstruction, interval end and allocation is checked. Reserved fields
+are zero on write. Unknown major versions or required flags are rejected.
+
+## 25. Required tests
+
+### Golden format tests
+
+- exact PackHeader, TableDirectory, BRLB and PackFooter bytes;
+- every scalar's minimum and maximum canonical encoding;
+- Create/Patch/Delete inode variants and every field bit;
+- grouped directory names with restart boundaries;
+- normalized Data/Hole extent bytes;
+- physical repacking preserves logical hash.
+
+### Reduction tests
+
+- create then delete emits nothing;
+- Put then Whiteout over absent parent emits nothing;
+- chmod then restore parent mode emits no inode patch;
+- chmod-only emits only the mode bit/value;
+- repeated overwrite emits only final visible extents;
+- adjacent compatible extents merge;
+- parent-equal data intervals disappear;
+- truncate/hole/extend never exposes hidden parent data;
+- hardlink count and dentry changes reconstruct exactly.
+
+### Query equivalence
+
+For generated parent and MemLayer states:
+
+```text
+resolve(parent + mutable MemLayer)
+    ==
+resolve(parent + decoded BRLP)
+```
+
+Run this property for lookup, readdir, inode attributes, xattrs, ACLs and reads across all chunk
+boundaries.
+
+### Corruption and fuzzing
+
+- arbitrary bytes for every decoder;
+- non-canonical varints;
+- invalid restart tables and key prefixes;
+- block/index key-range disagreement;
+- oversized zstd output and trailing compressed input;
+- truncated header, table, index, directory and footer;
+- bit flips in every checksum/hash scope;
+- parent cycle, wrong parent hash and excessive chain depth.
+
+No case may panic, allocate past limits or silently fall back to another metadata source.
+
+## 26. Implementation types
+
+```text
+src/workspace_overlay/memory_s3/pack/
+  format.rs          PackHeader, TableEntry, BlockHeader, PackFooter
+  varint.rs          canonical uvarint/svarint
+  block.rs           group/restart encoding and checked decoding
+  inode.rs           InodePatch schema and resolver
+  dentry.rs          directory-group codec
+  xattr.rs           xattr-group codec
+  acl.rs             ACL-group codec
+  extent.rs          normalized extent codec
+  index.rs           block index
+  filter.rs          optional Bloom filter
+  reduce.rs          parent-aware no-op elimination
+  builder.rs         streaming pack writer
+  reader.rs          range reader
+  scrub.rs           full verification
+```
+
+The physical-format module depends only on stable layer model types, BLAKE3, CRC32C, bytes and the
+selected compression codec. It must not depend on a concrete KV backend, SQL entity, FUSE request or
+process-local Rust archive layout.

--- a/doc/superpowers/specs/2026-08-24-brewfs-frozen-metadata-image-v1.md
+++ b/doc/superpowers/specs/2026-08-24-brewfs-frozen-metadata-image-v1.md
@@ -1,0 +1,929 @@
+# BrewFS Streaming Frozen Metadata Image v1
+
+Status: Superseded by [BrewFS Clustered Frozen Metadata v2](2026-08-24-brewfs-clustered-frozen-metadata-v2.md)
+
+This document is retained as the single-image prototype. New implementation work must use v2, which
+adds independently uploadable file clusters, union-mounted directory contributions, batch-addressable
+loading, and evictable runtime metadata.
+
+Format: BrewFS Frozen Image (`BRFI`)
+
+File suffix: `.brfi`
+
+Magic: `BRFIM001`
+
+## 1. Immutable-image contract
+
+A committed BRFI object is a complete, materialized filesystem namespace. It has no parent layer and
+no mutable records.
+
+```text
+effective FrozenImage + private MemLayer
+                    |
+                    | commit/build (offline and potentially expensive)
+                    v
+          complete immutable BRFI image
+```
+
+After publication:
+
+- no inode, dentry, extent, xattr or ACL is updated in place;
+- no Whiteout, Patch, transaction sequence or mutable version is stored;
+- an agent modification exists only in its private MemLayer;
+- a later commit builds another complete image;
+- all agents using one commit share one `Arc<FrozenImage>`.
+
+This format deliberately trades commit speed and cross-image metadata deduplication for read speed,
+simple recovery and streaming startup.
+
+## 2. Parent-first streaming invariant
+
+Namespace metadata is stored in breadth-first parent order. These rules are mandatory:
+
+1. root inode is the first logical record;
+2. directory groups are ordered by ascending parent NodeId;
+3. NodeIds are allocated breadth-first while processing those directory groups;
+4. a new child's complete hot inode attributes occur inline immediately after its parent dentry;
+5. a child directory group occurs only after the dentry that introduced that directory;
+6. a hardlink may refer only to a NodeId already introduced earlier in the stream;
+7. all segments of one directory are contiguous before the next directory begins;
+8. a loader may publish each validated name-prefix segment, but marks the directory Complete only
+   after its final segment.
+
+Therefore a sequential reader sees:
+
+```text
+root inode
+root entries + immediate child inode attributes
+depth-1 directory entries + their new child attributes
+depth-2 directory entries + their new child attributes
+...
+```
+
+The namespace becomes usable incrementally. Extents, xattrs, ACLs and symlink payloads are placed after
+the namespace pages and fetched in the background or on demand.
+
+## 3. Node IDs and FUSE inode numbers
+
+`NodeId` is a non-zero `u32`, densely assigned from `1..=node_count`. Root is always 1.
+
+```rust
+#[repr(transparent)]
+pub struct NodeId(u32);
+```
+
+Runtime array index is `NodeId - 1`. The FUSE inode namespace is:
+
+```text
+bit 63 = 0  frozen image inode; low 32 bits contain NodeId
+bit 63 = 1  private MemLayer inode; remaining bits contain agent-local ID
+```
+
+Bits 32..62 are zero for v1 frozen nodes. NodeId/FUSE inode zero is invalid.
+
+NodeIds remain stable for one mounted image but may change in a later commit. Hardlinks remain correct
+because all names for one file reuse the same NodeId. Stable inode identity across image replacement
+is outside v1.
+
+## 4. Deterministic breadth-first assignment
+
+The builder assigns NodeIds deterministically:
+
+1. assign root NodeId 1 and push it into a FIFO directory queue;
+2. pop directories in NodeId order;
+3. enumerate each directory by raw filename byte order;
+4. the first encounter of a node assigns the next NodeId;
+5. enqueue a newly assigned directory;
+6. later hardlink encounters reuse the existing NodeId.
+
+Directory hardlinks/cycles are invalid under existing BrewFS namespace rules. For multiply-linked
+non-directory inodes, the builder precomputes the earliest breadth-first `(parent NodeId, name)` key,
+so every later occurrence can be encoded as a backward reference.
+
+Equivalent namespaces and build options produce the same NodeId assignment and physical bytes.
+
+## 5. Readiness during streaming
+
+The loader tracks:
+
+```rust
+pub struct StreamingReadiness {
+    pub sequential_node_high_watermark: u32,
+    pub loaded_node_ranges: Arc<NodeRangeSet>,
+    pub directory_states: Arc<DirectoryReadinessTable>,
+    pub namespace_complete: bool,
+    pub extent_node_high_watermark: u32,
+    pub attribute_node_high_watermark: u32,
+}
+```
+
+An inline child inode is appended before its dentry is made visible. Directory state is:
+
+```text
+Introduced
+Streaming { loaded_through_name }
+Complete
+```
+
+Each complete segment advances `loaded_through_name`. END changes the state to Complete and finalizes
+the runtime lookup index.
+
+Operations behave as follows while loading:
+
+- getattr for an introduced node succeeds immediately;
+- lookup on a Streaming directory is authoritative when the target name is at or before
+  `loaded_through_name`; a later name triggers its indexed page fetch;
+- readdir may return the validated loaded prefix; reaching its frontier fetches/awaits the next page;
+- Complete directories answer all lookup/readdir requests without more namespace IO;
+- a file read whose extent group is absent triggers indexed Range GET and awaits that page;
+- xattr/ACL/readlink similarly trigger an attribute-page fetch;
+- incomplete state is never reported as NotFound or an empty directory.
+
+FUSE request cancellation may stop the wait, but it does not roll back already validated pages.
+
+## 6. Physical file order
+
+```text
++---------------------------------------+ offset 0
+| Superblock + section directory        | 4096 bytes
++---------------------------------------+
+| NamespacePageIndex                    | uncompressed
++---------------------------------------+
+| NamespacePage 0 (root first)          |
+| NamespacePage 1                       | breadth-first parent order
+| ...                                   |
++---------------------------------------+
+| ExtentPageIndex                       | uncompressed
++---------------------------------------+
+| ExtentPages                           | ascending NodeId
++---------------------------------------+
+| AttributePageIndex                    | uncompressed
++---------------------------------------+
+| AttributePages                        | ascending NodeId
++---------------------------------------+
+| Footer                                | 72 bytes
++---------------------------------------+ object length
+```
+
+Indexes precede the pages they address. A loader may first GET the superblock and three indexes, then
+sequentially stream namespace pages while performing targeted extent/attribute range reads.
+
+All pages are self-contained. Page regions begin at 8-byte-aligned offsets. Padding is zero.
+
+## 7. Scalar encoding
+
+Page payloads use:
+
+```text
+uvarint(x)  unsigned LEB128, shortest representation
+svarint(x)  ZigZag i64 followed by uvarint
+bytes(x)    uvarint(length) || raw bytes
+bool        0x00 or 0x01
+enum        stable u8 discriminant
+```
+
+Fixed numeric fields in headers and indexes use little-endian encoding. Hashes and UUIDs are raw bytes.
+
+Decoders reject overlong varints, overflow, unknown required discriminants, non-zero reserved bits and
+any size exceeding page/object/configured bounds.
+
+## 8. Superblock
+
+The first 4096 bytes contain a 256-byte header, 32 section slots of 96 bytes, reserved zeros and one
+final CRC32C.
+
+### 8.1 Header
+
+| Offset | Size | Field |
+|---:|---:|---|
+| 0 | 8 | magic: ASCII `BRFIM001` |
+| 8 | 2 | format major: `1` |
+| 10 | 2 | format minor: `0` |
+| 12 | 4 | superblock length: `4096` |
+| 16 | 8 | required feature flags |
+| 24 | 16 | volume ID |
+| 40 | 16 | deterministic image ID |
+| 56 | 32 | source revision hash |
+| 88 | 32 | semantic filesystem root hash |
+| 120 | 4 | logical image schema version: `1` |
+| 124 | 4 | reserved |
+| 128 | 8 | BrewFS chunk size |
+| 136 | 4 | root NodeId: `1` |
+| 140 | 4 | node count |
+| 144 | 8 | dentry count |
+| 152 | 8 | extent count |
+| 160 | 8 | logical attribute-value bytes |
+| 168 | 16 | deterministic runtime hash seed |
+| 184 | 2 | used section slots: `6` |
+| 186 | 2 | section slot size: `96` |
+| 188 | 2 | page header size: `64` |
+| 190 | 1 | NodeId width: `4` |
+| 191 | 1 | default page codec |
+| 192 | 32 | build-options digest |
+| 224 | 8 | total raw metadata bytes |
+| 232 | 4 | namespace page count |
+| 236 | 4 | extent page count |
+| 240 | 4 | attribute page count |
+| 244 | 4 | reserved |
+| 248 | 4 | header CRC32C over bytes `[0,248)` |
+| 252 | 4 | reserved |
+
+Feature flags:
+
+```text
+bit 0 DENSE_BFS_NODE_IDS
+bit 1 PARENT_FIRST_NAMESPACE
+bit 2 FULLY_MATERIALIZED_EXTENTS
+bit 3 PAGE_ZSTD
+bit 4 HAS_XATTR
+bit 5 HAS_ACL
+bits 6..63 reserved
+```
+
+Bits 0..2 are required.
+
+Image ID is the first 16 bytes of
+`BLAKE3("BRFIID1" || volume_id || semantic_root_hash || build_options_digest)`. Runtime hash seed is
+derived from `BLAKE3("BRFIHASH1" || semantic_root_hash)`. Commit timestamps are stored in the workspace
+head record, not BRFI, so identical logical input and build options reproduce identical bytes.
+
+The workspace head stores the complete reference needed for authenticated streaming:
+
+```rust
+pub struct FrozenImageRef {
+    pub image_hash: [u8; 32],
+    pub semantic_root_hash: [u8; 32],
+    pub superblock_digest: [u8; 32],
+    pub object_len: u64,
+}
+```
+
+The loader verifies the superblock digest before trusting section slots. Section slots authenticate
+page-index bytes, and page indexes authenticate individual page payloads.
+
+### 8.2 Section slot
+
+Slots begin at offset 256. Each is 96 bytes:
+
+| Offset | Size | Field |
+|---:|---:|---|
+| 0 | 2 | section kind |
+| 2 | 2 | section version |
+| 4 | 4 | flags |
+| 8 | 8 | object offset |
+| 16 | 8 | stored length |
+| 24 | 8 | total raw page bytes |
+| 32 | 8 | page/index-entry count |
+| 40 | 4 | fixed entry size, zero for page stream |
+| 44 | 4 | required alignment |
+| 48 | 32 | BLAKE3 section digest |
+| 80 | 8 | first logical key |
+| 88 | 8 | last logical key |
+
+Section kinds:
+
+```text
+1 NamespacePageIndex
+2 NamespacePages
+3 ExtentPageIndex
+4 ExtentPages
+5 AttributePageIndex
+6 AttributePages
+```
+
+Slots are ordered by kind. Sections are ordered, non-overlapping and before the footer. CRC32C over
+superblock bytes `[0,4092)` is stored at offset 4092.
+
+## 9. PageHeader
+
+Every page has a 64-byte header:
+
+| Offset | Size | Field |
+|---:|---:|---|
+| 0 | 8 | magic: ASCII `BRFIPG01` |
+| 8 | 2 | page kind |
+| 10 | 2 | page version: `1` |
+| 12 | 4 | page flags |
+| 16 | 4 | page ordinal |
+| 20 | 4 | required predecessor page ordinal, `0xffffffff` for none |
+| 24 | 8 | first logical key |
+| 32 | 8 | last logical key |
+| 40 | 4 | logical group count |
+| 44 | 4 | raw payload length |
+| 48 | 4 | stored payload length |
+| 52 | 1 | codec: None=0, Zstd=1 |
+| 53 | 3 | reserved |
+| 56 | 4 | CRC32C of stored payload |
+| 60 | 4 | header CRC32C over bytes `[0,60)` |
+
+Page kinds:
+
+```text
+Namespace=1
+Extent=2
+Attribute=3
+```
+
+Page flags:
+
+```text
+bit 0 FIRST_IN_SECTION
+bit 1 LAST_IN_SECTION
+bit 2 STARTS_WITH_CONTINUATION
+bit 3 ENDS_WITH_CONTINUATION
+bits 4..31 reserved
+```
+
+Namespace page `required_predecessor` is the preceding namespace ordinal when advancing the sequential
+frontier. A detached targeted read may validate/decode a later page through its authenticated index
+entry and NodeId range, but it does not advance the sequential frontier. Extent and Attribute pages
+use `0xffffffff` because their groups can always be independently range-fetched.
+
+Stored payload CRC is checked before decompression. Decoding must consume the full zstd frame and
+produce exactly `raw_len`, bounded by the v1 16 MiB hard limit.
+
+## 10. Page indexes
+
+Each page-index section is uncompressed and begins:
+
+```text
+magic       [8] = BRFIIDX1
+kind        u16
+version     u16 = 1
+entry_size  u16 = 64
+reserved    u16
+entry_count     u32
+key_arena_len   u32
+entries     [PageIndexEntry]
+key_arena   [key_arena_len]
+crc32c      u32
+reserved    u32
+```
+
+`PageIndexEntry` is 64 bytes:
+
+| Offset | Size | Field |
+|---:|---:|---|
+| 0 | 8 | first logical key |
+| 8 | 8 | last logical key |
+| 16 | 8 | object offset |
+| 24 | 4 | total page length including header, excluding padding |
+| 28 | 4 | raw payload length |
+| 32 | 4 | group count |
+| 36 | 4 | page flags |
+| 40 | 4 | first newly introduced NodeId; Namespace only |
+| 44 | 4 | newly introduced node count; Namespace only |
+| 48 | 16 | first 16 bytes of authenticated page BLAKE3 |
+
+For Namespace index entries, each 64-bit logical-key field packs:
+
+```text
+high 32 bits  parent NodeId
+low 32 bits   offset into the index key arena
+```
+
+The key-arena offset points to `name_len:u16_le || raw_name`. Empty name is the boundary key for an
+empty directory or root bootstrap page. Namespace index ordering compares parent NodeId, then raw name
+bytes. This permits binary search directly to the page containing `(parent,name)`, including one page
+in a billion-entry directory.
+
+Extent and Attribute indexes set `key_arena_len=0`; their logical key is owning NodeId in the low 32
+bits with the high bits zero, and their new-node fields are zero. Namespace new-node ranges are ordered
+and non-overlapping. They let a targeted loader locate the page that introduced a hardlink target
+without decoding every preceding namespace page. Entries are sorted; ranges may touch only when a
+logical group continues across adjacent pages.
+
+Index CRC32C covers its complete header, entry array and key arena, excluding the trailing
+CRC/reserved words.
+Authenticated page BLAKE3 covers PageHeader bytes `[0,60)` followed by the stored payload. When a page
+is fetched, header fields must match its index entry and the complete authenticated bytes must match
+both CRC32C scopes and BLAKE3-128 before decompression or publication.
+
+## 11. Namespace stream
+
+Every namespace page begins with an authenticated NodeId range. The first page then contains one root
+record before its directory segments:
+
+```text
+first_new_node_id uvarint
+new_node_count    uvarint
+root_record_len uvarint
+root_inode      [root_record_len]
+segment_count   uvarint
+directory_segments...
+```
+
+Later pages replace the root fields with `segment_count` immediately after the NodeId range. Page 0
+uses first NodeId 1 and counts root. A page introducing no node encodes both range fields as zero. The
+range must exactly match its authenticated PageIndexEntry.
+
+### 11.1 Directory segment
+
+```text
+parent_node_delta   uvarint
+segment_flags       u8
+if START:
+  total_directory_entries uvarint
+entry_count         uvarint
+
+repeated entries in raw-name order:
+  shared_name_bytes uvarint
+  name_suffix_len   uvarint
+  name_suffix       [name_suffix_len]
+  dentry_tag        u8
+  if NEW_NODE:
+    inode_record_len uvarint
+    inode_record     [inode_record_len]
+  else:
+    existing_node_id uvarint
+```
+
+At page start, previous parent NodeId and previous name are zero/empty. Parent deltas are non-negative
+because groups are in ascending parent order. Previous name resets at every segment.
+
+Segment flags:
+
+```text
+bit 0 START
+bit 1 END
+bits 2..7 reserved
+```
+
+A normal directory has START|END. A large directory has one START segment, zero or more middle
+segments and one END segment in consecutive pages. Entry name order continues across segments.
+`total_directory_entries` lets the loader preallocate the final arena/hash table and is checked against
+the accumulated count at END.
+
+`dentry_tag`:
+
+```text
+bit 7 NEW_NODE
+bits 0..3 child inode kind
+bits 4..6 reserved
+```
+
+If NEW_NODE is set, child NodeId is implicit: the next value in the page's authenticated new-node
+range. The inline inode record is decoded before publishing the dentry. Otherwise, `existing_node_id`
+must have been introduced by an earlier logical namespace page and represents a hardlink.
+
+No parent NodeId, child NodeId, layer ID or filename is duplicated outside this compact stream.
+
+### 11.2 Compact inode record
+
+```text
+kind          u8
+flags         uvarint
+size          uvarint
+mode          uvarint
+uid           uvarint
+gid           uvarint
+nlink         uvarint
+atime_ns      svarint
+mtime_ns      svarint
+ctime_ns      svarint
+if HAS_RDEV:  rdev uvarint
+```
+
+Flags:
+
+```text
+bit 0 HAS_RDEV
+bit 1 HAS_EXTENTS
+bit 2 HAS_XATTR
+bit 3 HAS_ACL
+bit 4 HAS_SYMLINK
+bit 5 IS_SPARSE
+bits 6..63 reserved
+```
+
+The first parent is implicit from the introducing directory. `parent_hint` is that parent only when
+`nlink=1`; otherwise it is None. Root uses itself as the mount-time parent hint.
+
+Runtime decoding appends one fixed 64-byte `InodeHot` record. Persisted bytes remain compact and
+stream-oriented; runtime arrays remain direct-index and CPU-efficient.
+
+## 12. Directory readiness and runtime indexes
+
+The persisted namespace contains no duplicate hash-slot table. While streaming one directory group,
+the loader appends its names/dentries into arenas and builds the immutable runtime lookup strategy:
+
+```text
+0 Empty
+1 Linear       1..8 entries
+2 Binary       9..64 entries
+3 FrozenHash   more than 64 entries
+```
+
+FrozenHash is built incrementally with maximum load factor 0.80. It stores relative dentry ordinal + 1
+in `u16` or `u32` slots. There is no insertion/deletion/tombstone API after END.
+
+After each validated segment, the loader publishes its sorted dentry prefix and advances the directory
+frontier. Before END, lookup uses the persisted page-name ranges plus binary search in loaded segments;
+it never returns NotFound for a name beyond the frontier. After validating END, entry ordering, child
+kinds and the completed FrozenHash, the loader marks the directory Complete. Persisting no hash slots
+reduces S3 bytes and lets build thresholds change without changing semantic image identity.
+
+## 13. Extent pages
+
+Extent groups are ordered by NodeId and may be fetched independently:
+
+```text
+file_group_count uvarint
+
+repeated file groups:
+  node_id_delta  uvarint
+  extent_count   uvarint
+  previous_end   = 0
+
+  repeated extents:
+    gap_from_previous_end uvarint
+    length                uvarint
+    slice_id              uvarint
+    slice_offset          uvarint
+```
+
+The image stores a complete final file map. There is no chunk index, layer ID, sequence, kind or Hole
+record. Gaps represent sparse holes/zeros. File size is in the inline inode record.
+
+Invariants:
+
+- NodeId refers to an introduced regular file with HAS_EXTENTS;
+- groups and extents are strictly ordered;
+- length and slice ID are non-zero;
+- logical/slice arithmetic does not overflow;
+- logical end is at most file size;
+- no extent crosses a BrewFS file-chunk boundary; the builder splits it at chunk boundaries so
+  `chunk_index = logical_offset / chunk_size` is reconstructable;
+- adjacent extents referencing one contiguous slice range are merged;
+- a file group may continue only in immediately adjacent pages and index ranges reflect continuation.
+
+When decoded, a file's extents append to one contiguous runtime extent arena and its direct
+`InodeRanges` entry is filled. A file read can fetch only the page range covering its NodeId.
+
+## 14. Attribute pages
+
+Attribute groups are ordered by NodeId:
+
+```text
+node_group_count uvarint
+
+repeated node groups:
+  node_id_delta uvarint
+  group_flags   u8
+
+  if HAS_SYMLINK:
+    symlink_target bytes
+
+  if HAS_XATTR:
+    xattr_count uvarint
+    names in sorted prefix-compressed order:
+      shared_name_bytes uvarint
+      name_suffix_len   uvarint
+      name_suffix       [name_suffix_len]
+      value             bytes
+
+  if HAS_ACL:
+    acl_count uvarint
+    sorted ACL entries:
+      acl_type          u8
+      acl_id_delta      svarint
+      value             bytes
+```
+
+Group flags must equal the corresponding inline inode flags. There are no Whiteouts. Empty xattr/ACL
+values are valid. ACL ID delta resets to zero whenever ACL type changes.
+
+Attribute pages are cold and normally zstd-compressed. A value never crosses a page unless it alone
+exceeds the target; such a value receives one dedicated page within existing BrewFS size limits.
+
+Decoded names and values append into shared byte arenas, and direct per-NodeId ranges are filled.
+
+## 15. Semantic root hash
+
+Physical pages, compression and page boundaries are not semantic. The logical stream is:
+
+```text
+magic BRFILOG1
+logical schema version u32_le
+
+root inode
+namespace directory groups in BFS parent order
+extent groups in NodeId order
+attribute groups in NodeId order
+```
+
+It uses the decoded compact scalar representation with no page headers/padding. Runtime hash seed,
+zstd level and page target are excluded.
+
+```text
+semantic_root_hash = BLAKE3(canonical logical stream)
+```
+
+Equivalent effective filesystems built with identical deterministic NodeId assignment produce the same
+semantic root hash even if physical page sizes/codecs differ.
+
+## 16. Footer and physical identity
+
+Footer is exactly 72 bytes:
+
+| Offset | Size | Field |
+|---:|---:|---|
+| 0 | 8 | magic: ASCII `BRFIEND1` |
+| 8 | 8 | complete object length |
+| 16 | 8 | superblock offset: `0` |
+| 24 | 8 | superblock length: `4096` |
+| 32 | 32 | image hash over all bytes before footer |
+| 64 | 4 | CRC32C over bytes `[0,64)` |
+| 68 | 4 | reserved |
+
+Object key:
+
+```text
+brewfs-meta/v1/volumes/{volume_id}/images/{image_hash[0]:02x}/{image_hash}.brfi
+```
+
+Upload uses create-only semantics. Semantic root identifies filesystem content; image hash identifies
+one physical paging/compression representation.
+
+## 17. Streaming loader
+
+```rust
+pub struct StreamingFrozenImageBuilder {
+    identity: ImageIdentity,
+    inode_hot: FillOnceNodeTable<InodeHot>,
+    inode_ranges: FillOnceNodeTable<InodeRanges>,
+    dentries: AppendOnlyArena<Dentry>,
+    names: ByteArena,
+    directory_indexes: DirectoryIndexArena,
+    extents: AppendOnlyArena<Extent>,
+    xattrs: AppendOnlyArena<Xattr>,
+    acls: AppendOnlyArena<Acl>,
+    values: ByteArena,
+    readiness: Arc<StreamingReadiness>,
+}
+```
+
+Loading sequence:
+
+1. GET footer and verify length/image hash against `FrozenImageRef`.
+2. GET the 4096-byte superblock and verify `superblock_digest`.
+3. GET/validate the three page indexes, normally as parallel ranges.
+4. Range-stream NamespacePages from first to last while within the configured preload budget.
+5. Publish each validated directory prefix and Complete transition.
+6. Use `(parent,name)` index ranges for targeted namespace pages beyond the preload frontier.
+7. If a targeted page references an unloaded hardlink NodeId, locate its introduction page through the
+   authenticated new-node ranges.
+8. Prefetch Extent/Attribute pages for recently introduced hot nodes.
+9. Serve other on-demand range fetches using page indexes.
+10. Retain cold pages in S3/local page cache when the full image exceeds the memory budget.
+11. Verify complete section/image digests during a background scrub or full-cache pass.
+
+Sequential arena snapshots use append-only chunks plus `ArcSwap`; targeted pages fill authenticated
+NodeId slots exactly once in sparse chunks. Publishing does not copy already decoded nodes, and a slot
+can never be replaced with different content. All readers see immutable validated regions.
+
+## 18. Persisted versus runtime representation
+
+The S3 format is compact and stream-ordered. Runtime is direct-index and read-optimized:
+
+```rust
+pub struct FrozenImage {
+    pub inode_hot: FillOnceChunkedNodeTable<InodeHot>,
+    pub inode_ranges: FillOnceChunkedNodeTable<InodeRanges>,
+    pub dentries: ChunkedArena<Dentry>,
+    pub directory_indexes: DirectoryIndexArena,
+    pub names: ChunkedByteArena,
+    pub extents: ChunkedArena<Extent>,
+    pub xattrs: ChunkedArena<Xattr>,
+    pub acls: ChunkedArena<Acl>,
+    pub values: ChunkedByteArena,
+    pub readiness: Arc<StreamingReadiness>,
+}
+```
+
+This separation permits compact transfer and progressive construction without paying varint/prefix
+decode cost on every lookup. All agents for one image hash share the same `Arc<FrozenImage>` and loader.
+
+## 19. Agent overlay boundary
+
+The mounted view is always:
+
+```text
+one private MemLayer -> one fully materialized FrozenImage
+```
+
+The MemLayer may override frozen inode fields, add/delete names, change xattrs/ACLs and add Data/Hole
+extents. The frozen image has no mutation method and no invalidation path.
+
+Commit freezes the MemLayer, resolves the complete two-level view, builds a new BRFI and atomically
+switches the workspace head only after remote verification. The old image remains valid forever while
+referenced.
+
+## 20. Build pipeline
+
+1. Freeze private mutations.
+2. Resolve the complete effective namespace.
+3. remove deleted/unreachable nodes and obsolete slice mappings;
+4. validate root reachability, directory acyclicity, hardlinks and nlink;
+5. compute deterministic breadth-first NodeIds;
+6. emit namespace directory groups in parent NodeId order;
+7. inline each newly introduced child's hot inode record after its first dentry;
+8. emit normalized complete extent groups by NodeId;
+9. emit cold attribute groups by NodeId;
+10. choose page boundaries without violating directory/group contiguity rules;
+11. write indexes before their page regions;
+12. compute semantic, page, section and image hashes;
+13. reopen and fully scrub the local artifact;
+14. upload create-only and remotely validate footer/superblock/indexes;
+15. CAS-publish the new workspace head.
+
+The build may be O(total metadata), use temporary disk and perform external sorting. This is accepted:
+committed files are immutable and the cost is paid once, while reads are shared across agents.
+
+## 21. Performance behavior
+
+After a directory has streamed:
+
+- getattr is direct NodeId array access;
+- readdir is one contiguous arena range;
+- small lookup is linear/binary over that range;
+- large lookup uses a completed immutable FrozenHash;
+- no varint is decoded again on the hot path;
+- no parent layer, KV service or mutable metadata cache is consulted.
+
+Startup behavior:
+
+- root inode is available from namespace page 0;
+- root directory becomes available after its END segment;
+- child inode attributes arrive inline with root entries;
+- deeper directories become ready breadth-first;
+- extent/attribute pages do not block namespace streaming;
+- early file reads trigger targeted range fetch instead of waiting for the full image.
+
+## 22. Redundancy policy
+
+The persisted stream omits:
+
+- repeated layer/parent IDs and KV prefixes;
+- database primary/secondary index pages;
+- full fixed inode rows in S3;
+- parent NodeId on every dentry;
+- explicit NodeId for newly introduced children;
+- inode ID on every extent/xattr/ACL value;
+- Whiteouts, tombstones, transaction sequences and mutable versions;
+- Hole extents and historical overwrites;
+- persisted directory hash slots.
+
+Intentional runtime-only redundancy includes fixed InodeHot arrays and FrozenHash slots. It is built
+once while streaming, kept only in shared host memory/cache and never increases S3 transfer bytes.
+
+## 23. Failure and retry
+
+- A page failing CRC/hash/decompression is never published.
+- A partially decoded segment is discarded or retained privately but never advances the published
+  directory frontier.
+- Retrying the same page is idempotent because arenas commit only at validated group boundaries.
+- A missing extent/attribute page blocks only operations requiring its NodeId range.
+- Namespace predecessor mismatch stops sequential publication and reports corruption.
+- Background full-hash failure marks the image unhealthy and rejects new requests; it never falls back
+  silently to KV metadata.
+- Loader cancellation preserves already published immutable prefixes for other active waiters.
+
+## 24. Limits
+
+| Item | Default | Hard limit |
+|---|---:|---:|
+| raw page target | 256 KiB | 16 MiB |
+| namespace page 0 target | 1 MiB | 16 MiB |
+| NodeIds | — | `u32::MAX - 1` |
+| page count per section | — | `u32::MAX - 1` |
+| one directory segment | page target | 16 MiB |
+| one decoded value | existing limit | 16 MiB format limit |
+| layer/image parents | none | none |
+
+Large root directories may span consecutive namespace pages. Validated root name prefixes are usable
+before END; arbitrary lookup jumps through the namespace name index, while Complete status is reached
+only at END.
+
+## 25. Validation
+
+Fast open validates footer and expected image reference, superblock BLAKE3/CRC, required flags,
+section bounds/alignment and all three authenticated page indexes.
+
+Each namespace page validates:
+
+- ordinal and predecessor;
+- parent NodeIds already introduced;
+- ascending parent group order and contiguous segments;
+- sorted names across page boundaries;
+- sequential new NodeIds are exactly next-high-watermark; targeted new NodeIds exactly match their
+  authenticated disjoint range and fill empty slots only;
+- hardlinks reference existing non-directory nodes;
+- kind hints match inline/existing inode kinds;
+- END counts match accumulated entries.
+
+Extent/attribute pages validate NodeId ownership, sort order, continuation, size/range arithmetic and
+inode flags.
+
+Full scrub additionally validates semantic root hash, every section digest, image hash, directory
+acyclicity, nlink counts, all expected extent/attribute groups and unreachable-node absence.
+
+## 26. Required tests
+
+### Format golden tests
+
+- exact 4096-byte superblock and 96-byte section slot;
+- exact 64-byte PageHeader, 64-byte PageIndexEntry and 72-byte footer;
+- compact root/child/hardlink inode records;
+- single and multi-page directory groups;
+- extent and attribute group encodings;
+- deterministic bytes across repeated builds.
+
+### Streaming-order tests
+
+- root record is first;
+- parent dentry precedes child directory group;
+- inline child inode commits before visible dentry;
+- BFS NodeIds are deterministic;
+- hardlink is always a backward reference;
+- a targeted later namespace page decodes from its authenticated NodeId range without earlier pages;
+- an unloaded hardlink target resolves through the introduction-page index;
+- validated directory prefixes are visible before END without false NotFound beyond the frontier;
+- a huge root supports partial readdir and indexed lookup into an unloaded later segment;
+- extent/attribute targeted fetch works before namespace completion;
+- incomplete directory waits and never returns false NotFound.
+
+### Equivalence property
+
+For generated base plus MemLayer:
+
+```text
+resolve(base + MemLayer)
+    ==
+resolve(progressively loaded build_brfi(base + MemLayer))
+```
+
+Run comparison after every published directory prefix and after complete load, covering namespace,
+inode attributes, hardlinks, xattrs, ACLs, symlinks and sampled file ranges.
+
+### Isolation/performance
+
+- 100 agents share one loader/FrozenImage;
+- agents maintain independent MemLayers;
+- root lookup/readdir latency measured at first-ready and fully-loaded states;
+- bytes-to-root-ready, bytes-to-depth-N-ready and total metadata bytes are reported;
+- cold extent fetch request/byte count is reported;
+- hot path contains no CompactCodec decode after readiness;
+- no KV calls occur.
+
+### Corruption/fuzzing
+
+- arbitrary superblocks, indexes, page headers and payloads;
+- invalid predecessor/continuation and parent-before-child violations;
+- non-canonical/overflow varints;
+- truncated zstd and decompression bombs;
+- invalid hardlinks, cycles, NodeId gaps and nlink mismatch;
+- no panic, unbounded allocation, false readiness or unchecked cast.
+
+## 27. Implementation modules
+
+```text
+src/workspace_overlay/frozen_image/
+  mod.rs
+  format.rs
+  superblock.rs
+  scalar.rs
+  page.rs
+  page_index.rs
+  namespace.rs
+  extent.rs
+  attribute.rs
+  bfs_builder.rs
+  stream_loader.rs
+  readiness.rs
+  runtime_arena.rs
+  directory_hash.rs
+  reader.rs
+  scrub.rs
+  cache.rs
+  error.rs
+```
+
+The module is feature-gated and independent of concrete KV/SQL metadata backends. Persisted parsing
+uses safe checked byte access. Runtime arenas expose immutable snapshots only.
+
+## 28. Implementation order
+
+1. Golden structs: superblock, section slots, page headers, indexes and footer.
+2. Canonical scalar decoder plus arbitrary-byte fuzzing.
+3. Deterministic BFS NodeId assignment and namespace-page builder.
+4. Streaming namespace loader with directory readiness barriers.
+5. Runtime direct inode/dentry arenas and Linear/Binary/FrozenHash lookup.
+6. Indexed Extent pages and on-demand read-plan loading.
+7. Indexed Attribute pages and cold value loading.
+8. Shared loader/cache across multiple agent workspaces.
+9. S3 sequential/range transport, retry and background scrub.
+10. Commit publication, crash injection, POSIX and performance gates.
+
+The first milestone is root-first streaming of a read-only image with getattr, lookup and readdir. It
+does not implement any mutation inside BRFI.

--- a/doc/superpowers/specs/2026-08-24-brewfs-memory-s3-readonly-layer-metadata-spec.md
+++ b/doc/superpowers/specs/2026-08-24-brewfs-memory-s3-readonly-layer-metadata-spec.md
@@ -1,0 +1,965 @@
+# BrewFS Memory + S3 Read-Only Layer Metadata Spec
+
+Status: Architecture archive; committed-base format superseded by
+[`2026-08-24-brewfs-clustered-frozen-metadata-v2.md`](2026-08-24-brewfs-clustered-frozen-metadata-v2.md)
+
+Target: optional BrewFS agent-workspace subsystem
+
+Format family: BrewFS Layer (`BRL`)
+
+For committed filesystems that are never modified, the normative implementation specification is the
+clustered v2 document above. It replaces the single-image `FrozenImage` with independently uploadable
+file clusters, union-mounted directory contributions, pageable indexes, and evictable metadata
+batches. The material below is retained only for the private MemLayer and historical architecture
+context; where it conflicts with clustered v2, v2 wins.
+
+## 1. Decision
+
+BrewFS agent workspaces use three different metadata representations:
+
+```text
+Shared committed base    -> immutable streaming FrozenImage in S3
+Host read cache          -> Arc<FrozenImage> shared by all local agents
+Per-agent writable head  -> private in-memory MemLayer + optional immutable WAL segments
+```
+
+Committed filesystem metadata is not stored in Redis, etcd, TiKV, SQLite or another row-oriented KV
+store. A FrozenImage contains the complete materialized namespace; committed reads do not follow a
+parent chain.
+
+S3 is the durable source of truth for committed images. Memory is the serving representation. One
+small workspace head pointer is conditionally updated to publish a new generation; FrozenImages, WAL
+segments, head records and snapshots are all write-once objects.
+
+The compact persisted representation is a parent-first page stream:
+
+- root and parent directory entries precede child directory groups;
+- new child inode attributes are inline with the introducing parent entry;
+- namespace pages are ordered breadth-first and can be published progressively;
+- extent and cold-attribute pages are separately indexed for on-demand Range GET;
+- sorted and prefix-compressed names;
+- canonical unsigned varints and ZigZag signed varints;
+- independently compressed and checksummed pages;
+- no JSON and no repeated field names;
+- runtime compilation into direct arrays and immutable directory hash indexes.
+
+The canonical persistence format is not a raw Rust struct dump. `rkyv` may be used for a disposable
+same-build process cache, but it is not the S3 format: persisted bytes must remain versioned,
+validated and readable across compiler and crate upgrades.
+
+## 2. Scope
+
+This spec defines:
+
+- the compact streaming format for a committed read-only image;
+- the private in-memory writable layer;
+- optional active-head WAL persistence;
+- S3 object naming and immutable publication;
+- workspace head CAS and fencing;
+- restart, cache, snapshot and GC behavior;
+- integration boundaries that keep normal BrewFS behavior unchanged.
+
+File data remains in BrewFS block objects. Layer metadata contains only extent references to
+`slice_id` and `slice_offset`.
+
+The following state is not stored in a FrozenImage:
+
+- active leases and open file handles;
+- POSIX locks and flock state;
+- dirty data-upload buffers;
+- quota reservations and transient counters;
+- mutable writer ownership;
+- uncommitted or delayed-delete data-object journals.
+
+## 3. Required invariants
+
+1. A published layer pack is immutable and content-addressed.
+2. A workspace has at most one publish-capable writer epoch.
+3. Agent-private mutations are visible only through that agent's `MemLayer` until published.
+4. All agents may share the same `Arc<FrozenLayer>` and data objects without copy-up.
+5. A write never mutates a sealed parent; it inserts a Put, Whiteout, Hole or Data delta into the
+   private head.
+6. A head pointer never references an object that has not already been uploaded and verified.
+7. Equal logical deltas have equal `delta_digest` regardless of compression or block boundaries.
+8. Corrupt S3 bytes never cause unchecked access, panic or unbounded allocation.
+9. No KV service is required to mount or read an already published workspace revision.
+10. When the feature is disabled, existing BrewFS mounts, metadata stores and wire formats are
+    unchanged.
+
+## 4. Runtime architecture
+
+```text
+                         S3-compatible object storage
+                  +---------------------------------------+
+                  | immutable layer packs (.brlp)         |
+                  | immutable WAL segments (.brlw)        |
+                  | immutable head records (.brlh)        |
+                  | immutable snapshots (.brls)           |
+                  | mutable CAS pointer per workspace     |
+                  +--------------------+------------------+
+                                       |
+                               range GET / PUT
+                                       |
+                  +--------------------v------------------+
+                  | LayerRuntime                           |
+                  |                                       |
+                  | LayerIndexCache -> Arc<FrozenLayer>    |
+                  | WorkspaceActor -> private MemLayer     |
+                  | WriterEpoch / group-commit WAL         |
+                  +--------------------+------------------+
+                                       |
+                              WorkspaceMetaLayer
+                                       |
+                                      VFS
+```
+
+`LayerRuntime` is a process-local service. A `WorkspaceActor` serializes mutations for one workspace
+and owns its `MemLayer`. Reads can execute concurrently against an immutable view consisting of:
+
+```rust
+pub struct WorkspaceView {
+    pub writable: Arc<MemLayerSnapshot>,
+    pub sealed: Arc<[Arc<FrozenLayer>]>, // newest first
+    pub head_generation: u64,
+    pub writer_epoch: u64,
+}
+```
+
+Publishing a new in-memory snapshot uses `ArcSwap` or an equivalent atomic pointer. Readers never
+hold the actor mutation lock while traversing sealed layers.
+
+## 5. S3 object namespace
+
+```text
+brewfs-meta/v1/volumes/{volume_id}/
+  layers/{first-byte-hex}/{pack_hash}.brlp
+  wal/{workspace_id}/{writer_epoch}/{first_seq}-{last_seq}-{wal_hash}.brlw
+  head-records/{workspace_id}/{generation}-{record_hash}.brlh
+  heads/{workspace_id}.brhp
+  snapshots/{snapshot_id}-{snapshot_hash}.brls
+  tombstones/{object_hash}.brlt
+```
+
+Objects under `layers`, `wal`, `head-records`, `snapshots` and `tombstones` are created with
+`If-None-Match: *`. Existing objects are accepted only when their length and content hash match.
+They are never overwritten.
+
+`heads/{workspace_id}.brhp` is the only mutable object. It is a small pointer updated with `If-Match`
+against the previously read ETag. A backend without conditional PUT support cannot enable durable
+multi-process workspace publication.
+
+No S3 LIST operation occurs on lookup, readdir, write, seal or mount hot paths. Object locations are
+derived from hashes or reached from explicit references.
+
+## 6. Persistent references
+
+```rust
+pub struct LayerRef {
+    pub layer_id: [u8; 16],
+    pub root_hash: [u8; 32],
+    pub pack_hash: [u8; 32],
+    pub pack_len: u64,
+}
+
+pub struct WalRef {
+    pub writer_epoch: u64,
+    pub first_sequence: u64,
+    pub last_sequence: u64,
+    pub previous_wal_hash: Option<[u8; 32]>,
+    pub wal_hash: [u8; 32],
+    pub object_len: u64,
+}
+```
+
+`pack_hash` and `wal_hash` determine object keys. A sealed layer manifest embeds its complete parent
+`LayerRef`; no external catalog lookup is needed to walk the chain.
+
+Logical hashes remain separate from physical hashes:
+
+```text
+delta_digest = BLAKE3(canonical logical layer stream)
+root_hash    = BLAKE3(schema_version_be || parent_root_hash || delta_digest)
+pack_hash    = BLAKE3(pack bytes before footer)
+wal_hash     = BLAKE3(WAL bytes before footer)
+```
+
+Compression or repacking may change `pack_hash`. It must not change `delta_digest` or `root_hash`.
+
+No global sealed-version allocator is required. External revision identity is:
+
+```rust
+pub struct LayerRevision {
+    pub layer: LayerRef,
+    pub workspace_generation: u64,
+}
+```
+
+The existing inode and slice ID allocation contract is outside this format. The builder accepts the
+IDs assigned by the workspace engine and validates their ranges; it does not depend on a KV counter.
+
+## 7. Compact scalar codec
+
+Sections 7-13 are an architectural overview of compact block ideas. They are not the BRLP byte-level
+contract. In particular, the normative format uses five specialized grouped tables, inode field-mask
+patches and normalized sequence-free sealed extents as specified in the linked physical-format
+document. Implementations MUST use that document when field layouts differ from this overview.
+
+Persisted record values use `CompactCodecV1`:
+
+```text
+uvarint  = unsigned LEB128, shortest possible encoding only
+svarint  = ZigZag(i64) followed by uvarint
+bytes    = uvarint(length) followed by raw bytes
+option   = represented by an operation tag or a presence bitmap
+enum     = stable u8 discriminant
+```
+
+Decoders reject:
+
+- overlong/non-canonical varints;
+- more than 10 bytes for a `u64` varint;
+- overflow during ZigZag conversion;
+- length values above the configured field/record limit;
+- unknown required enum values;
+- non-zero reserved bits.
+
+Keys use fixed-width big-endian integers where byte order must match logical order. They are compacted
+at the block level by prefix compression, which is more useful than varints for repeated parent inode
+and chunk prefixes.
+
+## 8. Prefix-compressed record blocks
+
+Each section is sorted by its canonical key and divided into target 64 KiB uncompressed blocks.
+Records never cross block boundaries. A record larger than the target occupies one block; the v1
+maximum decoded record size is 16 MiB.
+
+Within a block, each entry is:
+
+```text
+shared_key_bytes   uvarint
+key_suffix_len     uvarint
+value_len          uvarint
+key_suffix         [key_suffix_len]
+value              [value_len]
+```
+
+The full key is:
+
+```text
+previous_key[0..shared_key_bytes] || key_suffix
+```
+
+Every 16th entry is a restart entry with `shared_key_bytes=0`. The block ends with:
+
+```text
+restart_offset_0   u32 big-endian
+...
+restart_offset_n   u32 big-endian
+restart_count      u32 big-endian
+```
+
+Restart offsets point to entry starts and are strictly increasing. The first offset is zero. A reader
+binary-searches restart keys and scans at most one restart interval for a point lookup.
+
+Each raw block is optionally encoded as one independent zstd frame. The block index stores codec,
+stored length, raw length and CRC32C. The reader verifies stored CRC32C before decompression and
+requires exactly `raw_len` output with no trailing compressed bytes.
+
+## 9. Layer pack layout
+
+```text
++----------------------------------+ offset 0
+| fixed header                     |
++----------------------------------+
+| Dentry data blocks               |
+| Dentry Bloom filter + index      |
++----------------------------------+
+| Inode data blocks                |
+| Inode Bloom filter + index       |
++----------------------------------+
+| Xattr data blocks                |
+| Xattr Bloom filter + index       |
++----------------------------------+
+| ACL data blocks                  |
+| ACL Bloom filter + index         |
++----------------------------------+
+| Extent data blocks               |
+| Extent Bloom filter + index      |
++----------------------------------+
+| section directory               |
++----------------------------------+
+| fixed footer                     |
++----------------------------------+ end
+```
+
+Stable section tags:
+
+```text
+InodePatch=1, Dentry=2, Xattr=3, ACL=4, Extent=5
+```
+
+Every v1 section is present, including empty sections. Sections are stored in tag order. The header
+contains:
+
+- format major/minor and required feature bits;
+- volume ID and layer ID;
+- optional parent `LayerRef`;
+- workspace schema version and layer depth;
+- creation/seal time and chunk size;
+- `delta_digest`, parent `root_hash` and this `root_hash`;
+- section-directory offset and length;
+- header CRC32C.
+
+The parent pack hash in the parent `LayerRef` makes chain traversal self-contained. Root packs use an
+empty parent.
+
+The footer contains the complete object length, directory location, `pack_hash` and footer CRC32C.
+The hash excludes the footer to avoid self-reference.
+
+The section directory contains, for each section:
+
+```rust
+pub struct SectionHandle {
+    pub kind: SectionKind,
+    pub section_version: u16,
+    pub first_block_offset: u64,
+    pub stored_len: u64,
+    pub record_count: u64,
+    pub block_index_offset: u64,
+    pub block_index_len: u64,
+    pub filter_offset: u64,
+    pub filter_len: u64,
+    pub section_digest: [u8; 32],
+}
+```
+
+Directory bytes have their own CRC32C. A normal range-open validates footer, directory and header
+without downloading record blocks. A full scrub also verifies every section digest and `pack_hash`.
+
+## 10. Block index and Bloom filters
+
+A block-index entry contains:
+
+```rust
+pub struct BlockHandle {
+    pub first_key: Bytes,
+    pub last_key: Bytes,
+    pub offset: u64,
+    pub stored_len: u32,
+    pub raw_len: u32,
+    pub record_count: u32,
+    pub codec: CompressionCodec,
+    pub stored_crc32c: u32,
+}
+```
+
+Index keys use the same prefix-compressed block encoding. The reader loads section indexes at open
+time but fetches data blocks lazily.
+
+InodePatch and Dentry sections normally include a blocked Bloom filter. Xattr, ACL and Extent filters
+are optional. Bloom-filter negatives are authoritative; positives still require index lookup.
+
+Filters and indexes are covered by directory CRC/section digest and by `pack_hash`. Their decoded
+sizes are bounded before allocation.
+
+## 11. Canonical keys
+
+| Section | Ordered key |
+|---|---|
+| Dentry | `parent_ino:u64_be || name:bytes` |
+| Inode | `ino:u64_be` |
+| Xattr | `ino:u64_be || name:bytes` |
+| ACL | `ino:u64_be || acl_type:u8 || ordered_acl_id:u64_be` |
+| Extent | `ino:u64_be || chunk_index:u64_be || sequence:u64_be` |
+
+`ordered_acl_id = (acl_id as u64) XOR 0x8000_0000_0000_0000` preserves signed numeric order.
+
+Dentry names are raw bytes, non-empty and cannot contain NUL or `/`. Xattr names are raw bytes,
+non-empty and cannot contain NUL. Existing BrewFS maximum lengths remain in force.
+
+Keys are strictly increasing inside a section. Duplicate keys, unsorted restart keys or overlapping
+block key ranges are corruption.
+
+## 12. Compact values
+
+Persisted enum discriminants are append-only:
+
+```text
+DentryOp:   Put=0, Whiteout=1
+InodeState: Present=0, Deleted=1
+ValueOp:    Put=0, Whiteout=1
+ExtentKind: Data=0, Hole=1
+```
+
+### 12.1 Dentry
+
+```text
+op          u8
+sequence    uvarint
+if Put:
+  ino       uvarint
+  kind      u8
+```
+
+Whiteout has no inode payload.
+
+### 12.2 Inode
+
+```text
+state             u8
+kind              u8
+presence_bitmap   uvarint
+mode              uvarint
+uid               uvarint
+gid               uvarint
+rdev              uvarint
+nlink             uvarint
+size              uvarint
+atime_ns          svarint
+mtime_ns          svarint
+ctime_ns          svarint
+data_version      uvarint
+sequence          uvarint
+if HAS_PARENT:  parent_hint uvarint
+if HAS_SYMLINK: symlink_target bytes
+```
+
+V1 presence bits are `HAS_PARENT=0` and `HAS_SYMLINK=1`; all others are reserved. A symlink must have
+a target. A non-symlink must not. Deleted inode records retain complete attributes for deterministic
+diff and validation.
+
+### 12.3 Xattr and ACL
+
+```text
+op          u8
+sequence    uvarint
+if Put:
+  value     bytes
+```
+
+An empty Put value is valid. Whiteout has no value. ACL type and ID are in the key.
+
+### 12.4 Extent
+
+```text
+logical_offset  uvarint
+length          uvarint
+kind            u8
+if Data:
+  slice_id      uvarint
+  slice_offset  uvarint
+```
+
+Sequence is already part of the extent key. Required validation:
+
+- `length > 0`;
+- logical and slice ranges do not overflow;
+- `logical_offset + length <= chunk_size`;
+- Data uses a non-zero slice ID;
+- Hole has no slice payload;
+- sequences are increasing within equal `(ino, chunk_index)`.
+
+The layer resolver keeps logical offset separate from slice offset. It creates the final read plan
+before adapting visible Data extents to BrewFS `SliceDesc` operations.
+
+### 12.5 GC slice references
+
+Core BRLP bytes do not repeat slice IDs in another table. GC streams normalized Extent records. An
+optional, safely regenerable `.brlg` sidecar may contain delta-encoded unique slice IDs.
+
+## 13. Logical digest
+
+Physical prefix compression, varints, zstd blocks, indexes and Bloom filters are not the logical hash
+contract. The canonical logical encoder hashes the minimal InodePatch, Dentry, Xattr, ACL and
+normalized Extent streams defined by the BRLP logical schema.
+
+The pack builder feeds each decoded logical record into that encoder while it writes the compact
+physical form. It refuses to finish if the computed digest does not match the expected seal digest.
+A full scrub decodes records and repeats the same check.
+
+The layer ID is physical identity stored once in the pack header. It is not repeated in records and is
+not part of the semantic delta digest.
+
+## 14. In-memory representations
+
+### 14.1 Private writable MemLayer
+
+```rust
+pub struct MemLayer {
+    pub layer_id: LayerId,
+    pub parent: LayerRef,
+    pub next_sequence: u64,
+    dentries: BTreeMap<DentryKey, DentryDelta>,
+    inodes: HashMap<u64, InodeDelta>,
+    xattrs: BTreeMap<XattrKey, XattrDelta>,
+    acls: BTreeMap<AclKey, AclDelta>,
+    extents: BTreeMap<ExtentKey, DataExtentDelta>,
+    byte_arena: BytesArena,
+}
+```
+
+Only the owning `WorkspaceActor` mutates it. Read snapshots are immutable `Arc`s. Copy-up clones only
+the affected lower metadata record and retains data extent references until a write creates a new
+extent.
+
+Each agent has its own MemLayer. Two agents based on the same revision therefore share all lower
+`FrozenLayer`s and block objects while keeping different names, attributes and extents in memory.
+
+### 14.2 Shared FrozenLayer
+
+```rust
+pub enum FrozenLayer {
+    Hot(HotFrozenLayer),
+    Cold(LayerPackReader),
+}
+```
+
+`HotFrozenLayer` decodes a frequently used pack into arena-backed ordered indexes and is shared as
+`Arc<FrozenLayer>` across workspaces. `Cold` keeps only manifest, Bloom filters, block indexes and a
+bounded decoded-block cache. A pack may be promoted to Hot based on access count and memory budget.
+
+The compact S3 bytes and the optimized in-memory layout are deliberately different. Persistence
+optimizes transfer/storage; memory layout optimizes lookup and sharing.
+
+## 15. Active-head durability modes
+
+Sealed packs are always durable before publication. The writable MemLayer supports three explicit
+modes:
+
+```rust
+pub enum HeadDurability {
+    Ephemeral,
+    LocalJournal,
+    S3Journal,
+}
+```
+
+### Ephemeral
+
+Mutation acknowledgement means visible in process memory. Process or host loss discards unsealed
+changes. `seal`, `snapshot` and `commit` still upload and publish a durable pack before returning.
+This mode suits disposable agents and gives the lowest write latency.
+
+### LocalJournal
+
+Mutations are group-committed to an fsynced local WAL before acknowledgement. Restart on the same
+durable host recovers them. Host loss may lose unsealed changes.
+
+### S3Journal
+
+Mutations are encoded into an immutable WAL segment, uploaded, verified and attached to the workspace
+head using CAS before acknowledgement. This survives host loss but adds an S3 group-commit boundary.
+Batch size and maximum delay are configurable; correctness never depends on a timing assumption.
+
+The selected mode is recorded in the workspace head and surfaced by status APIs. A caller must not
+infer durable acknowledgement in Ephemeral or LocalJournal mode.
+
+## 16. Compact WAL format
+
+A `.brlw` segment contains:
+
+```text
+fixed WAL header
+compact RecordBatch blocks
+footer with wal_hash
+```
+
+The header includes volume/workspace/layer IDs, writer epoch, first/last sequence, previous WAL hash,
+record count and schema version. Records use the same CompactCodecV1 values as packs, preceded by a
+section tag. They are in mutation sequence order, not section-key order.
+
+Every logical transaction is framed:
+
+```text
+TxnBegin(txn_id, expected_sequence, operation_count)
+Operation(section_tag, key, value)
+...
+TxnCommit(txn_id, txn_digest)
+```
+
+Recovery applies only complete transactions with a valid commit digest. A segment is accepted only
+if its sequence range is contiguous with the previous published tail. WAL objects are never appended
+or overwritten; a new group commit creates a new segment.
+
+Seal replays the committed tail into the frozen MemLayer snapshot, produces one sorted pack, then
+starts a new writer epoch with no WAL tail. Old WAL becomes collectible after the new pack and head
+generation are durable.
+
+## 17. Head record and CAS pointer
+
+The immutable head record contains:
+
+```rust
+pub struct WorkspaceHeadRecord {
+    pub volume_id: VolumeId,
+    pub workspace_id: WorkspaceId,
+    pub generation: u64,
+    pub writer_epoch: u64,
+    pub writer_id: [u8; 16],
+    pub lease_expires_at_ns: i64,
+    pub base: LayerRef,
+    pub writable_layer_id: LayerId,
+    pub wal_tail: Option<WalRef>,
+    pub next_sequence: u64,
+    pub durability: HeadDurability,
+    pub previous_head_record_hash: Option<[u8; 32]>,
+}
+```
+
+It is encoded with CompactCodecV1, checksummed and written to `head-records/...` as an immutable
+object.
+
+The mutable `.brhp` pointer is intentionally tiny:
+
+```text
+magic                   [8]
+format_version          u16
+generation              u64
+head_record_hash        [32]
+head_record_len         u64
+crc32c                  u32
+```
+
+Publication writes and verifies the immutable head record, then conditionally replaces `.brhp` with
+`If-Match: old_etag`. CAS failure fences the caller. A writer with an old epoch may upload unreachable
+objects, but it cannot publish or acknowledge them as S3-durable.
+
+Lease expiry permits another writer to CAS-publish a higher writer epoch. Every S3Journal flush, seal,
+snapshot and commit checks the current pointer ETag/generation. The old writer is harmless after a
+successful steal because it cannot satisfy that precondition.
+
+The actor also stops acknowledging mutations when its locally observed lease deadline is reached.
+It must renew the lease through head-pointer CAS before resuming. This prevents Ephemeral and
+LocalJournal modes from continuing to report successful private writes indefinitely after ownership
+has moved to another host.
+
+## 18. Seal protocol
+
+1. Stop accepting new workspace mutations and drain in-flight operations.
+2. Publish or fsync the active WAL according to durability mode.
+3. Atomically freeze the MemLayer at sequence `N`.
+4. Stream its sorted sections into a staging `.brlp` file.
+5. Derive Bloom filters, block indexes, logical digest and pack hash.
+6. Locally reopen and fully verify the staging pack.
+7. Upload the content-addressed pack with create-only semantics.
+8. HEAD and range-read the remote footer, directory and header.
+9. Create an immutable head record whose base is the new pack and whose writable layer is empty.
+10. Upload and verify that head record.
+11. CAS the workspace `.brhp` pointer from the captured ETag/generation to the new head record.
+12. Publish the new in-memory `WorkspaceView` and resume mutations.
+
+Step 11 is the visibility point. Any failure before it leaves the old view authoritative. Retrying is
+idempotent because all prior objects are content-addressed or generation-addressed.
+
+If step 11 succeeds but the process exits before step 12, restart reads the new pointer and reconstructs
+the correct view. No multi-object S3 transaction is required.
+
+## 19. Mount and recovery
+
+Mount performs:
+
+1. GET workspace head pointer and capture ETag;
+2. GET and validate the referenced immutable head record;
+3. follow `base.parent` references to the sealed root, enforcing the depth limit;
+4. open packs cold or reuse matching `Arc<FrozenLayer>` cache entries;
+5. if a WAL tail exists, walk its hash chain to the epoch start and replay forward;
+6. rebuild MemLayer, verify sequence continuity and publish the initial view;
+7. acquire or renew writer epoch before accepting mutations.
+
+Recovery never discovers correctness-critical state by listing a prefix. Missing referenced objects,
+hash mismatch, a parent cycle, depth overflow, WAL gap or writer-epoch mismatch fails the mount with a
+typed corruption/fencing error.
+
+## 20. Reader and transport APIs
+
+```rust
+#[async_trait]
+pub trait LayerObjectStore: Send + Sync {
+    async fn put_create_only(&self, key: &str, body: ReplayableBody)
+        -> Result<CreateOutcome, LayerError>;
+    async fn get_range(&self, key: &str, range: Range<u64>)
+        -> Result<Bytes, LayerError>;
+    async fn head(&self, key: &str) -> Result<ObjectMeta, LayerError>;
+    async fn get_pointer(&self, key: &str) -> Result<(Bytes, EntityTag), LayerError>;
+    async fn put_pointer_conditional(
+        &self,
+        key: &str,
+        expected: Option<&EntityTag>, // None means If-None-Match: *
+        body: Bytes,
+    ) -> Result<EntityTag, LayerError>;
+}
+```
+
+```rust
+pub trait ReadonlyLayer {
+    async fn lookup_dentry(&self, parent: u64, name: &[u8]) -> Result<Option<DentryDelta>>;
+    async fn list_dentries(&self, parent: u64, cursor: DentryCursor, limit: usize)
+        -> Result<RecordPage<DentryDelta>>;
+    async fn get_inode(&self, ino: u64) -> Result<Option<InodeDelta>>;
+    async fn list_xattrs(&self, ino: u64) -> Result<Vec<XattrDelta>>;
+    async fn list_acls(&self, ino: u64) -> Result<Vec<AclDelta>>;
+    async fn get_extents(&self, ino: u64, chunk: u64) -> Result<Vec<DataExtentDelta>>;
+    async fn visit_slice_refs(&self, visitor: &mut dyn SliceVisitor) -> Result<()>;
+}
+```
+
+For RPC transfer, the service returns one or more complete CompactCodecV1 record blocks plus a small
+binary batch header. The receiver can validate and decode the same framing used in S3. Metadata is not
+converted to JSON, MessagePack or per-record protobuf on the hot path.
+
+## 21. Resolution behavior
+
+The view resolves newest to oldest:
+
+```text
+private MemLayer -> sealed pack -> sealed parent pack -> ... -> sealed root pack
+```
+
+- point lookup stops at the first matching Put/Whiteout or Present/Deleted record;
+- readdir performs a k-way ordered merge and keeps the newest layer's value for each name;
+- xattr and ACL Whiteout hide all lower values for the same key;
+- the writable MemLayer resolves mutation sequence before publication; sealed packs contain sorted,
+  normalized, sequence-free extents and fill uncovered ranges newest-layer first;
+- any mutation of a lower inode first writes its effective attributes into MemLayer;
+- lower metadata and block objects remain untouched.
+
+Read-only `FrozenLayer` objects can be shared across all agent workspaces because they contain no
+workspace-local cache invalidation state.
+
+## 22. Cache and memory policy
+
+```text
+ManifestCache: pack_hash -> validated header/directory/index/filter
+BlockCache:    (pack_hash, section, block_no) -> Arc<decoded block>
+HotLayerCache: pack_hash -> Weak<FrozenLayer>
+```
+
+All caches are weighted and bounded. Pack hash is always part of the key. Immutable entries need no
+mutation invalidation.
+
+Memory accounting separates:
+
+- shared frozen bytes, charged once per host;
+- private MemLayer bytes, charged to one workspace/agent;
+- decoded block-cache bytes;
+- WAL buffers and staging-pack bytes.
+
+When an agent is deleted, its private MemLayer and WAL buffers can be freed immediately. Shared base
+layers remain cached while referenced by other agents.
+
+## 23. Snapshot, fork and commit
+
+Snapshot writes an immutable `.brls` object containing a `LayerRef`, source workspace generation,
+optional name/owner metadata and checksum. The snapshot ID or returned object reference is the durable
+handle; no KV row is needed.
+
+Fork creates a new workspace head record whose base is the snapshot/revision `LayerRef` and whose
+MemLayer/WAL are empty, then creates its `.brhp` pointer with `If-None-Match: *`.
+
+Fast-forward commit requires the target head pointer still reference the expected fork base and
+generation. It writes a new immutable target head record and CAS-updates the target pointer. A conflict
+returns the current generation and performs no merge.
+
+Naming and listing snapshots are control-plane conveniences. They may be maintained in a separate
+append-only registry object stream, but filesystem correctness uses explicit snapshot references.
+
+## 24. GC
+
+GC roots are explicit workspace head pointers and retained snapshot references. Marking follows:
+
+```text
+head pointer -> head record -> base pack -> parent packs
+                          \-> WAL tail -> previous WAL segments
+snapshot -> layer pack -> parent packs
+pack -> normalized Extent records -> BrewFS data objects
+```
+
+S3 Inventory or a rate-limited prefix listing supplies sweep candidates; listing is not used for
+marking relationships. An object is deleted only if:
+
+1. it is absent from the completed mark set;
+2. it predates the configured orphan grace period;
+3. no active publication journal or local upload reports it in flight;
+4. a tombstone has been written and survived a second GC observation.
+
+Shared packs and slices are marked once by hash/ID. WAL segments superseded by a sealed pack are
+collectible after the head pointer and all snapshots no longer reference their epoch.
+
+## 25. Feature and module isolation
+
+```toml
+[features]
+workspace-overlay = []
+workspace-memory-s3 = ["workspace-overlay"]
+```
+
+```text
+src/workspace_overlay/memory_s3/
+  mod.rs
+  compact_codec.rs
+  mem_layer.rs
+  frozen_layer.rs
+  pack/
+    format.rs
+    builder.rs
+    reader.rs
+    index.rs
+    filter.rs
+  wal/
+    format.rs
+    writer.rs
+    recovery.rs
+  head/
+    record.rs
+    pointer.rs
+    lease.rs
+  runtime.rs
+  object_store.rs
+  cache.rs
+  gc.rs
+  error.rs
+```
+
+Rules:
+
+- the module is absent without `workspace-memory-s3`;
+- the feature is disabled by default;
+- flat BrewFS mounts never instantiate `LayerRuntime` or call the layer object store;
+- enabling the feature requires a dedicated metadata S3 prefix and conditional-write capability;
+- existing `MetaStore`, `MetaClient`, metadata serialization and block layout are not changed;
+- no silent fallback from corrupt S3 layer bytes to another metadata source is allowed.
+
+## 26. Limits
+
+V1 defaults and hard limits:
+
+| Item | Default | Hard limit |
+|---|---:|---:|
+| raw record block target | 64 KiB | 16 MiB |
+| one decoded record | — | 16 MiB |
+| layer depth | soft 8 | 32 |
+| restart interval | 16 | 256 |
+| Bloom bits/key | 10 | 32 |
+| RPC record batch | 1 MiB | 16 MiB |
+| one WAL segment | 4 MiB | 64 MiB |
+| readdir page | 1,024 records | 16,384 records |
+| symlink target | existing BrewFS limit | existing BrewFS limit |
+| xattr value | existing BrewFS limit | existing BrewFS limit |
+
+All stored lengths are checked against both object bounds and configured hard limits before memory
+allocation.
+
+## 27. Error behavior
+
+```rust
+pub enum LayerError {
+    NotFound,
+    AlreadyExistsMismatch,
+    UnsupportedVersion { major: u16, minor: u16 },
+    UnsupportedFeature(u64),
+    UnsupportedCodec(u8),
+    InvalidVarint,
+    BoundsExceeded { field: &'static str, value: u64, limit: u64 },
+    InvalidHeader(String),
+    InvalidDirectory(String),
+    InvalidBlock(String),
+    InvalidRecord(String),
+    ChecksumMismatch(ChecksumScope),
+    DigestMismatch { expected: [u8; 32], actual: [u8; 32] },
+    ParentCycle,
+    SequenceGap,
+    Fenced { expected_generation: u64, actual_generation: u64 },
+    ConditionalWriteUnavailable,
+    Backend(String),
+    Io(std::io::Error),
+}
+```
+
+Malformed data always returns a typed error. Decoding uses checked offsets, checked arithmetic and safe
+slice access. Logs size-limit and escape names; they never print xattr values, symlink targets or raw
+WAL payloads.
+
+## 28. Verification
+
+### Compact codec and pack
+
+- golden bytes for every scalar, record type, restart block, index, filter, header and footer;
+- non-canonical and overflow varint rejection;
+- deterministic pack bytes for identical records and build options;
+- identical logical digest across block size and compression choices;
+- insertion-order independence after sorting;
+- point/prefix/range lookup across restart and block boundaries;
+- empty sections, oversized single-record block and maximum limits;
+- arbitrary-byte fuzzing of every decoder;
+- truncation/bit-flip tests for every structural region.
+
+### Memory and isolation
+
+- two agents share the same `Arc<FrozenLayer>` but different MemLayers;
+- one agent's create/write/rename/unlink/xattr/truncate is invisible to another;
+- copy-up never modifies lower metadata or data objects;
+- dropping one agent releases only private accounting;
+- hot and cold FrozenLayer return byte-for-byte equivalent logical records.
+
+### S3 persistence
+
+- create-only pack/WAL/head-record upload is idempotent;
+- mismatched existing object is fatal;
+- head CAS has exactly one winner;
+- stale writer cannot publish after writer-epoch steal;
+- crash before and after every seal step recovers one complete view;
+- WAL replay rejects gaps, forks, partial transactions and wrong epochs;
+- mount reconstructs a workspace from S3 with no KV service;
+- no hot-path S3 LIST calls;
+- GC retains shared packs, shared slices, head records and WAL tails.
+
+### BrewFS behavior
+
+- resolver tests cover whiteouts, hardlinks, symlinks, ACLs, xattrs and overlapping Data/Hole extents;
+- pjdfstest and selected xfstests run against memory+S3 workspaces;
+- existing flat-volume test gates run with the feature absent and enabled-but-unused;
+- disabled mounts make zero LayerObjectStore calls.
+
+### Performance
+
+Report separately:
+
+- pack size versus uncompressed logical record bytes;
+- metadata bytes transferred for cold lookup, readdir and extent lookup;
+- warm lookup latency for MemLayer, Hot FrozenLayer and cached Cold FrozenLayer;
+- base-layer memory shared across 1, 10 and 100 agents;
+- private metadata bytes per agent;
+- seal throughput and peak staging memory;
+- S3Journal group-commit latency and requests per mutation;
+- mount/recovery time by layer depth and WAL length.
+
+Acceptance requires bounded builder/recovery memory, no material flat-volume regression, and no hidden
+durability downgrade. Ephemeral-mode numbers must not be presented as S3-durable write latency.
+
+## 29. Implementation sequence
+
+1. Implement and fuzz `CompactCodecV1` plus prefix-compressed blocks.
+2. Implement pack header/directory/index/filter/footer and golden fixtures.
+3. Implement streaming pack builder and local full verifier.
+4. Implement range-based reader and `FrozenLayer` hot/cold modes.
+5. Implement private MemLayer snapshots and resolver integration behind the feature.
+6. Implement content-addressed S3 pack upload and immutable layer-chain mount.
+7. Implement immutable head records and conditional head pointer updates.
+8. Add Ephemeral seal/fork/snapshot first; it has the smallest persistence surface.
+9. Add LocalJournal and then S3Journal with transaction framing and recovery.
+10. Add GC, crash injection, POSIX suites and matched performance gates.
+
+Steps 1-4 are standalone format work and do not alter mounted filesystem behavior. Step 5 is the first
+runtime integration and remains disabled by default.
+
+## 30. Definition of done
+
+1. A sealed base can be mounted from S3 packs with no KV/database service.
+2. Multiple agent workspaces share one in-memory FrozenLayer while keeping private MemLayers.
+3. Compact blocks can be stored, range-read and transferred without JSON reserialization.
+4. Seal publishes a complete pack and new workspace generation through one CAS visibility point.
+5. Restart reconstructs the exact selected durability state from explicit S3 references.
+6. Stale writers cannot publish after fencing.
+7. Corruption is detected without panic, excessive allocation or silent fallback.
+8. GC preserves every reachable layer, WAL and data slice.
+9. Existing BrewFS behavior and tests remain unchanged when the feature is unused.


### PR DESCRIPTION
## Summary

This PR specifies a write-once metadata and ingestion architecture for BrewFS agent workspaces.

The normative v2 design introduces:

- immutable file clusters that can independently contribute to the same mounted directory;
- deterministic `DirKey`-based directory union with strict collision handling;
- parent-first namespace streaming and independently authenticated metadata batches;
- pageable Merkle indexes plus bounded, evictable namespace/extent/attribute caches;
- deterministic FUSE inode encoding without a global billion-entry inode map;
- a private per-agent `MemLayer` over a shared immutable clustered snapshot;
- single-cluster ingestion from local directories, tar, tar.gz, tar.zst, and ZIP sources;
- metadata-first upload using `.brfc` metadata, data packs, and a final `.brfds` Data Seal;
- resumable S3 multipart upload using a durable local WAL, `ListParts` reconciliation, and optional remote checkpoints.

## Publication model

```text
.brfc metadata (uploaded and verified first)
  -> DataPack / large data objects
  -> .brfds Data Seal
  -> clustered snapshot manifest
  -> CAS WorkspaceHead publication
```

An incomplete upload is never mountable. Metadata references logical `SliceId`s; the Data Seal binds them to verified S3 frames only after data upload completes.

## Documents

- `brewfs-clustered-frozen-metadata-v2.md` is the normative implementation specification.
- The memory/S3 architecture, compact layer-pack, and single-image frozen metadata documents record the design progression and point readers to v2 where superseded.

## Scope

Documentation and implementation planning only. This PR intentionally does not change existing BrewFS runtime behavior. The proposed implementation is feature-gated and isolated from existing metadata backends.

## Validation

- Markdown code fences and section numbering checked.
- `git diff --check` passes.
- Branch is based on the current `main`.