### PR TITLE
fix(meta): fuse cached lookup attribute fetch

### DIFF
--- a/src/meta/client/mod.rs
+++ b/src/meta/client/mod.rs
@@ -1527,16 +1527,10 @@ impl<T: MetaStore + ?Sized + 'static> MetaClient<T> {
         trace!("MetaClient: lookup MISS ({}, '{}')", parent, name);
         self.metrics.record_lookup_cache_miss();
 
-        let result = self.store.lookup(parent, name).await?;
+        let result = self.store.lookup_with_attr(parent, name).await?;
 
-        if let Some(ino) = result {
-            if let Ok(Some(attr)) = self.store.stat(ino).await {
-                self.cache_lookup_attr(parent, name, ino, attr).await;
-            } else {
-                self.inode_cache
-                    .add_child(parent, name.to_string(), ino)
-                    .await;
-            }
+        if let Some((ino, attr)) = result {
+            self.cache_lookup_attr(parent, name, ino, attr).await;
             Ok(Some(ino))
         } else if self.options.case_insensitive {
             self.resolve_case(parent, name).await
@@ -3645,7 +3639,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_meta_client_lookup_only_does_not_count_lookup_attr_fused_path() {
+    async fn test_meta_client_lookup_only_does_not_change_lookup_with_attr_api_metrics() {
         let client = create_test_client().await;
         let ino = client
             .create_file(1, "lookup-only.txt".to_string())
@@ -3664,7 +3658,7 @@ mod tests {
 
         assert_eq!(
             after.lookup_attr_fused_miss, before.lookup_attr_fused_miss,
-            "lookup-only callers should stay on the lighter inode-only path"
+            "lookup-only callers should not be counted as lookup_with_attr API calls"
         );
     }
 

--- a/src/meta/stores/redis/tests.rs
+++ b/src/meta/stores/redis/tests.rs
@@ -2518,6 +2518,44 @@ async fn test_lookup_with_attr_returns_inode_attr_and_warms_node_cache() {
 #[serial]
 #[tokio::test]
 #[ignore]
+async fn test_meta_client_lookup_uses_fused_store_path() {
+    let store = Arc::new(new_test_store().await);
+    let root = store.root_ino();
+    let ino = store
+        .create_file(root, "client_lookup_attr.txt".to_string())
+        .await
+        .unwrap();
+    let client = MetaClient::new(
+        store.clone(),
+        CacheCapacity {
+            inode: 100,
+            path: 100,
+        },
+        CacheTtl::for_redis(),
+    );
+
+    store.node_cache.invalidate(&ino).await;
+    store
+        .lookup_with_attr(root, "warm-lookup-script")
+        .await
+        .unwrap();
+    reset_redis_commandstats(&store).await;
+
+    assert_eq!(
+        client.lookup(root, "client_lookup_attr.txt").await.unwrap(),
+        Some(ino)
+    );
+
+    let script_calls = redis_script_calls(&store).await;
+    assert!(
+        (1..=2).contains(&script_calls),
+        "MetaClient::lookup should use Redis lookup_with_attr as one business Lua script; observed {script_calls} script calls including client-side script cache handling"
+    );
+}
+
+#[serial]
+#[tokio::test]
+#[ignore]
 async fn test_meta_client_stat_fresh_uses_warm_store_node_cache() {
     let store = Arc::new(new_test_store().await);
     let root = store.root_ino();


### PR DESCRIPTION
## Summary
- make cache-miss `MetaClient::lookup` use the store `lookup_with_attr` operation
- populate the inode and directory-entry caches from the same backend result
- add a Redis command-path regression test proving ordinary client lookup uses the fused Lua operation

Addresses #30.

## Validation
- `cargo fmt --all -- --check`
- `cargo test --workspace --lib --bins --tests`
- ignored Redis regression test in a Redis-sharing container
- `cargo clippy --workspace --all-targets -- -D warnings -A clippy::manual_checked_ops`

The unmodified strict clippy command is currently blocked by the existing `manual_checked_ops` warning in `src/vfs/cache/write_back.rs:454`.