### PR TITLE
feat: add agent-isolated workspace overlays

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, "codex/**"]
+    branches: [main, "feat/**", "fix/**", "docs/**", "perf/**"]
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -20,6 +20,7 @@ on:
           - tikv-xfstests-smoke
           - tikv-pjdfstest
           - tikv-ltp
+          - workspace-overlay
           - all
       stress_ng_profile:
         description: stress-ng profile for the Docker stress job
@@ -72,6 +73,11 @@ jobs:
           bash -n docker/compose-xfstests/run_tikv_perf.sh
           bash -n docker/compose-xfstests/run_juicefs_perf_in_container.sh
           bash -n docker/compose-xfstests/run_juicefs_perf.sh
+          bash -n docker/compose-xfstests/run_workspace_overlay_dual_mount_in_container.sh
+          bash -n docker/compose-xfstests/run_workspace_overlay_control_in_container.sh
+          bash -n docker/compose-xfstests/run_workspace_overlay_suite_in_container.sh
+          bash -n docker/compose-xfstests/run_workspace_overlay_compose.sh
+          bash -n docker/compose-xfstests/run_workspace_overlay_suites.sh
           bash docker/compose-xfstests/test_perf_report_delta.sh
           bash docker/compose-xfstests/test_juicefs_direct_matrix.sh
           bash docker/compose-xfstests/test_juicefs_perf_report.sh
@@ -86,12 +92,130 @@ jobs:
         run: |
           cargo check -p brewfs --no-default-features --features fuse-tokio-runtime
           cargo check -p brewfs --no-default-features --features fuse-io-uring-runtime
+          cargo check -p brewfs --no-default-features --features fuse-tokio-runtime,workspace-overlay
+          cargo check -p brewfs --no-default-features --features fuse-io-uring-runtime,workspace-overlay
 
       - name: Test workspace
         run: cargo test --workspace --lib --bins -- --test-threads=1
 
-      - name: Clippy
-        run: cargo clippy --workspace
+      - name: Test workspace overlay
+        run: cargo test --workspace --features workspace-overlay -- --test-threads=1
+
+      - name: Test all features
+        run: cargo test --workspace --all-features -- --test-threads=1
+
+      - name: Clippy default features
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: Clippy workspace overlay
+        run: cargo clippy --workspace --all-targets --features workspace-overlay -- -D warnings
+
+  docker-workspace-overlay-smoke:
+    name: Docker workspace overlay smoke (${{ matrix.meta-backend }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        meta-backend: [redis, tikv]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler fuse3
+
+      - name: Enable FUSE
+        run: |
+          sudo modprobe fuse
+          test -e /dev/fuse
+          sudo chmod 666 /dev/fuse
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Show Docker versions
+        run: |
+          docker version
+          docker compose version
+
+      - name: Run workspace overlay control smoke
+        run: >-
+          bash docker/compose-xfstests/run_workspace_overlay_compose.sh
+          --backend "${{ matrix.meta-backend }}"
+          --control-only
+
+      - name: Upload workspace overlay smoke artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: workspace-overlay-smoke-${{ matrix.meta-backend }}-artifacts
+          path: docker/compose-xfstests/artifacts/**
+          if-no-files-found: warn
+
+  docker-workspace-overlay:
+    name: Docker workspace overlay (${{ matrix.meta-backend }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' &&
+        (inputs.docker_suite == 'workspace-overlay' || inputs.docker_suite == 'all')
+      }}
+    strategy:
+      fail-fast: false
+      matrix:
+        meta-backend: [redis, tikv]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler fuse3
+
+      - name: Enable FUSE
+        run: |
+          sudo modprobe fuse
+          test -e /dev/fuse
+          sudo chmod 666 /dev/fuse
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Show Docker versions
+        run: |
+          docker version
+          docker compose version
+
+      - name: Run workspace overlay xfstests and LTP Compose suite
+        run: >-
+          bash docker/compose-xfstests/run_workspace_overlay_compose.sh
+          --backend "${{ matrix.meta-backend }}"
+
+      - name: Upload workspace overlay artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: workspace-overlay-${{ matrix.meta-backend }}-artifacts
+          path: docker/compose-xfstests/artifacts/**
+          if-no-files-found: warn
 
   docker-pjdfstest:
     name: Docker pjdfstest smoke

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -201,7 +201,7 @@ checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
  "blake2",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "password-hash",
 ]
 
@@ -1039,6 +1039,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake3"
+version = "1.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9e454fc11f76977dc803893aff6304ed33d6a26efae8696573bea74baa27ae"
+dependencies = [
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1102,7 +1115,9 @@ dependencies = [
  "aws-sdk-s3",
  "axum 0.8.8",
  "base64 0.22.1",
+ "bincode",
  "bitflags 2.11.0",
+ "blake3",
  "bytes",
  "chrono",
  "clap",
@@ -1298,7 +1313,7 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -1510,6 +1525,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1560,6 +1581,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1770,7 +1800,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
@@ -4510,7 +4540,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -4522,7 +4552,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -6048,7 +6078,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -6065,7 +6095,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -292,6 +292,7 @@ rand = { workspace = true }
 hostname = { workspace = true }
 bitflags = { workspace = true }
 redis = { workspace = true }
+bincode = { workspace = true, optional = true }
 if-addrs = { workspace = true }
 uuid = { workspace = true, features = ["v7"] }
 parking_lot = { workspace = true }
@@ -301,11 +302,13 @@ rkyv = { workspace = true, optional = true, features = ["uuid-1"] }
 lz4_flex = { workspace = true }
 zstd = { workspace = true }
 governor = { workspace = true }
+blake3 = { workspace = true, optional = true }
 
 [features]
 default = ["fuse-io-uring-runtime"]
 fuse-io-uring-runtime = ["asyncfuse/io-uring-runtime"]
 fuse-tokio-runtime = ["asyncfuse/tokio-runtime"]
+workspace-overlay = ["dep:bincode", "dep:blake3"]
 profiling = ["dep:tracing-flame", "dep:tracing-chrome", "dep:console-subscriber"]
 jemalloc = ["dep:tikv-jemallocator"]
 jemalloc-profiling = ["jemalloc", "tikv-jemallocator/profiling"]

--- a/doc/architecture/README.md
+++ b/doc/architecture/README.md
@@ -18,6 +18,8 @@ changes runtime semantics rather than deployment or testing workflow.
 - [write-path.md](write-path.md): write flow.
 - [caching.md](caching.md): cache layers and invalidation.
 - [compaction-gc.md](compaction-gc.md): compaction and garbage collection.
+- [workspace-overlay.md](workspace-overlay.md): agent workspace layering, fencing,
+  Redis/TiKV transaction boundaries, and persisted graph.
 
 ## Semantics
 

--- a/doc/architecture/workspace-overlay.md
+++ b/doc/architecture/workspace-overlay.md
@@ -1,0 +1,208 @@
+# Workspace Overlay Architecture
+
+- Status: implemented, maintained with `src/workspace_overlay/`
+- Cargo feature: `workspace-overlay` (off by default)
+- Volume format: `workspace-v1`
+- Production metadata backends: Redis and TiKV
+
+This document is the maintained architecture reference for BrewFS agent
+workspaces. The detailed API, state-machine fields, and implementation checklist
+remain in the
+[workspace overlay implementation spec](../superpowers/specs/2026-08-23-brewfs-workspace-overlay-implementation-spec.md).
+Changes to persisted records, transaction boundaries, fencing, layer reachability,
+or mount integration must update this document in the same pull request.
+
+## Goals and boundaries
+
+Workspace Overlay lets multiple agents share immutable base files and object
+blocks while keeping each agent's namespace, inode attributes, and data extents
+private. Forking creates metadata records and a new writable head; it does not
+copy the sealed base or clean object data.
+
+The feature is deliberately isolated from existing BrewFS volumes:
+
+- flat volumes continue through the existing `MetaStore -> MetaClient -> VFS` path;
+- workspace volumes use `WorkspaceStore -> WorkspaceMetaLayer -> VFS`;
+- the default build does not compile `src/workspace_overlay/`;
+- object keys and the existing `SliceDesc` representation are unchanged;
+- a workspace error never falls back to flat-volume semantics.
+
+## Component architecture
+
+```mermaid
+flowchart TB
+    AgentA[Agent A mount] --> FuseA[FUSE / VFS]
+    AgentB[Agent B mount] --> FuseB[FUSE / VFS]
+
+    FuseA --> MetaA[WorkspaceMetaLayer<br/>workspace A]
+    FuseB --> MetaB[WorkspaceMetaLayer<br/>workspace B]
+
+    MetaA --> Resolver[Layer resolver<br/>newest record wins]
+    MetaB --> Resolver
+    MetaA --> Catalog[WorkspaceStore state machine]
+    MetaB --> Catalog
+
+    Catalog --> KV{Redis or TiKV}
+    Resolver --> KV
+
+    KV --> Topology[control<br/>low-frequency topology]
+    KV --> Hot[hot/workspace<br/>hot/layer<br/>hot/lease<br/>hot/allocator]
+    KV --> Delta[delta/dentry · inode<br/>xattr · acl · extent]
+
+    FuseA --> Chunk[Existing chunk read/write path]
+    FuseB --> Chunk
+    Chunk --> Objects[(S3-compatible or local<br/>immutable blocks)]
+
+    Shared[Fixed sealed base] --> Resolver
+    Delta --> Resolver
+    Shared -. shared by both agents .-> Objects
+```
+
+Every active view contains exactly two layers: one private writable overlay and
+one flat sealed base. The base has no parent and remains fixed until an explicit
+seal publishes a replacement base. Point reads batch the two exact keys into one
+Redis `MGET` or TiKV batch-get; they never scan metadata. Whiteouts in the upper
+stop fallback to the base. Extents are clipped and combined into a read plan
+before the existing chunk reader fetches object blocks.
+
+`statfs` does not enumerate inode deltas to synthesize effective usage. Such a
+scan is O(N), needs to block workspace mutations for a consistent view, and is
+unbounded on the FUSE hot path. Until Redis, TiKV, and SQLite persist usage
+counters and update them atomically with each workspace mutation, the workspace
+metadata layer returns an explicit `NotSupported` error instead of reporting
+zero usage or an inconsistent snapshot.
+
+## Persisted graph
+
+```mermaid
+flowchart LR
+    WS1[Workspace A] --> HA[Writable head A]
+    WS2[Workspace B] --> HB[Writable head B]
+    HA --> Base[Sealed base revision]
+    HB --> Base
+    LeaseA[Lease A] -. fences writes .-> WS1
+    LeaseB[Lease B] -. fences writes .-> WS2
+    Snap[Snapshot] -. GC root .-> Base
+    Journal[Seal journal] -. recovery root .-> HA
+
+    HA --> DA[Private deltas A]
+    HB --> DB[Private deltas B]
+    Base --> Blocks[Shared immutable blocks]
+```
+
+Workspace heads, snapshots, active leases, and incomplete seal journals are GC
+roots. A layer or object slice may be deleted only after it is unreachable from
+all roots and the configured lease grace period has elapsed.
+
+The active graph invariant is `writable(depth=2) -> sealed(depth=1) -> null`.
+Sealed ancestry is never exposed to the FUSE data path.
+
+## Transaction architecture
+
+### Hot data path
+
+Ordinary namespace, inode, xattr, ACL, and extent mutations do not read or CAS
+the global `control` record. They atomically check exactly three entity records
+and update the current layer plus delta keys:
+
+```mermaid
+sequenceDiagram
+    participant M as Workspace mount
+    participant S as KvWorkspaceStore
+    participant K as Redis / TiKV
+
+    M->>S: mutation + HeadGuard
+    S->>K: batched hot records + authoritative time<br/>(Redis TIME+MGET / TiKV transaction timestamp+batch-get)
+    S->>S: validate workspace, head epoch,<br/>owner, lease generation and expiry
+    S->>K: atomic CAS(three expected values)<br/>put hot/layer + delta keys
+    alt CAS conflict
+        S->>K: bounded retry from fresh values
+    else committed
+        S-->>M: allocated sequence range
+    end
+```
+
+The writable layer owns its `next_sequence`, so writers in the same workspace
+serialize correctly while sibling workspaces do not contend. Lease renewal CASes
+only `hot/lease/<lease-id>`. Each ID allocator CASes only its own
+`hot/allocator/<name>` record.
+
+Named dentry, inode, xattr, and ACL resolution uses exact batched reads. Prefix
+enumeration is reserved for `readdir`, layer materialization, and GC. Redis keeps
+a transactionally maintained lexicographic key index so those operations read
+only the requested key range; `SCAN MATCH` is used once only to migrate an older
+catalog that lacks the index marker.
+
+### Low-frequency topology path
+
+Seal, fork, snapshot, commit, compaction, and GC retain a versioned `control`
+document so graph changes remain all-or-reject. Before committing, the store
+hydrates and exact-value-checks the hot records used by the transition. The same
+backend transaction updates `control`, changed hot mirrors, journals, and any
+required delta keys. A concurrent writer or heartbeat therefore makes a stale
+topology transaction retry instead of silently committing from an old view.
+
+Redis implements multi-key CAS with a binary-safe Lua script. All workspace keys
+use one fixed cluster hash tag. TiKV uses pessimistic transactions and
+`get_for_update` for the checked entity keys.
+
+## Authoritative lease time
+
+Lease expiry must be based on metadata-backend time, never mount-host wall time:
+
+- Redis uses `TIME`;
+- TiKV reuses the transaction start timestamp and converts its PD TSO physical
+  millisecond component to nanoseconds with checked arithmetic;
+- SQLite is a local semantic and fault-injection backend and uses its local
+  transaction clock.
+
+Every mutation also checks workspace ID, head layer ID, head epoch, lease ID,
+holder generation, writable state, and expiry. A stale mount is fenced before
+any delta or sequence update is committed.
+
+## State transitions
+
+Writable heads follow `Writable -> Sealing`; abort is permitted only before
+hashing and restores the old writable view. A successful seal materializes the
+fixed base plus the writable delta into a new flat sealed base, creates one empty
+writable overlay, and atomically switches the workspace and active lease to that
+pair. Immutable object blocks are reused rather than copied. The durable journal
+makes recovery idempotent across crashes, and mount recovery flattens a transient
+post-switch chain before admitting a writer.
+
+Fast-forward commit is deliberately restricted: the source revision and target
+fork base must still match, the target head must be empty, and the target must
+have no active writable lease. Conflicts preserve the child workspace for
+inspection or retry.
+
+## Code map
+
+- `src/workspace_overlay/meta_layer.rs`: POSIX-facing workspace metadata layer.
+- `src/workspace_overlay/resolver.rs`: layered namespace and extent resolution.
+- `src/workspace_overlay/catalog.rs`: backend-neutral storage contract.
+- `src/workspace_overlay/stores/kv_store.rs`: shared Redis/TiKV state machine and
+  hot-record transaction boundaries.
+- `src/workspace_overlay/stores/redis.rs`: Redis key scoping, Lua CAS, server time.
+- `src/workspace_overlay/stores/tikv.rs`: TiKV transactions, scans, and PD TSO.
+- `src/workspace_overlay/lifecycle.rs`: seal, fork, snapshot, commit, recovery.
+- `src/workspace_overlay/gc.rs` and `compaction.rs`: reachability and flattening.
+- `src/workspace_overlay/cache_scope.rs`: workspace-aware cache identities.
+
+## Required maintenance and verification
+
+Any architecture change must preserve and test these invariants:
+
+1. sibling workspaces share sealed bases but never observe each other's deltas;
+2. hot mutations never CAS `control`;
+3. same-head sequence allocation is gap-safe under backend CAS retries;
+4. heartbeat and allocators remain entity-local;
+5. stale epochs and lease generations cannot partially write;
+6. active leases and incomplete journals prevent premature GC;
+7. default flat-volume behavior and serialized metadata remain unchanged;
+8. Redis and TiKV both pass the distributed two-store concurrency contract.
+9. every mounted workspace resolves exactly two layers;
+10. named point reads issue no prefix scans, regardless of backend key count.
+
+The feature test suite, resolver oracle tests, real Redis/TiKV backend contracts,
+dual-mount isolation tests, pjdfstest, and xfstests gates are the acceptance
+evidence for this subsystem.

--- a/doc/superpowers/specs/2026-08-23-brewfs-workspace-overlay-implementation-spec.md
+++ b/doc/superpowers/specs/2026-08-23-brewfs-workspace-overlay-implementation-spec.md
@@ -1,0 +1,1664 @@
+# BrewFS Workspace Overlay 实现规范
+
+- 状态：Implementation spec / 与当前代码同步
+- 日期：2026-08-23
+- 功能名：Workspace Overlay
+- Cargo feature：`workspace-overlay`
+- volume format：`workspace-v1`
+- 首要生产 backend：Redis、TiKV
+- 本地语义与故障注入 backend：SQLite / SQLx
+
+## 1. 实现目标
+
+在 BrewFS 中增加可 fork 的 workspace view：多个 workspace 共享 sealed base layer 和
+immutable slice/block，每个 workspace 只保存自己的 namespace、inode 属性和数据 extent
+变更。
+
+v1 必须支持：
+
+1. 创建 workspace volume；
+2. 创建、挂载和销毁 workspace；
+3. seal/snapshot；
+4. 从 sealed revision fork；
+5. workspace 内完整的核心 POSIX mutation 隔离；
+6. path 级 diff；
+7. discard；
+8. fast-forward、all-or-reject commit；
+9. lease-aware GC 和 layer compaction；
+10. crash recovery 与 stale writer fencing。
+
+## 2. 不可破坏的兼容契约
+
+以下均为硬约束：
+
+1. `workspace-overlay` 不加入默认 Cargo features；
+2. 默认构建不编译 workspace module；
+3. 现有 flat metadata schema 不增加字段或迁移；
+4. `SliceDesc` 的字段、serde/rkyv 编码和 golden bytes 不改变；
+5. object key 继续使用 `chunks/{slice_id}/{block_index}`；
+6. flat cache key、dirty writeback key 和现有后台任务不增加 workspace 维度；
+7. 普通 volume 不查询 workspace schema，不启动 workspace lease/watch/GC/compaction；
+8. legacy volume 不允许通过 mount 参数直接转换成 workspace volume；
+9. flat-only binary 遇到 `workspace-v1` volume 必须返回
+   `FeatureNotCompiled("workspace-overlay")`；
+10. workspace backend 的错误不得回退为 flat semantics。
+
+## 3. Feature 与启动分流
+
+### 3.1 Cargo feature
+
+在根 `Cargo.toml` 增加：
+
+```toml
+[features]
+default = ["fuse-io-uring-runtime"]
+workspace-overlay = ["dep:bincode", "dep:blake3"]
+```
+
+workspace-only dependency 必须声明为 `optional = true` 并由该 feature 开启。v1 应优先复用
+现有依赖，不新增必选 dependency。
+
+### 3.2 Module 声明
+
+`src/lib.rs` 与 `src/main.rs`：
+
+```rust
+#[cfg(feature = "workspace-overlay")]
+pub mod workspace_overlay;
+```
+
+### 3.3 Volume marker
+
+配置增加 `volume_format`，旧配置缺省为 `flat-v1`。composition root 先依据配置分流；普通
+配置不探测或查询 workspace schema。
+
+workspace path 随后从独立 header 读取不可变 marker 并交叉校验：
+
+```text
+volume_format = "workspace-v1"
+schema_version = 1
+volume_id = UUID
+```
+
+不得通过猜测 delta 表是否存在来判断 format。配置声明 `workspace-v1` 但 header 缺失或
+不匹配时返回 corruption；配置声明 flat 时不读取该 header。
+
+### 3.4 Mount-time 分流
+
+只允许在 composition root 分流一次：
+
+```rust
+match volume_format {
+    VolumeFormat::FlatV1 => mount_flat(config).await,
+    #[cfg(feature = "workspace-overlay")]
+    VolumeFormat::WorkspaceV1 => mount_workspace(config).await,
+    #[cfg(not(feature = "workspace-overlay"))]
+    VolumeFormat::WorkspaceV1 => Err(FeatureNotCompiled("workspace-overlay")),
+}
+```
+
+flat path 保持：
+
+```text
+MetaStore -> MetaClient<MetaStore> -> VFS<S, MetaClient<R>>
+```
+
+workspace path 使用：
+
+```text
+WorkspaceStore -> WorkspaceMetaLayer<W> -> VFS<S, WorkspaceMetaLayer<W>>
+```
+
+选择完成后，不在每个 FUSE syscall 中检查 `workspace_enabled`。
+
+## 4. 目录与依赖边界
+
+新增：
+
+```text
+src/workspace_overlay/
+  mod.rs
+  error.rs
+  ids.rs
+  model.rs
+  catalog.rs
+  digest.rs
+  resolver/
+    mod.rs
+    chain.rs
+    dentry.rs
+    inode.rs
+    extent.rs
+    xattr.rs
+  meta_layer/
+    mod.rs
+    namespace.rs
+    attributes.rs
+    data.rs
+    locks.rs
+  lifecycle/
+    mod.rs
+    create.rs
+    seal.rs
+    fork.rs
+    discard.rs
+    lease.rs
+    recovery.rs
+  publish/
+    mod.rs
+    diff.rs
+    commit.rs
+    conflict.rs
+  stores/
+    mod.rs
+    database.rs
+    kv_backend.rs
+    kv_store.rs
+    redis.rs
+    tikv.rs
+  cache.rs
+  gc.rs
+  compaction.rs
+  control.rs
+  metrics.rs
+
+src/chunk/read_plan.rs
+```
+
+依赖规则：
+
+```text
+workspace_overlay -> meta::MetaLayer / chunk / vfs stable types
+workspace_overlay -> WorkspaceStore implementations
+chunk::read_plan  -X-> workspace_overlay
+flat meta/vfs     -X-> workspace_overlay
+composition root  -> flat path + workspace path
+```
+
+`src/chunk/read_plan.rs` 是 feature-gated 的中立执行类型，不得包含 `WorkspaceId`、`LayerId`
+或 workspace backend 逻辑。
+
+## 5. 核心类型
+
+所有 ID 使用 newtype，禁止在内部 API 中传裸 `String`：
+
+```rust
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub struct WorkspaceId(Uuid);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub struct LayerId(Uuid);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub struct LeaseId(Uuid);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub struct JournalId(Uuid);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub struct SnapshotId(Uuid);
+```
+
+### 5.1 BaseRevision
+
+```rust
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct BaseRevision {
+    pub layer_id: LayerId,
+    pub sealed_version: u64,
+    pub root_hash: [u8; 32],
+}
+```
+
+### 5.2 ViewContext
+
+一个 writable mount 绑定一个 workspace：
+
+```rust
+pub struct ViewContext {
+    pub workspace_id: WorkspaceId,
+    pub head_layer_id: LayerId,
+    pub head_epoch: u64,
+    pub lease_id: LeaseId,
+    pub holder_generation: u64,
+}
+```
+
+`head_epoch` 仅在 seal/restack、recovery head replacement 或 commit 时增加。普通 metadata
+mutation 不增加 head epoch。
+
+### 5.3 状态枚举
+
+```rust
+pub enum WorkspaceState {
+    Active,
+    Quiescing,
+    Sealing,
+    Deleting,
+    Error,
+}
+
+pub enum LayerState {
+    Writable,
+    Sealing,
+    Sealed,
+    Deleting,
+}
+
+pub enum LeaseState {
+    Active,
+    Releasing,
+    Released,
+    Expired,
+}
+```
+
+sealed layer 永不可修改；active workspace 恰好有一个 writable head 和一个平坦 sealed
+base。固定不变量为 `writable(depth=2) -> sealed(depth=1) -> null`，不得把 sealed ancestry
+暴露给挂载数据路径。
+
+### 5.4 持久 enum 编码
+
+持久 discriminant 固定如下，后续不得重排：
+
+```text
+WorkspaceState: Active=0, Quiescing=1, Sealing=2, Deleting=3, Error=4
+LayerState:     Writable=0, Sealing=1, Sealed=2, Deleting=3
+LeaseState:     Active=0, Releasing=1, Released=2, Expired=3
+DentryOp:       Put=0, Whiteout=1
+InodeState:     Present=0, Deleted=1
+ValueOp:        Put=0, Whiteout=1
+ExtentKind:     Data=0, Hole=1
+SealPhase:      Prepare=0, Quiesced=1, DataDrained=2, Hashed=3,
+                HeadSwitched=4, Completed=5, Aborted=6
+```
+
+未知值返回 `UnsupportedSchemaVersion` 或 `CorruptMetadata`，不得映射到默认状态。
+
+## 6. WorkspaceStore 接口
+
+`WorkspaceStore` 与现有 `MetaStore` 完全独立：
+
+```rust
+#[async_trait]
+pub trait WorkspaceStore: Send + Sync {
+    fn name(&self) -> &'static str;
+    fn capabilities(&self) -> WorkspaceStoreCapabilities;
+
+    async fn initialize_workspace_schema(&self) -> Result<(), WorkspaceError>;
+    async fn load_workspace(&self, id: WorkspaceId) -> Result<WorkspaceRecord, WorkspaceError>;
+    async fn load_layer(&self, id: LayerId) -> Result<LayerRecord, WorkspaceError>;
+    async fn load_layer_chain(&self, head: LayerId) -> Result<Vec<LayerRecord>, WorkspaceError>;
+
+    async fn create_volume_root(&self, request: CreateVolumeRoot) -> Result<WorkspaceRecord, WorkspaceError>;
+    async fn create_workspace(&self, request: CreateWorkspace) -> Result<WorkspaceRecord, WorkspaceError>;
+    async fn create_snapshot(&self, request: CreateSnapshot) -> Result<SnapshotRecord, WorkspaceError>;
+    async fn load_snapshot(&self, id: SnapshotId) -> Result<SnapshotRecord, WorkspaceError>;
+    async fn delete_snapshot(&self, id: SnapshotId) -> Result<(), WorkspaceError>;
+
+    async fn acquire_lease(&self, request: AcquireLease) -> Result<SnapshotLease, WorkspaceError>;
+    async fn renew_lease(&self, request: RenewLease) -> Result<SnapshotLease, WorkspaceError>;
+    async fn release_lease(&self, request: ReleaseLease) -> Result<(), WorkspaceError>;
+
+    async fn get_dentry_deltas(&self, request: DentryQuery) -> Result<Vec<DentryDelta>, WorkspaceError>;
+    async fn get_inode_deltas(&self, request: InodeQuery) -> Result<Vec<InodeDelta>, WorkspaceError>;
+    async fn get_extent_deltas(&self, request: ExtentQuery) -> Result<Vec<DataExtentDelta>, WorkspaceError>;
+    async fn get_xattr_deltas(&self, request: XattrQuery) -> Result<Vec<XattrDelta>, WorkspaceError>;
+    async fn get_acl_deltas(&self, request: AclQuery) -> Result<Vec<AclDelta>, WorkspaceError>;
+
+    async fn apply_namespace_mutation(&self, request: NamespaceMutation) -> Result<MutationResult, WorkspaceError>;
+    async fn apply_inode_mutation(&self, request: InodeMutation) -> Result<FileAttr, WorkspaceError>;
+    async fn append_data_extent(&self, request: AppendDataExtent) -> Result<(), WorkspaceError>;
+    async fn apply_xattr_mutation(&self, request: XattrMutation) -> Result<(), WorkspaceError>;
+    async fn apply_acl_mutation(&self, request: AclMutation) -> Result<(), WorkspaceError>;
+    async fn apply_lock_mutation(&self, request: LockMutation) -> Result<(), WorkspaceError>;
+
+    async fn begin_seal(&self, request: BeginSeal) -> Result<SealJournal, WorkspaceError>;
+    async fn advance_seal(&self, request: AdvanceSeal) -> Result<SealJournal, WorkspaceError>;
+    async fn commit_seal(&self, request: CommitSeal) -> Result<SealResult, WorkspaceError>;
+    async fn abort_recoverable_seal(&self, request: AbortSeal) -> Result<(), WorkspaceError>;
+
+    async fn fork_revision(&self, request: ForkRevision) -> Result<Vec<WorkspaceRecord>, WorkspaceError>;
+    async fn fast_forward_commit(&self, request: FastForwardCommit) -> Result<CommitResult, WorkspaceError>;
+    async fn mark_workspace_deleting(&self, request: MarkDeleting) -> Result<(), WorkspaceError>;
+
+    async fn list_gc_roots(&self) -> Result<GcRoots, WorkspaceError>;
+    async fn list_layers(&self, cursor: GcCursor) -> Result<LayerPage, WorkspaceError>;
+    async fn delete_layer_metadata(&self, request: DeleteLayerMetadata) -> Result<(), WorkspaceError>;
+}
+```
+
+### 6.1 Mutation guard
+
+所有 mutation 请求必须携带：
+
+```rust
+pub struct HeadGuard {
+    pub workspace_id: WorkspaceId,
+    pub expected_head_layer_id: LayerId,
+    pub expected_head_epoch: u64,
+    pub lease_id: LeaseId,
+    pub holder_generation: u64,
+}
+```
+
+backend 在同一事务中检查：
+
+1. workspace state 为 `Active`；
+2. head ID 和 epoch 匹配；
+3. head state 为 `Writable`；
+4. lease 为 `Active` 且未过期；
+5. holder generation 匹配。
+
+任一不匹配返回 `WorkspaceError::Fenced`，不得重试到新 head。
+
+### 6.2 Capability
+
+```rust
+pub struct WorkspaceStoreCapabilities {
+    pub atomic_head_switch: bool,
+    pub durable_lease: bool,
+    pub transactional_namespace_mutation: bool,
+    pub transactional_rename: bool,
+    pub watch_head_change: bool,
+}
+```
+
+v1 mount 要求前四项均为 true；缺失时返回 `UnsupportedCapability`。
+
+### 6.3 Redis/TiKV 事务 substrate
+
+Redis 与 TiKV 共用 `WorkspaceKvBackend` 和 `KvWorkspaceStore<B>`，不得复制两套
+`WorkspaceStore` 状态机。backend 必须提供：
+
+```rust
+async fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, WorkspaceError>;
+async fn scan_prefix(&self, prefix: &[u8]) -> Result<Vec<KvEntry>, WorkspaceError>;
+async fn compare_and_swap(
+    &self,
+    checks: &[KvCheck],
+    writes: &[KvWrite],
+) -> Result<bool, WorkspaceError>;
+async fn server_time_ns(&self) -> Result<i64, WorkspaceError>;
+```
+
+`compare_and_swap` 必须原子检查全部 expected value 并应用全部 put/delete；条件不匹配返回
+`false`，不得产生部分写。`control` 只串行化 seal/fork/snapshot/GC 等低频拓扑转换；
+workspace head、writable layer、lease 和 allocator 均有独立 hot record。普通 mutation 只 CAS
+当前 workspace/head/lease，并在同一事务提交 delta key；lease heartbeat 只 CAS 对应 lease，
+allocator 只 CAS 对应名称。不同 workspace 的热路径不得读取、锁定或写入 `control`，也不得
+共享进程内 mutex。拓扑转换会读取全部 hot records，并在同一 backend transaction 中检查
+它们、更新 `control` 和发生变化的 hot records，保证跨 mount 正确性。
+
+持久记录使用 bincode，并带固定 envelope magic `BWSKV001`。未知 magic、解码失败或
+schema version 不匹配必须 fail-closed。
+
+逻辑 key schema：
+
+```text
+control
+hot/workspace/<workspace-id>
+hot/layer/<layer-id>
+hot/lease/<lease-id>
+hot/allocator/<allocator-name>
+delta/dentry/<layer>/<parent-ino-order-key>/<hex-name>
+delta/inode/<layer>/<ino-order-key>
+delta/xattr/<layer>/<ino-order-key>/<hex-name>
+delta/acl/<layer>/<ino-order-key>/<acl-type>/<acl-id-order-key>
+delta/extent/<layer>/<ino-order-key>/<chunk-index>/<sequence>
+```
+
+inode、chunk 和 sequence 使用固定宽度、保持数值顺序的十六进制 component；文件名和
+xattr name 使用原始 bytes 的 hex，禁止 UTF-8 有损转换。layer 删除必须先进入
+`Deleting`，再按 layer prefix 删除所有 delta，最后 CAS 删除 control metadata。
+
+Redis 物理前缀为 `{brewfs-ws-v1}:<workspace-namespace>:ws:v1/`。固定 hash tag 保证
+Redis Cluster 中 Lua 涉及的所有 key 位于同一 slot；CAS 使用 binary-safe Lua，lease
+到期时间使用 Redis `TIME`。
+
+TiKV 物理前缀为 `<workspace-namespace>/ws:v1/`。CAS 使用 pessimistic transaction 和
+`get_for_update` 锁定本次 CAS 的实体 keys，冲突执行有界重试；prefix scan 使用同一只读
+事务和分页 range。lease 的当前时间必须来自 `TransactionClient::current_timestamp()` 的
+PD TSO physical 毫秒分量并安全换算为纳秒，禁止使用 mount host wall clock。
+
+`workspace-namespace` 只允许 ASCII 字母、数字、`-`、`_`、`.`，为空或包含其他字符时
+启动失败。不同 volume 必须使用不同 namespace。
+
+## 7. 数据库 schema
+
+本节定义 SQLite 参考实现。SQLite 表统一使用 `ws_v1_` 前缀，不得修改现有 flat 表；
+Redis/TiKV 使用 6.3 节的 backend-neutral key schema。
+
+### 7.1 Volume header
+
+```sql
+CREATE TABLE ws_v1_volume_header (
+    singleton_id          INTEGER PRIMARY KEY CHECK(singleton_id = 1),
+    volume_format         TEXT NOT NULL,
+    schema_version        INTEGER NOT NULL,
+    volume_id             BLOB NOT NULL,
+    created_at_ns         INTEGER NOT NULL
+);
+```
+
+该表只由 workspace path 读取。初始化时 header 最后插入；已存在 header 时字段不可修改。
+
+### 7.2 Workspace
+
+```sql
+CREATE TABLE ws_v1_workspaces (
+    workspace_id          BLOB PRIMARY KEY,
+    head_layer_id         BLOB NOT NULL,
+    head_epoch            INTEGER NOT NULL,
+    fork_base_layer_id    BLOB,
+    fork_base_version     INTEGER,
+    fork_base_root_hash   BLOB,
+    owner_id              TEXT,
+    state                 INTEGER NOT NULL,
+    created_at_ns         INTEGER NOT NULL,
+    updated_at_ns         INTEGER NOT NULL
+);
+```
+
+### 7.3 Layer
+
+```sql
+CREATE TABLE ws_v1_layers (
+    layer_id              BLOB PRIMARY KEY,
+    parent_layer_id       BLOB,
+    state                 INTEGER NOT NULL,
+    schema_version        INTEGER NOT NULL,
+    sealed_version        INTEGER,
+    delta_digest          BLOB,
+    root_hash             BLOB,
+    depth                 INTEGER NOT NULL,
+    owner_workspace_id    BLOB,
+    next_sequence         INTEGER NOT NULL,
+    owned_slice_count     INTEGER NOT NULL DEFAULT 0,
+    owned_bytes           INTEGER NOT NULL DEFAULT 0,
+    created_at_ns         INTEGER NOT NULL,
+    sealed_at_ns          INTEGER
+);
+
+CREATE INDEX ws_v1_layers_parent_idx ON ws_v1_layers(parent_layer_id);
+```
+
+`parent_layer_id` 创建后不可修改。只有 writable layer 的 `owner_workspace_id` 可以执行
+mutation。
+
+### 7.4 Dentry delta
+
+```sql
+CREATE TABLE ws_v1_dentry_delta (
+    layer_id              BLOB NOT NULL,
+    parent_ino            INTEGER NOT NULL,
+    name                  BLOB NOT NULL,
+    op                    INTEGER NOT NULL,
+    ino                   INTEGER,
+    entry_type            INTEGER,
+    sequence              INTEGER NOT NULL,
+    PRIMARY KEY(layer_id, parent_ino, name)
+);
+
+CREATE INDEX ws_v1_dentry_parent_idx
+    ON ws_v1_dentry_delta(layer_id, parent_ino);
+```
+
+`op` 为 `Put` 或 `Whiteout`。name 按原始字节保存；进入 FUSE/MetaLayer 边界时继续遵守当前
+BrewFS 的名称校验规则。
+
+### 7.5 Inode delta
+
+```sql
+CREATE TABLE ws_v1_inode_delta (
+    layer_id              BLOB NOT NULL,
+    ino                   INTEGER NOT NULL,
+    state                 INTEGER NOT NULL,
+    kind                  INTEGER NOT NULL,
+    size                  INTEGER NOT NULL,
+    mode                  INTEGER NOT NULL,
+    uid                   INTEGER NOT NULL,
+    gid                   INTEGER NOT NULL,
+    rdev                  INTEGER NOT NULL,
+    nlink                 INTEGER NOT NULL,
+    atime_ns              INTEGER NOT NULL,
+    mtime_ns              INTEGER NOT NULL,
+    ctime_ns              INTEGER NOT NULL,
+    symlink_target        BLOB,
+    parent_hint           INTEGER,
+    data_version          INTEGER NOT NULL,
+    sequence              INTEGER NOT NULL,
+    PRIMARY KEY(layer_id, ino)
+);
+```
+
+第一次修改 lower inode 时只 copy-up有效 `FileAttr`，不复制文件数据。
+
+### 7.6 Xattr 与 ACL delta
+
+```sql
+CREATE TABLE ws_v1_xattr_delta (
+    layer_id              BLOB NOT NULL,
+    ino                   INTEGER NOT NULL,
+    name                  BLOB NOT NULL,
+    op                    INTEGER NOT NULL,
+    value                 BLOB,
+    sequence              INTEGER NOT NULL,
+    PRIMARY KEY(layer_id, ino, name)
+);
+
+CREATE TABLE ws_v1_acl_delta (
+    layer_id              BLOB NOT NULL,
+    ino                   INTEGER NOT NULL,
+    acl_type              INTEGER NOT NULL,
+    acl_id                INTEGER NOT NULL,
+    op                    INTEGER NOT NULL,
+    value                 BLOB,
+    sequence              INTEGER NOT NULL,
+    PRIMARY KEY(layer_id, ino, acl_type, acl_id)
+);
+```
+
+remove 操作写 `Whiteout`，不能删除 upper row。
+
+### 7.7 Data extent delta
+
+```sql
+CREATE TABLE ws_v1_data_extent_delta (
+    layer_id              BLOB NOT NULL,
+    ino                   INTEGER NOT NULL,
+    chunk_index           INTEGER NOT NULL,
+    logical_offset        INTEGER NOT NULL,
+    length                INTEGER NOT NULL,
+    kind                  INTEGER NOT NULL,
+    slice_id              INTEGER,
+    slice_offset          INTEGER,
+    sequence              INTEGER NOT NULL,
+    PRIMARY KEY(layer_id, ino, chunk_index, sequence)
+);
+
+CREATE INDEX ws_v1_extent_lookup_idx
+    ON ws_v1_data_extent_delta(layer_id, ino, chunk_index, sequence);
+```
+
+约束：
+
+- `Data`：`slice_id` 与 `slice_offset` 非空；
+- `Hole`：两者为空；
+- offset/length 均为 chunk-local；
+- `length > 0`；
+- `logical_offset + length <= chunk_size`；
+- 同一 layer 内 sequence 单调递增。
+
+### 7.8 Lease
+
+```sql
+CREATE TABLE ws_v1_snapshot_leases (
+    lease_id              BLOB PRIMARY KEY,
+    workspace_id          BLOB NOT NULL,
+    base_layer_id         BLOB NOT NULL,
+    base_version          INTEGER NOT NULL,
+    base_root_hash        BLOB NOT NULL,
+    holder_generation     INTEGER NOT NULL,
+    writable              INTEGER NOT NULL,
+    state                 INTEGER NOT NULL,
+    expires_at_ns         INTEGER NOT NULL,
+    created_at_ns         INTEGER NOT NULL,
+    updated_at_ns         INTEGER NOT NULL
+);
+
+CREATE UNIQUE INDEX ws_v1_one_writer_idx
+    ON ws_v1_snapshot_leases(workspace_id)
+    WHERE writable = 1 AND state = 0;
+```
+
+v1 每个 workspace 最多一个 writable lease。`writable` 字段为后续 read-only mount 预留；
+v1 mount 请求只能创建 `writable=1`。snapshot 通过 `ws_v1_snapshots` 本身成为 GC root，不能
+直接挂载；需要读取 snapshot 时先 fork 成 workspace。
+
+### 7.9 Snapshot
+
+```sql
+CREATE TABLE ws_v1_snapshots (
+    snapshot_id           BLOB PRIMARY KEY,
+    name                  TEXT,
+    layer_id              BLOB NOT NULL,
+    sealed_version        INTEGER NOT NULL,
+    root_hash             BLOB NOT NULL,
+    owner_id              TEXT,
+    created_at_ns         INTEGER NOT NULL
+);
+
+CREATE UNIQUE INDEX ws_v1_snapshot_name_idx
+    ON ws_v1_snapshots(name)
+    WHERE name IS NOT NULL;
+```
+
+snapshot 是 sealed `BaseRevision` 的持久 GC root。删除 snapshot 只删除 root reference，由 GC
+决定 layer/object 回收。
+
+### 7.10 Journal 与 allocator
+
+```sql
+CREATE TABLE ws_v1_seal_journal (
+    journal_id            BLOB PRIMARY KEY,
+    workspace_id          BLOB NOT NULL,
+    old_head_layer_id     BLOB NOT NULL,
+    expected_head_epoch   INTEGER NOT NULL,
+    phase                 INTEGER NOT NULL,
+    pending_bytes         INTEGER NOT NULL,
+    delta_digest          BLOB,
+    root_hash             BLOB,
+    new_head_layer_id     BLOB,
+    last_error            TEXT,
+    created_at_ns         INTEGER NOT NULL,
+    updated_at_ns         INTEGER NOT NULL
+);
+
+CREATE TABLE ws_v1_allocators (
+    name                  TEXT PRIMARY KEY,
+    next_value            INTEGER NOT NULL
+);
+```
+
+allocator 至少包含 `inode`、`sealed_version`。slice ID 继续使用现有 volume-global allocator。
+
+## 8. Layer digest
+
+seal 时计算：
+
+```text
+delta_digest = BLAKE3(canonical layer delta stream)
+root_hash    = BLAKE3(schema_version || parent_root_hash || delta_digest)
+```
+
+canonical stream 规则：
+
+1. 表顺序固定为 dentry、inode、xattr、acl、extent；
+2. 每张表按完整 primary key 升序；
+3. integer 使用 big-endian 固定宽度；
+4. bytes/string 使用 `u64 length + raw bytes`；
+5. nullable 字段先写一字节 presence；
+6. enum 写稳定的显式 `u8` discriminant；
+7. schema version 进入 digest；
+8. 不使用 JSON、Debug 输出或数据库行的隐式顺序。
+
+`digest.rs` 提供唯一的编码实现和 golden fixtures。
+
+## 9. Resolver
+
+resolver 必须是无 I/O 的纯逻辑；store 负责批量加载固定 layer pair 和 delta，resolver 只处理
+已加载 records。
+
+### 9.1 Fixed layer pair
+
+`load_layer_chain(head)` 为兼容 store contract 保留，但挂载只能接受：
+
+```text
+[writable head, flat sealed base]
+```
+
+校验：
+
+- 长度必须为 2；
+- head 为 writable、depth=2、parent 指向 base；
+- base 为 sealed、depth=1、parent 为空；
+- point lookup 使用一次 Redis `MGET` 或 TiKV batch-get 读取两个完整 key；
+- named dentry/inode/xattr/ACL 查询不得调用 prefix scan。
+
+### 9.2 Lookup
+
+对 `(parent_ino, name)` 从 newest 向 root：
+
+1. 命中 `Put`：返回 ino/type；
+2. 命中 `Whiteout`：返回 `None`；
+3. 未命中：继续 lower；
+4. base 未命中：返回 `None`。
+
+### 9.3 Readdir
+
+1. 对 upper 和 base 查询 `(layer_id, parent_ino)` 的局部索引；
+2. newest-first 插入 `BTreeMap<name, Winner>`；
+3. 已有 winner 的 name 不再被 lower 覆盖；
+4. whiteout 进入 winner map，但最终不输出；
+5. 输出按当前 BrewFS readdir 稳定排序规则；
+6. `.` 与 `..` 继续由 VFS/MetaLayer 当前语义生成，不存 dentry delta。
+
+### 9.4 Inode
+
+从 newest 向 root 返回第一个 inode row：
+
+- `Present` 返回属性；
+- `Deleted` 返回不存在；
+- 未命中继续 lower。
+
+写属性前先 resolve effective inode，再将完整结果 copy-up 到 head 后修改目标字段。
+
+### 9.5 Xattr/ACL
+
+按 `(ino, name)` 或 `(ino, type, id)` newest-wins。Whiteout 停止 lower lookup。
+
+### 9.6 Extent
+
+workspace 持久类型：
+
+```rust
+pub enum ExtentKind {
+    Data { slice_id: u64, slice_offset: u64 },
+    Hole,
+}
+
+pub struct LayerExtent {
+    pub layer_id: LayerId,
+    pub logical_offset: u64,
+    pub length: u64,
+    pub sequence: u64,
+    pub kind: ExtentKind,
+}
+```
+
+resolve 指定 chunk range：
+
+1. `uncovered = requested range`；
+2. layer newest-first；
+3. 同一 layer sequence 从大到小；
+4. extent 与 uncovered 相交的部分成为 winner；
+5. `Data` winner 计算：
+
+```text
+resolved.slice_offset = extent.slice_offset + intersection.start - extent.logical_offset
+```
+
+6. `Hole` winner 只从 uncovered 中切除，对应结果保持为零；
+7. 未被任何 extent 覆盖的范围为零；
+8. 最终 plan 按 logical offset 升序、无重叠。
+
+必须使用 checked arithmetic；overflow 返回 `CorruptMetadata`。
+
+## 10. Chunk read plan 接缝
+
+`src/chunk/read_plan.rs`：
+
+```rust
+pub enum ReadPlanSegment {
+    Data {
+        logical_offset: u64,
+        length: u64,
+        slice_id: u64,
+        slice_offset: u64,
+    },
+    Zero {
+        logical_offset: u64,
+        length: u64,
+    },
+}
+
+pub struct ResolvedReadPlan {
+    pub segments: Vec<ReadPlanSegment>,
+}
+```
+
+executor：
+
+1. 调用方 buffer 先清零；
+2. `Zero` 不触发 BlockStore 请求；
+3. `Data` 使用 `block_span_iter_slice(slice_offset, length, layout)`；
+4. block key 仍为 `(slice_id, block_index)`；
+5. 继续使用现有 clean cache、singleflight、checksum 和并发读取；
+6. 每个 segment 写入互不重叠的 buffer range；
+7. plan 越界或重叠返回 `InvalidReadPlan`。
+
+### 10.1 Backend provider
+
+feature 内新增中立 trait：
+
+```rust
+#[async_trait]
+pub trait WorkspaceReadPlanProvider: Send + Sync {
+    async fn read_plan(
+        &self,
+        ino: i64,
+        chunk_index: u64,
+        offset: u64,
+        len: u64,
+    ) -> Result<ResolvedReadPlan, MetaError>;
+
+    async fn range_has_data(
+        &self,
+        ino: i64,
+        offset: u64,
+        len: u64,
+    ) -> Result<bool, MetaError>;
+}
+```
+
+`WorkspaceMetaLayer<W>` 实现该 trait。
+
+`Backend` 在 feature build 下增加：
+
+```rust
+workspace_read_plan: Option<Arc<dyn WorkspaceReadPlanProvider>>
+```
+
+- 当前 `Backend::new` 设置为 `None`；
+- 新增 `Backend::new_workspace` 设置 provider；
+- feature 未启用时该字段和相关代码不编译。
+
+### 10.2 FileReader
+
+`read_chunk_span_into`：
+
+```text
+provider == None:
+    保持当前 chunk_slices -> DataFetcher::read_at_into_from_slices
+
+provider != None:
+    provider.read_plan(...)
+    chunk::read_plan::execute_into(...)
+```
+
+workspace path 不写入当前 `chunk_slices: DashMap<u64, Vec<SliceDesc>>`。有效 plan cache 由
+`WorkspaceMetaLayer` 管理，key 为：
+
+```text
+(workspace_id, head_epoch, ino, chunk_index, inode_data_version)
+```
+
+write/truncate/punch-hole 后增加 inode `data_version` 并删除对应 plan cache。
+
+VFS 当前 `range_has_committed_slices()` 在 workspace provider 存在时必须改调
+`range_has_data()`；flat path 保持当前 `get_slices()` 实现。
+
+## 11. WorkspaceMetaLayer
+
+`WorkspaceMetaLayer<W: WorkspaceStore>` 实现现有 `MetaLayer`。它持有：
+
+```rust
+pub struct WorkspaceMetaLayer<W> {
+    store: Arc<W>,
+    view: ArcSwap<ViewContext>,
+    resolver_cache: WorkspaceResolverCache,
+    root_ino: AtomicI64,
+    session: WorkspaceSession,
+}
+```
+
+### 11.1 禁止的实现方式
+
+- 不在 `WorkspaceMetaLayer` 内调用 flat `MetaStore` mutation；
+- 不让未实现方法静默委托给 flat store；
+- 不通过 downcast 判断具体 backend；
+- 不把 workspace ID编码进 inode、chunk ID 或 slice ID；
+- 不缓存不带 `head_epoch/data_version` 的有效 view。
+
+### 11.2 MetaLayer 方法覆盖清单
+
+以下必须在 v1 实现，不得返回 `NotImplemented`：
+
+```text
+initialize/stat_fs
+stat/stat_fresh/stat_for_open
+lookup/lookup_with_attr/lookup_path/readdir/opendir
+mkdir/rmdir/create_file/create_node/link/symlink/unlink
+rename/rename_exchange/rename_with_flags/can_rename
+set_file_size/extend_file_size/truncate/fallocate_file
+get_names/get_dentries/get_dir_parent/get_paths/read_symlink
+set_attr/chmod/chown/open/close
+write/append_slice/invalidate_chunk_slices
+next_id
+start_session/shutdown_session
+get_plock/set_plock/get_flock/set_flock
+set_xattr/get_xattr/list_xattr/remove_xattr
+set_acl/get_acl
+```
+
+workspace `get_slices` 无法无损表达 Hole 与裁剪后的 `slice_offset`，因此明确返回
+`NotSupported("workspace view requires read_plan")`。所有已知调用点必须在 workspace path
+改用 `WorkspaceReadPlanProvider`：FileReader 使用 `read_plan()`，
+`range_has_committed_slices()` 使用 `range_has_data()`，flat compactor 在 workspace mount
+禁用。不得返回丢失 Hole 的伪 slice list。
+
+其他 maintenance 方法：
+
+- `get_deleted_files()` 返回空集合，删除回收由 workspace GC 管理；
+- `remove_file_metadata()` 返回 NotSupported，只允许 GC 通过 WorkspaceStore 删除；
+- `stat_fs()` 不得为每次调用遍历 layer graph。Redis、TiKV、SQLite 尚未持久化并在 mutation
+  transaction 内原子更新 usage counter 时，必须明确返回 `NotSupported`，不得伪报零 usage
+  或返回非一致快照；计数器落地后再返回 volume-wide capacity/inode limit，并分别通过
+  workspace metrics 报告 private/shared bytes。
+
+### 11.3 Cache
+
+独立 cache：
+
+```text
+effective inode:  (head_epoch, ino, inode_version)
+dentry:           (head_epoch, parent_ino, name)
+readdir:           (head_epoch, parent_ino, dir_version)
+read plan:         (head_epoch, ino, chunk_index, data_version)
+xattr/ACL:         (head_epoch, ino, attribute_version)
+```
+
+namespace mutation 增加相关 parent/inode version 并精确失效。seal/restack 后 effective view
+不变，但更新 head epoch 并清空 writable-head mutation cache；sealed lower cache可按
+`BaseRevision` 保留。
+
+## 12. POSIX mutation
+
+所有多 row 操作在一个 WorkspaceStore transaction 中执行，并使用同一个 `HeadGuard`。
+
+### 12.1 Create/mkdir/symlink/mknod
+
+1. resolve parent 并校验权限；
+2. resolve 同名 dentry，存在则返回 `AlreadyExists`；
+3. 从 volume-global inode allocator 取新 inode；
+4. head 写 `InodeDelta::Present`；
+5. head 写 `DentryDelta::Put`；
+6. 更新 parent mtime/ctime/version；
+7. 同一事务提交。
+
+### 12.2 Unlink
+
+1. resolve dentry 与 inode；
+2. head 写 dentry Whiteout；
+3. copy-up inode 并减少 nlink；
+4. nlink 到零时写 `InodeDelta::Deleted`，但 open handle 仍保留运行期引用；
+5. 更新 parent；
+6. close 最后一个 handle 后才允许 GC inode 私有数据。
+
+### 12.3 Rmdir
+
+除 unlink 步骤外，必须对 effective readdir 判空。只检查 head rows 不足以判断 lower child。
+
+### 12.4 Rename
+
+一个事务内：
+
+1. resolve source、destination 和两个 parent；
+2. 校验类型、权限、sticky bit、目录循环和 replace 规则；
+3. source 写 Whiteout；
+4. destination 写 Put；
+5. 被替换 destination 更新 nlink/deleted state；
+6. 目录移动更新 parent hint 与 `..` 语义；
+7. 更新两个 parent 时间/version；
+8. commit。
+
+`RENAME_EXCHANGE` 同时写两个 Put，不产生短暂缺失状态。
+
+### 12.5 Hardlink
+
+inode number 不变；head 增加 dentry Put，并 copy-up inode 增加 nlink。child workspace 的
+nlink 变化不得影响 sibling。
+
+### 12.6 Setattr/xattr/ACL
+
+resolve effective value，copy-up 到 head 后修改。remove 写 Whiteout。
+
+### 12.7 Locks
+
+flock/plock key 必须包含 `workspace_id`。不同 workspace 的同 inode 不互相阻塞；同一
+workspace 的多个 handle 继续遵守当前 BrewFS lock 语义。
+
+### 12.8 Atime
+
+沿用当前 BrewFS mount 的 atime/relatime/noatime 策略，但任何实际发生的 atime mutation 都
+必须 copy-up 到 workspace head。不得更新 sealed lower inode。性能测试需要单独记录纯读取
+是否因为 atime 产生 private metadata；agent workspace 推荐默认 relatime 或 noatime。
+
+## 13. 数据写入
+
+### 13.1 普通 write
+
+现有 DataWriter 继续创建新 `slice_id` 并上传 immutable block。提交 metadata 时，
+`WorkspaceMetaLayer::write` 转换：
+
+```text
+SliceDesc {
+  slice_id,
+  chunk_id,
+  offset,
+  length
+}
+
+=>
+
+DataExtentDelta::Data {
+  logical_offset = offset,
+  length,
+  slice_id,
+  slice_offset = 0,
+  sequence = next_layer_sequence
+}
+```
+
+同一 transaction 更新 inode size、mtime/ctime、data_version。不得向 flat slice table
+append。
+
+### 13.2 Truncate
+
+shrink `old_size -> new_size`：
+
+1. 更新 inode size；
+2. 对 `[new_size, old_size)` 按 chunk 拆分并追加 Hole extent；
+3. 增加 data_version；
+4. 同一事务提交。
+
+再次 extend 时未写区域读取为零，lower bytes 不得复活。
+
+truncate(0) v1 可以写覆盖已知有效范围的 Hole；后续优化可增加 chunk/file opaque marker，
+但不得改变可见语义。
+
+### 13.3 Punch hole / zero range
+
+- `FALLOC_FL_PUNCH_HOLE`：追加 Hole，不改变 size；
+- extend beyond EOF：只更新 size，新范围自然为零；
+- `ZERO_RANGE`：v1 使用 Hole 语义；若未来实现物理预分配，另行增加 extent kind；
+- keep-size/preallocation 必须保持当前 stat/statfs 约定。
+
+### 13.4 Write ordering
+
+同一 writable head 内使用当前 VFS/FUSE write ordering，并由 layer `sequence` 提供持久顺序。
+sequence 在追加 metadata 的事务内分配；不得根据 slice ID推断顺序。
+
+### 13.5 Metadata 可见性与 durability
+
+普通 write 提交 extent 前，新 slice 必须满足以下之一：
+
+1. object block 已 remote durable；或
+2. 已进入现有可 crash-recover 的 durable writeback staging/journal，且 staging key 可由
+   workspace recovery 唯一定位。
+
+seal/snapshot/fork 不接受第二种状态；`DurableRemote` barrier 必须把所有引用 slice 上传并
+确认 remote durable。
+
+若 object upload 成功后 HeadGuard 被 fence，metadata 不提交，该 slice 记录为 orphan并由
+grace GC 回收。不得把 mutation 自动重放到新 head。
+
+### 13.6 Workspace dirty key
+
+workspace persistent writeback/recovery key 必须包含：
+
+```text
+(volume_id, workspace_id, head_epoch, ino, chunk_index, local_sequence, writer_epoch)
+```
+
+workspace staging 目录使用：
+
+```text
+<cache-root>/workspace-v1/<volume-id>/<workspace-id>/<head-epoch>/...
+```
+
+不得修改 flat dirty key 格式。mount 时验证解析后的绝对 cache path 位于配置的 cache root
+内部。
+
+## 14. Workspace 生命周期
+
+### 14.1 创建 workspace volume
+
+事务内：
+
+1. 初始化 `ws_v1_*` schema；
+2. 分配 root inode；
+3. 创建 root sealed layer `L0`；
+4. root layer 写 root inode；
+5. 计算 root digest/revision；
+6. 创建 writable layer `L1(parent=L0)`；
+7. 创建默认 workspace 指向 L1；
+8. 写 volume marker。
+
+marker 最后写。marker 写入前失败可重试初始化；marker 存在但 schema 不完整视为 corruption。
+
+### 14.2 Mount
+
+1. 读取 format marker；
+2. 加载 workspace/head；
+3. 校验 chain；
+4. 获取 writable 或 read-only lease；
+5. 构造 `ViewContext`；
+6. 构造 `WorkspaceMetaLayer`；
+7. 构造 `Backend::new_workspace`；
+8. 启动 lease heartbeat；
+9. mount 成功后对外返回 session token。
+
+任何后续步骤失败必须释放 lease。agent 不获得 metadata/object backend credential。
+
+### 14.3 Seal/restack
+
+phase：
+
+```text
+Prepare -> Quiesced -> DataDrained -> Hashed -> HeadSwitched -> Completed
+```
+
+算法：
+
+1. 控制面阻止该 workspace 新 command；
+2. 等 active command 退出；超时返回 `Busy`；
+3. CAS workspace `Active -> Quiescing -> Sealing`；
+4. 创建 seal journal，记录 old head/epoch；
+5. fence 新 metadata mutation；
+6. 等待已接收 VFS mutation 完成；
+7. 执行 `DurableRemote` barrier，确认 pending upload/writeback 为零；
+8. materialize 固定 base 与 old head，计算平坦 delta/root hash 和 sealed version；
+9. 创建 parent 为空的新 sealed base，复用所有仍可见 immutable slice；
+10. 创建空 new head，parent 指向新 sealed base；
+11. 原子切换 workspace 和 active lease 到新的固定 layer pair，并增加 epoch；
+12. journal 标记 HeadSwitched/Completed；
+13. 更新 mount ViewContext，恢复 workspace Active 和 command admission。
+
+步骤 11 是唯一可见性切换点。实现允许 journal recovery 中出现短暂 sealed chain，但在重新
+mount 或恢复 command admission 前必须完成 flatten；普通 FUSE I/O 永远不可观察该状态。
+
+### 14.4 Fork
+
+输入必须是 `BaseRevision`。若从 active workspace fork，先 seal/restack，得到 sealed
+revision。
+
+事务内为每个 child：
+
+1. 创建 writable head，parent=base.layer_id；
+2. 创建 workspace record；
+3. 保存 fork base 的 layer/version/hash；
+4. 不遍历 inode、extent、slice 或 object。
+
+child mount 时再获取 lease。
+
+### 14.5 Snapshot
+
+`workspace snapshot`：
+
+1. 对 source 执行 seal/restack；
+2. 得到 sealed `BaseRevision`；
+3. 创建 `SnapshotRecord`；
+4. snapshot record 成功持久化后返回 snapshot ID/revision；
+5. 同名 snapshot 返回 `AlreadyExists`，不覆盖旧 snapshot。
+
+snapshot 创建失败不回滚已经成功的 seal；返回错误中携带 sealed revision，调用方可重试
+只创建 snapshot record。
+
+### 14.6 Discard
+
+1. 禁止新 mount/mutation；
+2. writable lease 必须释放或被管理员显式 fence；
+3. workspace 标记 Deleting；
+4. 删除 workspace head root reference；
+5. 由后台 GC 回收不可达 layer/object；
+6. 不同步递归删除 parent。
+
+### 14.7 Fast-forward commit
+
+v1 precondition：
+
+1. source 已 seal；
+2. target 没有 active writable lease；
+3. target writable head 为空，不含任何 delta；
+4. target head 的 sealed parent revision 与 source 的 `fork_base` 完整相等；
+5. source/target 属于同一 volume；
+6. source 的固定层对与 revision 校验通过。
+
+一个事务内：
+
+1. 再次比较 target revision；
+2. 创建 target new writable head，parent=source sealed head；
+3. 切换 target head并增加 epoch；
+4. 返回 commit revision。
+
+任一 precondition 失败返回 `Conflict`，target 不发生任何变化。v1 target 必须没有 active
+mount lease；commit 后的新 mount 看到新 revision。
+
+## 15. Lease 与 fencing
+
+### 15.1 Heartbeat
+
+- 默认 TTL：30 秒；
+- heartbeat：10 秒；
+- GC grace：至少 2 × TTL；
+- heartbeat 只允许相同 holder generation 延长；
+- wall clock 由 backend/server 产生，不信任客户端时间。
+
+### 15.2 Holder generation
+
+每次 mount/session 重建分配新的 generation。recovery 后旧 generation 的 heartbeat、write、
+seal continuation 全部返回 `Fenced`。
+
+### 15.3 Head switch
+
+head switch 增加 `head_epoch`。旧 epoch mutation 永久失败；调用方不得自动替换 guard 后重放
+非幂等 mutation。
+
+## 16. Crash recovery
+
+启动时扫描非终态 seal journal：
+
+| Journal phase | 恢复动作 |
+|---|---|
+| Prepare/Quiesced | 若 head 未切换，恢复旧 head Writable/Active 或继续 seal |
+| DataDrained | 验证 remote objects 后继续 hash/seal |
+| Hashed | 验证 digest 后创建/复用 new head并执行 CAS switch |
+| HeadSwitched | 保留新 head，完成 journal，不回滚 |
+| Completed | 可归档/清理 journal |
+
+恢复规则：
+
+- object 已上传但 metadata 未引用：进入 orphan grace；
+- metadata 不得引用不存在或未 durable 的 object；
+- head switch 前后必须得到旧 view 或新 view之一；
+- new head 创建操作用 journal ID 保证幂等；
+- 无法证明状态时将 workspace 设为 Error，不猜测继续。
+
+## 17. Diff
+
+v1 `workspace diff` 比较 fork base 与当前 sealed/head delta：
+
+```rust
+pub enum PathChangeKind {
+    Added,
+    Modified,
+    Deleted,
+    Renamed,
+    MetadataOnly,
+}
+
+pub struct PathChange {
+    pub path: Vec<u8>,
+    pub kind: PathChangeKind,
+    pub old_path: Option<Vec<u8>>,
+    pub ino: Option<i64>,
+    pub changed_ranges: Vec<Range<u64>>,
+}
+```
+
+规则：
+
+- dentry Whiteout -> Deleted；
+- Put 且 base 无同名 -> Added；
+- inode/extent/xattr/ACL delta -> Modified/MetadataOnly；
+- 相同 inode 从一个 path whiteout 到另一 path Put -> Renamed；
+- 无法唯一识别 rename 时输出 delete + add；
+- changed_ranges 来自 Data/Hole extents 的逻辑范围合并；
+- diff 只读 metadata，不下载 object payload。
+
+## 18. GC
+
+### 18.1 Roots
+
+mark roots：
+
+- 所有 workspace head；
+- 所有 active/releasing lease 的 base；
+- 所有非终态 journal 引用；
+- 所有管理员 snapshot/tag；
+- 正在构建的 compaction result。
+
+### 18.2 Layer mark
+
+从 root 沿 parent 标记 reachable layer。不可达 layer 超过 grace period 后才能进入 Deleting。
+
+### 18.3 Slice mark
+
+不能仅按 `owner_layer` 删除 object，因为 compaction layer 可能继续引用原 slice。每次 GC
+cycle 从所有 reachable layer 的 Data extent 标记 reachable slice ID：
+
+1. mark reachable layers；
+2. 扫描其 Data extent，构建 reachable slice set；
+3. 删除不可达 layer metadata；
+4. 对不在 reachable slice set、没有 dirty/orphan lease 且超过 grace 的 slice 执行现有
+   object deletion；
+5. 删除失败保留 tombstone 并重试。
+
+不得为 fork 对每个 slice 增加 eager refcount。
+
+## 19. Seal materialization
+
+active workspace 不存在可增长 layer depth，也不依赖后台 depth compaction。seal 的
+materialization：
+
+1. 读取固定 sealed base 和已 quiesce 的 writable upper；
+2. 构建等价的平坦 sealed layer；
+3. namespace/dentry/xattr/ACL 计算 newest winner；
+4. extent 计算等价 Data/Hole plan；
+5. 可复用 immutable slice，不强制重写 object；
+6. 计算新 digest/root hash；
+7. CAS 替换 workspace、active lease 和空 writable head；
+8. 旧 layer 保留到所有 lease/reference 消失；
+9. 后续 GC 回收。
+
+materialization 只发生在显式 seal/snapshot/publish 控制路径，不进入 foreground FUSE
+mutation。fork 只接受 flat `BaseRevision`，因此仍为 O(1) metadata mutation。
+
+## 20. 后台任务
+
+workspace mount/daemon 只启动 feature module 内的：
+
+```text
+lease heartbeat
+expired lease reaper
+seal recovery worker
+layer GC
+orphan object GC
+workspace compaction
+head invalidation watcher（backend 支持时）
+```
+
+不得为 workspace mount 启动当前基于 raw flat MetaStore 的 CompactionWorker/GC。普通 mount
+仍只启动现有任务。
+
+## 21. Control API 与 CLI
+
+feature 启用时增加：
+
+```text
+brewfs workspace --meta-backend <sqlx|redis|tikv> \
+  [--meta-url <url>] \
+  [--meta-tikv-pd-endpoints <pd...>] \
+  [--workspace-namespace <name>] <command>
+
+brewfs workspace init-volume
+brewfs workspace create [--from <revision>]
+brewfs workspace snapshot <workspace>
+brewfs workspace fork <workspace-or-revision> --count <n>
+brewfs workspace list
+brewfs workspace inspect <workspace>
+brewfs workspace diff <workspace> [--against <revision>]
+brewfs workspace discard <workspace>
+brewfs workspace commit <workspace> --to <target>
+
+brewfs mount <mountpoint> --workspace <workspace-id>
+```
+
+workspace CLI 和 mount 必须选择同一个 backend、endpoint 与 `workspace-namespace`。
+workspace 模式明确拒绝 etcd；普通 flat mount 的 backend 选择保持不变。
+
+revision 外部编码：
+
+```text
+<layer-uuid>:<sealed-version>:<root-hash-hex>
+```
+
+API 不接受只有 layer ID 的 fork/commit precondition。
+
+### 21.1 Inspect 输出
+
+至少包含：
+
+```text
+workspace_id/state/owner
+head_layer_id/head_epoch
+base_revision/layer_depth
+lease_id/holder_generation/expires_at
+private metadata rows/private bytes/shared bytes
+pending writeback
+last seal journal phase/error
+```
+
+## 22. Error 类型
+
+```rust
+pub enum WorkspaceError {
+    FeatureNotCompiled(&'static str),
+    UnsupportedVolumeFormat(String),
+    UnsupportedSchemaVersion(u32),
+    UnsupportedCapability(&'static str),
+    WorkspaceNotFound(WorkspaceId),
+    LayerNotFound(LayerId),
+    LeaseNotFound(LeaseId),
+    Busy,
+    Fenced,
+    Conflict(ConflictDetail),
+    LayerDepthLimit { depth: u32, hard_limit: u32 },
+    CorruptMetadata(String),
+    InvalidReadPlan(String),
+    InvalidStateTransition { from: String, to: String },
+    Backend(String),
+    Io(std::io::Error),
+}
+```
+
+错误映射到 errno 时：
+
+- Fenced -> `ESTALE`；
+- Busy -> `EBUSY`；
+- not found -> `ENOENT`；
+- conflict -> control API conflict，不映射成普通文件 syscall；
+- corruption -> `EIO` 并记录高优先级事件。
+
+## 23. Metrics
+
+```text
+brewfs_workspace_mount_total{result}
+brewfs_workspace_fork_total{result}
+brewfs_workspace_fork_control_latency_seconds
+brewfs_workspace_fork_drain_latency_seconds
+brewfs_workspace_seal_total{result,phase}
+brewfs_workspace_seal_pending_bytes
+brewfs_workspace_quiesce_latency_seconds
+brewfs_workspace_publish_total{result}
+brewfs_workspace_publish_changed_paths
+brewfs_workspace_layer_depth
+brewfs_workspace_resolver_steps
+brewfs_workspace_extent_plan_segments
+brewfs_workspace_private_bytes_written
+brewfs_workspace_parent_bytes_read
+brewfs_workspace_shared_cache_hits
+brewfs_workspace_active_leases
+brewfs_workspace_fenced_writes_total
+brewfs_workspace_gc_reachable_layers
+brewfs_workspace_gc_orphan_bytes
+brewfs_workspace_compaction_bytes
+```
+
+flat `.stats` 现有字段不得改变；workspace metric 仅在 feature build 注册。
+
+## 24. 测试规范
+
+### 24.1 Default-flat 非干扰 gate
+
+必须自动验证：
+
+1. `cargo test` 默认不编译 workspace module；
+2. default dependency tree 不增加 workspace-only dependency；
+3. legacy schema snapshot 不变；
+4. `SliceDesc` serde/rkyv golden bytes 不变；
+5. object key golden tests 不变；
+6. default binary help 不出现 workspace 命令；
+7. flat workload 的 metadata/object request 数不增加；
+8. feature-enabled binary 挂载 flat volume 时 WorkspaceStore mock 调用为零；
+9. feature-enabled flat mount 不启动 workspace task；
+10. flat-only binary 对 workspace marker fail-closed。
+
+### 24.2 Resolver unit/property tests
+
+- dentry Put/Whiteout/recreate；
+- inode Present/Deleted/copy-up；
+- xattr/ACL Whiteout；
+- data -> hole -> data；
+- lower extent 中间裁剪的 slice_offset；
+- truncate shrink 后 extend 不复活 lower bytes；
+- 多层相同 logical range newest-wins；
+- 随机操作与内存 byte-array/tree oracle 比较；
+- overflow、zero length、越界和 corrupt chain。
+
+### 24.3 POSIX tests
+
+- 两 workspace 修改同一文件，互不可见；
+- create/unlink/recreate；
+- rmdir 检查 lower child；
+- rename replace/exchange/noreplace；
+- directory rename 与 `..`；
+- hardlink/nlink；
+- open-unlink-read/write-close；
+- chmod/chown/xattr/ACL；
+- truncate/extend/punch-hole/sparse file；
+- mmap、fallocate；
+- flock/plock 只在同 workspace 互斥；
+- symlink 与循环限制；
+- xfstests、pjdfstest 双 workspace harness。
+
+### 24.4 Lifecycle/crash tests
+
+在 seal 每一 phase 注入 crash：
+
+```text
+before/after quiesce
+before/after dirty freeze
+before/after object upload
+before/after metadata append
+before/after digest
+before/after layer sealed
+before/after head switch
+before/after journal complete
+```
+
+结果必须为旧 view 或新 view 之一。
+
+另测：
+
+- stale head epoch write；
+- stale holder generation heartbeat/write；
+- fork 不遍历文件/slice；
+- commit target revision changed；
+- commit 一个 conflict 时零部分生效；
+- publish失败保留 source workspace；
+- active command 未退出返回 Busy。
+
+### 24.5 GC/compaction
+
+- 100 child 共享 base，删除 99 个不回收 base；
+- active lease 阻止回收；
+- expired lease grace；
+- compaction 复用 slice 后 origin layer 删除不误删 object；
+- CAS replacement 失败保留旧 graph；
+- orphan upload grace 后回收；
+- GC 重启幂等。
+
+### 24.6 性能
+
+- 百万文件 base fork 的 metadata mutation 数为常数；
+- 修改 10 GiB 文件中 4 KiB 不复制整文件；
+- 固定两层 lookup/stat/create/unlink 的 Redis `SCAN` 增量必须为 0；
+- point lookup 必须保持一次 backend round trip，且耗时不随无关 key 数量增长；
+- 100 child 读同 base block 的 shared cache/singleflight；
+- randrw、small-file create、rename、git checkout/build；
+- 分开报告 active throughput、fsync/close、seal drain、fork control latency；
+- default-flat 与 feature-enabled-flat 对照，回归超出噪声阈值即阻断。
+
+### 24.7 CI matrix
+
+```text
+cargo fmt --check
+cargo clippy --all-targets
+cargo test
+
+cargo clippy --all-targets --features workspace-overlay
+cargo test --features workspace-overlay
+cargo test --all-features
+
+workspace smoke: fuse-io-uring-runtime
+workspace smoke: fuse-tokio-runtime
+workspace Redis: live distributed catalog contract + 双 mount FUSE + pjdfstest
+workspace TiKV: live distributed catalog contract + 双 mount FUSE + pjdfstest
+```
+
+## 25. 分阶段 PR
+
+### PR 1：Feature scaffolding 与纯 resolver
+
+- default-off feature；
+- `workspace_overlay` module；
+- ID/model/error；
+- LayerExtent/Hole resolver；
+- digest canonical encoder；
+- unit/property/benchmark；
+- 不改 schema、mount、writer、CLI。
+
+### PR 2：WorkspaceStore 与 SQLite 参考实现
+
+- `ws_v1_*` migrations；
+- WorkspaceStore database 实现；
+- HeadGuard transaction；
+- root volume/workspace 初始化；
+- store contract/crash tests；
+- 不接 FUSE。
+
+### PR 3：WorkspaceMetaLayer namespace
+
+- stat/lookup/readdir；
+- create/unlink/rmdir/rename/link/symlink；
+- setattr/xattr/ACL/locks；
+- cache/version invalidation；
+- namespace POSIX tests；
+- 数据仍不接入。
+
+### PR 4：数据读写
+
+- `chunk::read_plan`；
+- Backend workspace provider seam；
+- FileReader workspace branch；
+- WorkspaceMetaLayer write/extent；
+- truncate/punch-hole；
+- block sharing和写放大 tests；
+- default-flat performance comparison。
+
+### PR 5：Mount 与 lease
+
+- volume marker；
+- mount-time format 分流；
+- lease/heartbeat/fencing；
+- writable mount singleton；
+- CLI mount flag；
+- recovery cleanup。
+
+### PR 6：Seal/fork/discard
+
+- quiesce；
+- DurableRemote barrier；
+- seal journal/recovery；
+- fork/discard；
+- control CLI/API；
+- crash injection。
+
+### PR 7：Diff/commit
+
+- path diff；
+- fast-forward preconditions；
+- all-or-reject CAS commit；
+- conflict diagnostics。
+
+### PR 8：GC/compaction/observability
+
+- layer/slice mark-and-sweep；
+- orphan GC；
+- lease-aware compaction；
+- metrics/inspect；
+- depth/performance gates。
+
+### PR 9：Redis/TiKV 生产 backend
+
+- 独立 `ws:v1:*` prefix；
+- backend-neutral KV store；
+- Redis binary-safe Lua CAS、cluster hash tag 和 server-time lease；
+- TiKV pessimistic transaction、prefix range scan 和冲突重试；
+- CLI/mount backend 分流与 namespace 校验；
+- Redis/TiKV 双实例并发 contract；
+- Redis/TiKV 双 mount isolation、xfstests、pjdfstest gate。
+
+etcd 等其他 backend 必须在独立 PR 中实现；未实现时明确拒绝 workspace volume。
+
+## 26. Definition of Done
+
+Workspace Overlay v1 只有满足以下全部条件才可声明可用：
+
+1. default-flat 所有现有 correctness/performance gate 无回归；
+2. feature、schema、cache、task 和 object compatibility 契约全部通过；
+3. 两个 workspace 在核心 POSIX mutation 上完全隔离；
+4. partial write 只产生修改范围相关的新 slice/block；
+5. truncate/hole 不暴露 lower data；
+6. seal/fork/commit crash test 不产生半提交 view；
+7. fork 不遍历 base inode/slice/object；
+8. stale writer/lease 被 fencing；
+9. discard/GC/compaction 不删除可达 object；
+10. fast-forward commit 为 all-or-reject；
+11. xfstests、pjdfstest 和现有 Rust workspace gate 通过；
+12. flat-only 与 workspace-enabled binary 的部署错误均 fail-closed。
+13. Redis 和 TiKV 分别通过两个独立 store instance 的 CAS 并发 contract；
+14. Redis/TiKV 上两个 sibling workspace 同时挂载时共享 sealed base 且 mutation 互不可见。

--- a/doc/testing/test-script-reference.md
+++ b/doc/testing/test-script-reference.md
@@ -24,6 +24,9 @@ Run commands from the repository root.
 | FUSE correctness smoke | `bash docker/compose-xfstests/run_redis_xfstests.sh --cases "generic/001 generic/002 generic/100"` | 5-15 min |
 | Full Redis + RustFS xfstests | `bash docker/compose-xfstests/run_redis_xfstests.sh` | hours |
 | LTP filesystem coverage | `bash docker/compose-xfstests/run_redis_ltp.sh` | 30-90 min |
+| Workspace overlay control smoke (Redis/TiKV) | `bash docker/compose-xfstests/run_workspace_overlay_compose.sh --backend <redis\|tikv> --control-only` | build time plus a few min |
+| Workspace overlay xfstests + LTP (Redis) | `bash docker/compose-xfstests/run_workspace_overlay_compose.sh --backend redis` | workload-dependent |
+| Workspace overlay xfstests + LTP (TiKV) | `bash docker/compose-xfstests/run_workspace_overlay_compose.sh --backend tikv` | workload-dependent |
 | CI-safe stress | `bash docker/compose-xfstests/run_redis_stress_ng.sh --profile smoke` | a few min |
 | Complete performance run | `bash docker/compose-xfstests/run_redis_perf.sh --read-throughput-profile` | 10-30 min plus build |
 | Metadata performance smoke | `bash docker/compose-xfstests/run_redis_meta_perf.sh --quick` | 2-5 min plus build |
@@ -117,6 +120,52 @@ entry points. They use the same host-binary build path and artifact layout.
 | SQLite | `run_sqlite_xfstests.sh` | local by default; `--s3` selects RustFS |
 | etcd | `run_etcd_xfstests.sh` | local by default; `--s3` selects RustFS |
 | TiKV | `run_tikv_xfstests.sh` | RustFS, fixed |
+
+### Workspace overlay Compose suite
+
+The workspace overlay Compose runner exercises the feature through the same
+FUSE boundary used by agents. It starts the selected Redis or TiKV metadata
+service, seeds one base workspace, forks two workspaces, verifies shared base
+data and isolated mutations, and then runs the selected suite independently on
+both forks. Local filesystem data is used so the test focuses on overlay
+metadata and block visibility without adding an object-store dependency.
+
+Run the complete configured xfstests and LTP profiles with:
+
+```bash
+bash docker/compose-xfstests/run_workspace_overlay_compose.sh --backend redis
+bash docker/compose-xfstests/run_workspace_overlay_compose.sh --backend tikv
+```
+
+The default run leaves `XFSTESTS_CASES` empty so the container driver discovers
+the full xfstests corpus and applies `tests/scripts/xfstests_slayer.exclude`.
+LTP runs its complete `fs` command-file set after merging
+`docker/compose-xfstests/ltp_skip_tests.txt`; these repository exclusions are
+the only default coverage reductions. Set `XFSTESTS_CASES` or use
+`--xfstests-cases` only for a targeted diagnostic run. The Compose profile uses
+`LTP_TIMEOUT_MUL=4` because the 1,000-link `linker01` case is substantially
+slower through FUSE than on a local filesystem; override it when diagnosing
+timeout behavior.
+
+For a quick Compose smoke run, limit xfstests while retaining both workspace
+forks and the LTP profile:
+
+```bash
+bash docker/compose-xfstests/run_workspace_overlay_compose.sh \
+  --backend redis \
+  --xfstests-cases "generic/001 generic/002 generic/100"
+```
+
+Pull requests and pushes run `--control-only` against both Redis and TiKV. That
+bounded gate still builds and mounts BrewFS through FUSE, seeds a shared base,
+forks two workspaces, and verifies isolation; it skips xfstests and LTP. The
+complete xfstests/LTP matrix remains a `workflow_dispatch` gate because of its
+multi-hour runtime.
+
+Artifacts are written below `docker/compose-xfstests/artifacts/` under separate
+`workspace-a/` and `workspace-b/` directories. Use `--keep` to inspect the
+running services after a failure; otherwise the runner removes the Compose
+project and its volumes on exit.
 
 Examples:
 

--- a/docker/compose-xfstests/Dockerfile.ltp
+++ b/docker/compose-xfstests/Dockerfile.ltp
@@ -54,11 +54,15 @@ RUN apt-get update && \
 COPY --from=builder /opt/ltp /opt/ltp
 COPY target/docker/brewfs /usr/local/bin/brewfs
 COPY docker/compose-xfstests/run_ltp_in_container.sh /usr/local/bin/run_ltp_in_container.sh
+COPY docker/compose-xfstests/run_workspace_overlay_suite_in_container.sh /usr/local/bin/run_workspace_overlay_suite_in_container.sh
 COPY docker/compose-xfstests/ltp_skip_tests.txt /usr/local/share/brewfs/ltp_skip_tests.txt
 COPY docker/ltp_report.sh /usr/local/bin/ltp_report.sh
 
 RUN set -e; \
-    chmod +x /usr/local/bin/brewfs /usr/local/bin/run_ltp_in_container.sh /usr/local/bin/ltp_report.sh; \
+    sed -i 's/\r$//' /usr/local/bin/run_ltp_in_container.sh /usr/local/bin/run_workspace_overlay_suite_in_container.sh \
+        /usr/local/share/brewfs/ltp_skip_tests.txt; \
+    chmod +x /usr/local/bin/brewfs /usr/local/bin/run_ltp_in_container.sh \
+        /usr/local/bin/run_workspace_overlay_suite_in_container.sh /usr/local/bin/ltp_report.sh; \
     mkdir -p /mnt/brewfs /run/brewfs /var/lib/brewfs/data /artifacts /usr/local/share/brewfs; \
     grep -q '^user_allow_other$' /etc/fuse.conf 2>/dev/null || echo 'user_allow_other' >> /etc/fuse.conf
 

--- a/docker/compose-xfstests/Dockerfile.pjdfstest
+++ b/docker/compose-xfstests/Dockerfile.pjdfstest
@@ -52,6 +52,7 @@ COPY docker/compose-xfstests/pjdfstest_skip_tests.txt /usr/local/share/brewfs/pj
 COPY docker/compose-xfstests/pjdfstest-brewfs /opt/pjdfstest/tests/brewfs
 
 RUN set -e; \
+    sed -i 's/\r$//' /usr/local/bin/run_pjdfstest_in_container.sh /opt/pjdfstest/tests/brewfs/*.t; \
     chmod +x /usr/local/bin/brewfs /usr/local/bin/run_pjdfstest_in_container.sh /opt/pjdfstest/tests/brewfs/*.t; \
     mkdir -p /mnt/brewfs /run/brewfs /var/lib/brewfs/data /artifacts /usr/local/share/brewfs; \
     grep -q '^user_allow_other$' /etc/fuse.conf 2>/dev/null || echo 'user_allow_other' >> /etc/fuse.conf

--- a/docker/compose-xfstests/Dockerfile.workspace-overlay-pjdfstest
+++ b/docker/compose-xfstests/Dockerfile.workspace-overlay-pjdfstest
@@ -1,0 +1,42 @@
+ARG BASE_IMAGE=slayerfs-xfstests:local
+FROM ${BASE_IMAGE} AS builder
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        autoconf \
+        automake \
+        build-essential \
+        git \
+        libtool \
+        pkg-config && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+RUN git clone --depth 1 https://github.com/pjd/pjdfstest.git . && \
+    if [ -f autogen.sh ]; then ./autogen.sh; \
+    elif [ -f configure.ac ] || [ -f configure.in ]; then autoreconf -fi; \
+    fi && \
+    if [ -x ./configure ]; then ./configure; fi && \
+    make -j"$(nproc)" && \
+    mkdir -p /opt/pjdfstest && \
+    cp -a . /opt/pjdfstest
+
+FROM ${BASE_IMAGE}
+
+COPY --from=builder /opt/pjdfstest /opt/pjdfstest
+COPY target/docker/brewfs /usr/local/bin/brewfs
+COPY docker/compose-xfstests/run_pjdfstest_in_container.sh /usr/local/bin/run_pjdfstest_in_container.sh
+COPY docker/compose-xfstests/pjdfstest_skip_tests.txt /usr/local/share/brewfs/pjdfstest_skip_tests.txt
+COPY docker/compose-xfstests/pjdfstest-brewfs /opt/pjdfstest/tests/brewfs
+
+RUN sed -i 's/\r$//' /usr/local/bin/run_pjdfstest_in_container.sh && \
+    find /opt/pjdfstest/tests/brewfs -type f -name '*.t' \
+        -exec sed -i 's/\r$//' {} + && \
+    chmod +x /usr/local/bin/brewfs /usr/local/bin/run_pjdfstest_in_container.sh \
+        /opt/pjdfstest/tests/brewfs/*.t && \
+    mkdir -p /mnt/brewfs /run/brewfs /var/lib/brewfs/data /artifacts \
+        /usr/local/share/brewfs
+
+ENV PJDFSTEST_DIR=/opt/pjdfstest
+
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/run_pjdfstest_in_container.sh"]

--- a/docker/compose-xfstests/Dockerfile.workspace-overlay-xfstests
+++ b/docker/compose-xfstests/Dockerfile.workspace-overlay-xfstests
@@ -1,0 +1,19 @@
+ARG BASE_IMAGE=slayerfs-xfstests:local
+FROM ${BASE_IMAGE}
+
+COPY target/docker/brewfs /usr/local/bin/brewfs
+COPY docker/compose-xfstests/run_xfstests_in_container.sh /usr/local/bin/run_xfstests_in_container.sh
+COPY docker/compose-xfstests/run_workspace_overlay_suite_in_container.sh /usr/local/bin/run_workspace_overlay_suite_in_container.sh
+COPY docker/compose-xfstests/run_workspace_overlay_control_in_container.sh /usr/local/bin/run_workspace_overlay_control_in_container.sh
+COPY docker/compose-xfstests/run_workspace_overlay_dual_mount_in_container.sh /usr/local/bin/run_workspace_overlay_dual_mount_in_container.sh
+
+RUN sed -i 's/\r$//' /usr/local/bin/run_xfstests_in_container.sh && \
+    sed -i 's/\r$//' /usr/local/bin/run_workspace_overlay_suite_in_container.sh && \
+    sed -i 's/\r$//' /usr/local/bin/run_workspace_overlay_control_in_container.sh && \
+    sed -i 's/\r$//' /usr/local/bin/run_workspace_overlay_dual_mount_in_container.sh && \
+    chmod +x /usr/local/bin/brewfs /usr/local/bin/run_xfstests_in_container.sh \
+        /usr/local/bin/run_workspace_overlay_suite_in_container.sh \
+        /usr/local/bin/run_workspace_overlay_control_in_container.sh \
+        /usr/local/bin/run_workspace_overlay_dual_mount_in_container.sh
+
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/run_xfstests_in_container.sh"]

--- a/docker/compose-xfstests/docker-compose.workspace-overlay.yml
+++ b/docker/compose-xfstests/docker-compose.workspace-overlay.yml
@@ -1,0 +1,176 @@
+x-workspace-environment: &workspace-environment
+  BREWFS_META_BACKEND: ${BREWFS_WORKSPACE_META_BACKEND:-redis}
+  BREWFS_META_URL: ${BREWFS_WORKSPACE_META_URL:-redis://redis:6379/0}
+  BREWFS_META_TIKV_PD_ENDPOINTS: ${BREWFS_WORKSPACE_TIKV_PD_ENDPOINTS:-pd:2379}
+  BREWFS_META_TIKV_NAMESPACE: ${BREWFS_WORKSPACE_NAMESPACE:-brewfs-workspace-overlay}
+  BREWFS_WORKSPACE_META_BACKEND: ${BREWFS_WORKSPACE_META_BACKEND:-redis}
+  BREWFS_WORKSPACE_META_URL: ${BREWFS_WORKSPACE_META_URL:-redis://redis:6379/0}
+  BREWFS_WORKSPACE_TIKV_PD_ENDPOINTS: ${BREWFS_WORKSPACE_TIKV_PD_ENDPOINTS:-pd:2379}
+  BREWFS_WORKSPACE_NAMESPACE: ${BREWFS_WORKSPACE_NAMESPACE:-brewfs-workspace-overlay}
+  BREWFS_WORKSPACE_STATE_DIR: /var/lib/brewfs
+  BREWFS_VOLUME_FORMAT: workspace-v1
+  BREWFS_DATA_BACKEND: local-fs
+  BREWFS_DATA_DIR: /var/lib/brewfs/data
+  BREWFS_SQLITE_PATH: /var/lib/brewfs/workspace.db
+  BREWFS_CONFIG_PATH: /run/brewfs/config.yaml
+  BREWFS_ARTIFACT_ROOT: /artifacts
+  BREWFS_LOG_FILE: /artifacts/brewfs.log
+  BREWFS_MOUNT_WAIT_SECS: ${BREWFS_MOUNT_WAIT_SECS:-60}
+  BREWFS_PRE_MOUNT_WAIT_SECS: ${BREWFS_PRE_MOUNT_WAIT_SECS:-10}
+  BREWFS_MOUNT_READY_DELAY_SECS: ${BREWFS_MOUNT_READY_DELAY_SECS:-1}
+  BREWFS_FUSE_OP_LOG: ${BREWFS_FUSE_OP_LOG:-0}
+  RUST_LOG: ${RUST_LOG:-brewfs=info,asyncfuse=warn}
+
+x-fuse-test: &fuse-test
+  privileged: true
+  devices:
+    - /dev/fuse:/dev/fuse
+  cap_add:
+    - SYS_ADMIN
+  security_opt:
+    - apparmor=unconfined
+  volumes:
+    - ${BREWFS_WORKSPACE_ARTIFACT_DIR:-./artifacts}:/artifacts
+    - workspace-overlay-state:/var/lib/brewfs
+  networks:
+    - brewfs-workspace-overlay
+  ulimits:
+    nofile:
+      soft: 65536
+      hard: 65536
+
+services:
+  # Build-only base used by Dockerfile.workspace-overlay-xfstests.
+  xfstests-base:
+    image: slayerfs-xfstests:local
+    build:
+      context: ../..
+      dockerfile: docker/compose-xfstests/Dockerfile
+    entrypoint: ["/bin/true"]
+
+  redis:
+    profiles: ["redis"]
+    image: docker.io/library/redis:7.2-alpine
+    command: ["redis-server", "--appendonly", "no"]
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 2s
+      timeout: 2s
+      retries: 60
+    networks:
+      - brewfs-workspace-overlay
+
+  pd:
+    profiles: ["tikv"]
+    image: pingcap/pd:v8.5.0
+    command:
+      - --name=pd
+      - --data-dir=/data/pd
+      - --client-urls=http://0.0.0.0:2379
+      - --advertise-client-urls=http://pd:2379
+      - --peer-urls=http://0.0.0.0:2380
+      - --advertise-peer-urls=http://pd:2380
+      - --initial-cluster=pd=http://pd:2380
+      - --log-level=warn
+    volumes:
+      - workspace-overlay-pd:/data/pd
+    networks:
+      - brewfs-workspace-overlay
+
+  tikv:
+    profiles: ["tikv"]
+    image: pingcap/tikv:v8.5.0
+    depends_on:
+      pd:
+        condition: service_started
+    command:
+      - --addr=0.0.0.0:20160
+      - --advertise-addr=tikv:20160
+      - --status-addr=0.0.0.0:20180
+      - --pd=pd:2379
+      - --data-dir=/data/tikv
+      - --log-level=warn
+    volumes:
+      - workspace-overlay-tikv:/data/tikv
+    networks:
+      - brewfs-workspace-overlay
+    ulimits:
+      nofile:
+        soft: 1048576
+        hard: 1048576
+
+  tikv-ready:
+    profiles: ["tikv"]
+    image: curlimages/curl:8.10.1
+    depends_on:
+      pd:
+        condition: service_started
+      tikv:
+        condition: service_started
+    entrypoint: ["/bin/sh", "-ec"]
+    command:
+      - |
+        attempts=0
+        while [ "$$attempts" -lt 90 ]; do
+          body="$$(curl -fsS http://pd:2379/pd/api/v1/stores 2>/dev/null || true)"
+          echo "$$body" | grep -Fq '"state_name": "Up"' && exit 0
+          attempts=$$((attempts + 1))
+          sleep 2
+        done
+        echo "TiKV did not register an Up store within 180 seconds" >&2
+        exit 1
+    networks:
+      - brewfs-workspace-overlay
+
+  xfstests:
+    image: brewfs-workspace-xfstests:local
+    build:
+      context: ../..
+      dockerfile: docker/compose-xfstests/Dockerfile.workspace-overlay-xfstests
+      args:
+        BASE_IMAGE: slayerfs-xfstests:local
+    entrypoint: ["/usr/bin/tini", "--", "/usr/local/bin/run_workspace_overlay_suite_in_container.sh"]
+    environment:
+      <<: *workspace-environment
+      WORKSPACE_OVERLAY_SUITE: xfstests
+      XFSTESTS_CASES: ${XFSTESTS_CASES:-}
+      XFSTESTS_CHECK_ARGS: ${XFSTESTS_CHECK_ARGS:-}
+      XFSTESTS_SKIP_CASES: ${XFSTESTS_SKIP_CASES:-0}
+    <<: *fuse-test
+
+  workspace-control:
+    image: brewfs-workspace-xfstests:local
+    entrypoint: ["/usr/bin/tini", "--", "/usr/local/bin/run_workspace_overlay_control_in_container.sh"]
+    environment:
+      <<: *workspace-environment
+      BREWFS_BIN: /usr/local/bin/brewfs
+    <<: *fuse-test
+
+  ltp:
+    image: brewfs-ltp:local
+    build:
+      context: ../..
+      dockerfile: docker/compose-xfstests/Dockerfile.ltp
+    entrypoint: ["/usr/bin/tini", "--", "/usr/local/bin/run_workspace_overlay_suite_in_container.sh"]
+    environment:
+      <<: *workspace-environment
+      WORKSPACE_OVERLAY_SUITE: ltp
+      LTP_SCENARIOS: ${LTP_SCENARIOS:-fs}
+      LTP_EXTRA_ARGS: ${LTP_EXTRA_ARGS:-}
+      LTP_SKIP_TESTS: ${LTP_SKIP_TESTS:-}
+      LTP_SKIP_TESTS_FILE: ${LTP_SKIP_TESTS_FILE:-}
+      LTP_DEFAULT_SKIP_TESTS_FILE: ${LTP_DEFAULT_SKIP_TESTS_FILE:-/usr/local/share/brewfs/ltp_skip_tests.txt}
+      LTP_TIMEOUT_MUL: ${LTP_TIMEOUT_MUL:-4}
+      BREWFS_READ_MEMORY_BYTES: ${BREWFS_READ_MEMORY_BYTES:-1073741824}
+      BREWFS_WRITE_MEMORY_BYTES: ${BREWFS_WRITE_MEMORY_BYTES:-268435456}
+      BREWFS_MEMORY_BUDGET_BYTES: ${BREWFS_MEMORY_BUDGET_BYTES:-1073741824}
+    <<: *fuse-test
+
+networks:
+  brewfs-workspace-overlay:
+    driver: bridge
+
+volumes:
+  workspace-overlay-state:
+  workspace-overlay-pd:
+  workspace-overlay-tikv:

--- a/docker/compose-xfstests/ltp_skip_tests.txt
+++ b/docker/compose-xfstests/ltp_skip_tests.txt
@@ -105,7 +105,7 @@ inode02
 # policy is fixed; see doc/testing/xfstests-redis-rustfs-fix-plan.md.
 iogen01
 # Data integrity issues (needs deeper investigation)
-writetest
+writetest01
 fs_di
 # OOM/compaction deadlock risk
 fs_racer

--- a/docker/compose-xfstests/run_ltp_in_container.sh
+++ b/docker/compose-xfstests/run_ltp_in_container.sh
@@ -9,6 +9,9 @@ err()  { log "ERROR $*" >&2; }
 
 config_path="${BREWFS_CONFIG_PATH:-/run/brewfs/config.yaml}"
 mount_dir="${BREWFS_MOUNT_POINT:-/mnt/brewfs}"
+volume_format="${BREWFS_VOLUME_FORMAT:-}"
+workspace_id="${BREWFS_WORKSPACE_ID:-}"
+workspace_namespace="${BREWFS_WORKSPACE_NAMESPACE:-brewfs}"
 data_backend="${BREWFS_DATA_BACKEND:-local-fs}"
 data_dir="${BREWFS_DATA_DIR:-${BREWFS_HOME:-/var/lib/brewfs}/data}"
 meta_backend="${BREWFS_META_BACKEND:-redis}"
@@ -38,6 +41,17 @@ ltp_tmp_dir=""
 : "${BREWFS_WRITE_MEMORY_BYTES:=268435456}"
 : "${BREWFS_MEMORY_BUDGET_BYTES:=1073741824}"
 
+validate_workspace_config() {
+    if [[ "$volume_format" == "workspace-v1" && -z "$workspace_id" ]]; then
+        err "BREWFS_WORKSPACE_ID is required for BREWFS_VOLUME_FORMAT=workspace-v1"
+        exit 2
+    fi
+    if [[ -n "$workspace_id" && "$volume_format" != "workspace-v1" ]]; then
+        err "BREWFS_WORKSPACE_ID requires BREWFS_VOLUME_FORMAT=workspace-v1"
+        exit 2
+    fi
+}
+
 write_config() {
     mkdir -p "$(dirname "$config_path")" "$mount_dir"
     if [[ "$data_backend" == "local-fs" ]]; then
@@ -46,6 +60,13 @@ write_config() {
 
     {
         echo "mount_point: $mount_dir"
+        if [[ -n "$volume_format" ]]; then
+            echo "volume_format: $volume_format"
+        fi
+        if [[ -n "$workspace_id" ]]; then
+            echo "workspace: $workspace_id"
+            echo "workspace_namespace: $workspace_namespace"
+        fi
         echo
         case "$data_backend" in
             local-fs)
@@ -506,6 +527,8 @@ run_ltp() {
 
 main() {
     local normalized_fuse_op_log
+
+    validate_workspace_config
 
     if [[ -z "$artifact_dir" ]]; then
         ts="$(date +%s)-$RANDOM"

--- a/docker/compose-xfstests/run_pjdfstest_in_container.sh
+++ b/docker/compose-xfstests/run_pjdfstest_in_container.sh
@@ -7,8 +7,22 @@ info() { log "INFO  $*"; }
 ok()   { log "OK    $*"; }
 err()  { log "ERROR $*" >&2; }
 
+validate_workspace_config() {
+    if [[ "$volume_format" == "workspace-v1" && -z "$workspace_id" ]]; then
+        err "BREWFS_WORKSPACE_ID is required for BREWFS_VOLUME_FORMAT=workspace-v1"
+        exit 2
+    fi
+    if [[ -n "$workspace_id" && "$volume_format" != "workspace-v1" ]]; then
+        err "BREWFS_WORKSPACE_ID requires BREWFS_VOLUME_FORMAT=workspace-v1"
+        exit 2
+    fi
+}
+
 config_path="${BREWFS_CONFIG_PATH:-/run/brewfs/config.yaml}"
 mount_dir="${BREWFS_MOUNT_POINT:-/mnt/brewfs}"
+volume_format="${BREWFS_VOLUME_FORMAT:-}"
+workspace_id="${BREWFS_WORKSPACE_ID:-}"
+workspace_namespace="${BREWFS_WORKSPACE_NAMESPACE:-brewfs}"
 data_backend="${BREWFS_DATA_BACKEND:-local-fs}"
 data_dir="${BREWFS_DATA_DIR:-${BREWFS_HOME:-/var/lib/brewfs}/data}"
 meta_backend="${BREWFS_META_BACKEND:-redis}"
@@ -22,6 +36,7 @@ artifact_root="${BREWFS_ARTIFACT_ROOT:-/artifacts}"
 artifact_dir="${BREWFS_ARTIFACT_DIR:-}"
 pjdfstest_dir="${PJDFSTEST_DIR:-/opt/pjdfstest}"
 pjdfstest_extra_args="${PJDFSTEST_EXTRA_ARGS:-}"
+pjdfstest_include_patterns="${PJDFSTEST_INCLUDE_PATTERNS:-}"
 pjdfstest_skip_patterns="${PJDFSTEST_SKIP_PATTERNS:-}"
 pjdfstest_skip_patterns_file="${PJDFSTEST_SKIP_PATTERNS_FILE:-}"
 pjdfstest_default_skip_file="${PJDFSTEST_DEFAULT_SKIP_FILE:-/usr/local/share/brewfs/pjdfstest_skip_tests.txt}"
@@ -35,6 +50,13 @@ write_config() {
 
     {
         echo "mount_point: $mount_dir"
+        if [[ -n "$volume_format" ]]; then
+            echo "volume_format: $volume_format"
+        fi
+        if [[ -n "$workspace_id" ]]; then
+            echo "workspace: $workspace_id"
+            echo "workspace_namespace: $workspace_namespace"
+        fi
         echo
         case "$data_backend" in
             local-fs)
@@ -322,11 +344,23 @@ trim_skip_file() {
 }
 
 prepare_test_list() {
+    local raw_includefile="$tmp_dir/include-patterns.raw"
+    local includefile="$tmp_dir/include-patterns.txt"
     local raw_skipfile="$tmp_dir/skip-patterns.raw"
     local skipfile="$tmp_dir/skip-patterns.txt"
     local all_tests="$tmp_dir/tests.all"
+    local included_tests="$tmp_dir/tests.included"
     local selected_tests="$tmp_dir/tests.selected"
+    local include_source
     local skip_source
+
+    : >"$raw_includefile"
+    if [[ -n "$pjdfstest_include_patterns" ]]; then
+        for include_source in $pjdfstest_include_patterns; do
+            printf '%s\n' "$include_source" >>"$raw_includefile"
+        done
+    fi
+    sort -u "$raw_includefile" >"$includefile"
 
     : >"$raw_skipfile"
     if [[ -f "$pjdfstest_default_skip_file" ]]; then
@@ -348,14 +382,20 @@ prepare_test_list() {
 
     cd "$pjdfstest_dir"
     find tests -type f -name '*.t' | sort >"$all_tests"
-    if [[ -s "$skipfile" ]]; then
-        grep -Ev -f "$skipfile" "$all_tests" >"$selected_tests"
+    if [[ -s "$includefile" ]]; then
+        grep -E -f "$includefile" "$all_tests" >"$included_tests" || true
     else
-        cp "$all_tests" "$selected_tests"
+        cp "$all_tests" "$included_tests"
+    fi
+    if [[ -s "$skipfile" ]]; then
+        grep -Ev -f "$skipfile" "$included_tests" >"$selected_tests" || true
+    else
+        cp "$included_tests" "$selected_tests"
     fi
 
     cp -f "$all_tests" "$artifact_dir/all-tests.txt"
     cp -f "$selected_tests" "$artifact_dir/selected-tests.txt"
+    cp -f "$includefile" "$artifact_dir/include-patterns.txt"
     cp -f "$skipfile" "$artifact_dir/skip-patterns.txt"
     printf '%s' "$selected_tests"
 }
@@ -411,6 +451,10 @@ run_pjdfstest() {
     selected_count="$(wc -l <"$selected_tests_file" | tr -d '[:space:]')"
     all_count="$(wc -l <"$artifact_dir/all-tests.txt" | tr -d '[:space:]')"
     skipped_count=$((all_count - selected_count))
+    if [[ "$selected_count" -eq 0 ]]; then
+        err "pjdfstest selection matched no tests"
+        return 2
+    fi
 
     if [[ -n "$pjdfstest_extra_args" ]]; then
         read -r -a extra <<<"$pjdfstest_extra_args"
@@ -470,6 +514,7 @@ on_exit() {
 }
 
 main() {
+    validate_workspace_config
     local normalized_fuse_op_log
 
     if [[ -z "$artifact_dir" ]]; then

--- a/docker/compose-xfstests/run_workspace_overlay_compose.sh
+++ b/docker/compose-xfstests/run_workspace_overlay_compose.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+COMPOSE_FILE="$SCRIPT_DIR/docker-compose.workspace-overlay.yml"
+ARTIFACT_ROOT="${BREWFS_WORKSPACE_ARTIFACT_ROOT:-$SCRIPT_DIR/artifacts}"
+BACKEND="${BREWFS_WORKSPACE_META_BACKEND:-redis}"
+XFSTESTS_CASES_VALUE="${XFSTESTS_CASES:-}"
+RUN_XFSTESTS=true
+RUN_LTP=true
+CONTROL_ONLY=false
+BUILD_IMAGES=true
+KEEP=false
+
+log() { printf '[workspace-overlay-compose] %s\n' "$*"; }
+die() { log "ERROR: $*" >&2; exit 2; }
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [options]
+
+Run the workspace overlay integration stack with Docker Compose.  A shared
+base is seeded through FUSE, forked into two workspaces, checked for isolation,
+then each selected filesystem suite runs against both forks.
+
+Options:
+  --backend BACKEND          metadata backend: redis or tikv (default: $BACKEND)
+  --xfstests-cases "CASES"   xfstests cases; omit for the complete configured suite
+  --skip-xfstests            do not run xfstests
+  --skip-ltp                 do not run LTP
+  --control-only             run only init/seed/fork/isolation verification
+  --ltp-skip-tests "NAMES"   extra LTP test names to skip
+  --ltp-extra-args "ARGS"    extra arguments passed to runltp
+  --reuse-images             reuse existing images and target/docker/brewfs
+  --keep                     keep Compose services and volumes after the run
+  -h, --help                 show this help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --backend)
+            [[ $# -ge 2 ]] || die "--backend requires a value"
+            BACKEND="$2"
+            shift 2
+            ;;
+        --xfstests-cases)
+            [[ $# -ge 2 ]] || die "--xfstests-cases requires a value"
+            XFSTESTS_CASES_VALUE="$2"
+            shift 2
+            ;;
+        --skip-xfstests)
+            RUN_XFSTESTS=false
+            shift
+            ;;
+        --skip-ltp)
+            RUN_LTP=false
+            shift
+            ;;
+        --control-only)
+            RUN_XFSTESTS=false
+            RUN_LTP=false
+            CONTROL_ONLY=true
+            shift
+            ;;
+        --ltp-skip-tests)
+            [[ $# -ge 2 ]] || die "--ltp-skip-tests requires a value"
+            export LTP_SKIP_TESTS="$2"
+            shift 2
+            ;;
+        --ltp-extra-args)
+            [[ $# -ge 2 ]] || die "--ltp-extra-args requires a value"
+            export LTP_EXTRA_ARGS="$2"
+            shift 2
+            ;;
+        --reuse-images)
+            BUILD_IMAGES=false
+            shift
+            ;;
+        --keep)
+            KEEP=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            die "unknown option: $1"
+            ;;
+    esac
+done
+
+case "$BACKEND" in
+    redis|tikv) ;;
+    *) die "--backend must be redis or tikv" ;;
+esac
+[[ "$CONTROL_ONLY" == true || "$RUN_XFSTESTS" == true || "$RUN_LTP" == true ]] \
+    || die "at least one of xfstests or LTP must be selected"
+
+command -v cargo >/dev/null || die "cargo is required"
+command -v docker >/dev/null || die "docker is required"
+command -v git >/dev/null || die "git is required"
+[[ -e /dev/fuse ]] || die "/dev/fuse is required"
+
+mkdir -p "$ARTIFACT_ROOT"
+export BREWFS_WORKSPACE_ARTIFACT_DIR="$ARTIFACT_ROOT"
+export BREWFS_WORKSPACE_META_BACKEND="$BACKEND"
+export BREWFS_WORKSPACE_META_URL="${BREWFS_WORKSPACE_META_URL:-redis://redis:6379/0}"
+export BREWFS_WORKSPACE_TIKV_PD_ENDPOINTS="${BREWFS_WORKSPACE_TIKV_PD_ENDPOINTS:-pd:2379}"
+export BREWFS_WORKSPACE_NAMESPACE="${BREWFS_WORKSPACE_NAMESPACE:-workspace-overlay-$(date +%s)-$RANDOM}"
+export XFSTESTS_CASES="$XFSTESTS_CASES_VALUE"
+
+ts="$(date +%Y%m%d-%H%M%S)-$RANDOM"
+project_name="brewfs-workspace-overlay-$ts"
+compose_args=(-f "$COMPOSE_FILE" -p "$project_name")
+
+cleanup() {
+    local status=$?
+    set +e
+    if [[ "$KEEP" == false ]]; then
+        docker compose "${compose_args[@]}" --profile redis --profile tikv \
+            down -v --remove-orphans >/dev/null 2>&1 || true
+    else
+        log "keeping Compose project $project_name (--keep)"
+    fi
+    exit "$status"
+}
+trap cleanup EXIT INT TERM
+
+if [[ "$BUILD_IMAGES" == true ]]; then
+    log "building workspace-overlay release binary"
+    (
+        cd "$PROJECT_DIR"
+        CARGO_PROFILE_RELEASE_DEBUG=0 cargo build --release -p brewfs --bin brewfs \
+            --features workspace-overlay
+        mkdir -p target/docker
+        install -m 755 target/release/brewfs target/docker/brewfs
+    )
+
+    log "building xfstests base image"
+    docker compose "${compose_args[@]}" build --pull=false xfstests-base
+    log "building workspace xfstests image"
+    docker compose "${compose_args[@]}" build --pull=false xfstests
+    if [[ "$RUN_LTP" == true ]]; then
+        log "building LTP image"
+        docker compose "${compose_args[@]}" build --pull=false ltp
+    fi
+fi
+
+case "$BACKEND" in
+    redis)
+        log "starting Redis metadata service"
+        docker compose "${compose_args[@]}" --profile redis up -d --wait redis
+        ;;
+    tikv)
+        log "starting TiKV/PD metadata services"
+        docker compose "${compose_args[@]}" --profile tikv up -d pd tikv
+        docker compose "${compose_args[@]}" --profile tikv run --rm --no-deps tikv-ready
+        ;;
+esac
+
+run_control() {
+    local mode="$1"
+    docker compose "${compose_args[@]}" run --rm --no-deps workspace-control "$mode"
+}
+
+log "initializing workspace catalog"
+run_control init
+log "seeding shared base through a FUSE mount"
+run_control seed
+log "forking two independent workspaces"
+run_control fork
+log "verifying simultaneous workspace isolation"
+run_control verify
+
+status=0
+if [[ "$RUN_XFSTESTS" == true ]]; then
+    log "running xfstests on both workspaces"
+    set +e
+    docker compose "${compose_args[@]}" run --rm --no-deps xfstests
+    xfstests_status=$?
+    set -e
+    (( xfstests_status == 0 )) || status=1
+fi
+
+if [[ "$RUN_LTP" == true ]]; then
+    log "running LTP filesystem tests on both workspaces"
+    set +e
+    docker compose "${compose_args[@]}" run --rm --no-deps ltp
+    ltp_status=$?
+    set -e
+    (( ltp_status == 0 )) || status=1
+fi
+
+log "artifacts: $ARTIFACT_ROOT"
+exit "$status"

--- a/docker/compose-xfstests/run_workspace_overlay_control_in_container.sh
+++ b/docker/compose-xfstests/run_workspace_overlay_control_in_container.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+mode="${1:-}"
+state_dir="${BREWFS_WORKSPACE_STATE_DIR:-/var/lib/brewfs}"
+bin="${BREWFS_BIN:-/usr/local/bin/brewfs}"
+catalog_backend="${BREWFS_WORKSPACE_META_BACKEND:-redis}"
+catalog_url="${BREWFS_WORKSPACE_META_URL:-redis://redis:6379/0}"
+catalog_tikv_endpoints="${BREWFS_WORKSPACE_TIKV_PD_ENDPOINTS:-pd:2379}"
+catalog_namespace="${BREWFS_WORKSPACE_NAMESPACE:-brewfs-workspace-overlay}"
+
+die() {
+    printf '[workspace-overlay] ERROR: %s\n' "$*" >&2
+    exit 1
+}
+
+[[ "$catalog_backend" == redis || "$catalog_backend" == tikv ]] \
+    || die "BREWFS_WORKSPACE_META_BACKEND must be redis or tikv"
+[[ "$mode" == init || "$mode" == seed || "$mode" == fork || "$mode" == verify ]] \
+    || die "usage: $0 {init|seed|fork|verify}"
+
+mkdir -p "$state_dir"
+
+catalog_cli_args=(
+    workspace
+    --meta-backend "$catalog_backend"
+    --workspace-namespace "$catalog_namespace"
+)
+case "$catalog_backend" in
+    redis) catalog_cli_args+=(--meta-url "$catalog_url") ;;
+    tikv) catalog_cli_args+=(--meta-tikv-pd-endpoints "$catalog_tikv_endpoints") ;;
+esac
+
+run_cli() {
+    "$bin" "${catalog_cli_args[@]}" "$@"
+}
+
+workspace_id_from_json() {
+    python3 - "$1" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as stream:
+    document = json.load(stream)
+if isinstance(document, list):
+    values = [item["workspace_id"] for item in document]
+    print("\n".join(values))
+else:
+    print(document["workspace_id"])
+PY
+}
+
+case "$mode" in
+    init)
+        run_cli init-volume --owner workspace-compose \
+            >"$state_dir/workspace-init.json"
+        workspace_id_from_json "$state_dir/workspace-init.json" \
+            | head -n 1 >"$state_dir/root-workspace.id"
+        printf '[workspace-overlay] initialized root workspace %s\n' \
+            "$(tr -d '[:space:]' <"$state_dir/root-workspace.id")"
+        ;;
+    seed)
+        root_workspace="$(tr -d '[:space:]' <"$state_dir/root-workspace.id")"
+        [[ -n "$root_workspace" ]] || die "root workspace id is missing"
+        export BREWFS_WORKSPACE_HARNESS_MODE=seed
+        export BREWFS_WORKSPACE_A="$root_workspace"
+        export BREWFS_WORKSPACE_CATALOG_URL="$catalog_url"
+        unset BREWFS_WORKSPACE_B || true
+        exec /usr/local/bin/run_workspace_overlay_dual_mount_in_container.sh
+        ;;
+    fork)
+        root_workspace="$(tr -d '[:space:]' <"$state_dir/root-workspace.id")"
+        [[ -n "$root_workspace" ]] || die "root workspace id is missing"
+        run_cli fork "$root_workspace" --count 2 --owner workspace-compose \
+            >"$state_dir/workspace-fork.json"
+        mapfile -t fork_ids < <(workspace_id_from_json "$state_dir/workspace-fork.json")
+        [[ "${#fork_ids[@]}" -eq 2 ]] || die "expected two forked workspaces"
+        printf '%s\n' "${fork_ids[0]}" >"$state_dir/workspace-a.id"
+        printf '%s\n' "${fork_ids[1]}" >"$state_dir/workspace-b.id"
+        printf '[workspace-overlay] forked workspaces %s and %s\n' \
+            "${fork_ids[0]}" "${fork_ids[1]}"
+        ;;
+    verify)
+        workspace_a="$(tr -d '[:space:]' <"$state_dir/workspace-a.id")"
+        workspace_b="$(tr -d '[:space:]' <"$state_dir/workspace-b.id")"
+        [[ -n "$workspace_a" && -n "$workspace_b" ]] \
+            || die "forked workspace ids are missing"
+        export BREWFS_WORKSPACE_HARNESS_MODE=verify
+        export BREWFS_WORKSPACE_A="$workspace_a"
+        export BREWFS_WORKSPACE_B="$workspace_b"
+        export BREWFS_WORKSPACE_CATALOG_URL="$catalog_url"
+        exec /usr/local/bin/run_workspace_overlay_dual_mount_in_container.sh
+        ;;
+esac

--- a/docker/compose-xfstests/run_workspace_overlay_dual_mount_in_container.sh
+++ b/docker/compose-xfstests/run_workspace_overlay_dual_mount_in_container.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+bin="${BREWFS_BIN:-/usr/local/bin/brewfs}"
+state_dir="${BREWFS_WORKSPACE_STATE_DIR:-/var/lib/brewfs}"
+catalog_url="${BREWFS_WORKSPACE_CATALOG_URL:-sqlite:workspace.db}"
+catalog_backend="${BREWFS_WORKSPACE_META_BACKEND:-sqlx}"
+catalog_tikv_endpoints="${BREWFS_WORKSPACE_TIKV_PD_ENDPOINTS:-pd:2379}"
+catalog_namespace="${BREWFS_WORKSPACE_NAMESPACE:-brewfs}"
+data_dir="${BREWFS_DATA_DIR:-$state_dir/data}"
+artifact_dir="${BREWFS_ARTIFACT_DIR:-/artifacts/workspace-dual-mount}"
+mount_a="${BREWFS_WORKSPACE_MOUNT_A:-/mnt/brewfs-a}"
+mount_b="${BREWFS_WORKSPACE_MOUNT_B:-/mnt/brewfs-b}"
+workspace_a="${BREWFS_WORKSPACE_A:?BREWFS_WORKSPACE_A is required}"
+workspace_b="${BREWFS_WORKSPACE_B:-}"
+mode="${BREWFS_WORKSPACE_HARNESS_MODE:-verify}"
+
+pid_a=""
+pid_b=""
+last_pid=""
+
+log() { printf '[workspace-overlay] %s\n' "$*"; }
+
+is_mounted() {
+    findmnt -rn --target "$1" --output FSTYPE 2>/dev/null | grep -Eq '^fuse(\.|$)'
+}
+
+stop_mount() {
+    local pid="$1"
+    local target="$2"
+    local status=0
+
+    if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+        kill -INT "$pid" 2>/dev/null || true
+        for _ in $(seq 1 100); do
+            kill -0 "$pid" 2>/dev/null || break
+            sleep 0.1
+        done
+    fi
+    if is_mounted "$target"; then
+        fusermount3 -u "$target" 2>/dev/null || umount "$target" 2>/dev/null || true
+    fi
+    if [[ -n "$pid" ]]; then
+        wait "$pid" 2>/dev/null || status=$?
+    fi
+    return "$status"
+}
+
+cleanup() {
+    local status=$?
+    set +e
+    stop_mount "$pid_b" "$mount_b"
+    stop_mount "$pid_a" "$mount_a"
+    if is_mounted "$mount_a" || is_mounted "$mount_b"; then
+        log "a mountpoint remained mounted during cleanup"
+        status=1
+    fi
+    exit "$status"
+}
+trap cleanup EXIT INT TERM
+
+start_mount() {
+    local workspace="$1"
+    local target="$2"
+    local cache_dir="$3"
+    local log_file="$4"
+    local fuse_log_file="${log_file%.log}.fuse.log"
+    local -a catalog_args=(
+        --meta-backend "$catalog_backend"
+        --workspace-namespace "$catalog_namespace"
+    )
+    case "$catalog_backend" in
+        sqlx|redis)
+            catalog_args+=(--meta-url "$catalog_url")
+            ;;
+        tikv)
+            catalog_args+=(--meta-tikv-pd-endpoints "$catalog_tikv_endpoints")
+            ;;
+        *)
+            log "unsupported workspace catalog backend: $catalog_backend"
+            return 2
+            ;;
+    esac
+
+    mkdir -p "$target" "$cache_dir" "$(dirname "$log_file")"
+    (
+        cd "$state_dir"
+        exec env \
+            XDG_CACHE_HOME="$cache_dir" \
+            BREWFS_FUSE_LOG_FILE="$fuse_log_file" \
+            "$bin" mount \
+            --privileged \
+            --volume-format workspace-v1 \
+            --workspace "$workspace" \
+            --data-backend local-fs \
+            --data-dir "$data_dir" \
+            "${catalog_args[@]}" \
+            "$target"
+    ) >"$log_file" 2>&1 &
+    last_pid=$!
+}
+
+wait_for_mount() {
+    local pid="$1"
+    local target="$2"
+    local log_file="$3"
+    local deadline=$((SECONDS + 60))
+
+    while (( SECONDS < deadline )); do
+        if is_mounted "$target"; then
+            return 0
+        fi
+        if ! kill -0 "$pid" 2>/dev/null; then
+            log "mount process exited before $target became ready"
+            sed -n '1,240p' "$log_file" >&2 || true
+            return 1
+        fi
+        sleep 0.1
+    done
+    log "timed out waiting for mount at $target"
+    sed -n '1,240p' "$log_file" >&2 || true
+    return 1
+}
+
+seed_base() {
+    log "seeding workspace $workspace_a"
+    printf 'shared-base\n' >"$mount_a/shared-base.txt"
+    printf '0123456789abcdef' >"$mount_a/base-data.bin"
+    python3 - "$mount_a/mmap-base.bin" <<'PY'
+import pathlib
+import sys
+
+pathlib.Path(sys.argv[1]).write_bytes(b"x" * 4096)
+PY
+    sync "$mount_a/shared-base.txt" "$mount_a/base-data.bin" "$mount_a/mmap-base.bin"
+}
+
+verify_isolation() {
+    [[ -n "$workspace_b" ]] || {
+        log "BREWFS_WORKSPACE_B is required in verify mode"
+        return 2
+    }
+
+    cmp -s "$mount_a/shared-base.txt" "$mount_b/shared-base.txt"
+    cmp -s "$mount_a/base-data.bin" "$mount_b/base-data.bin"
+    [[ "$(stat -c %i "$mount_a/base-data.bin")" == "$(stat -c %i "$mount_b/base-data.bin")" ]]
+
+    printf 'workspace-a\n' >"$mount_a/a-only.txt"
+    [[ ! -e "$mount_b/a-only.txt" ]]
+    printf 'workspace-b\n' >"$mount_b/b-only.txt"
+    [[ ! -e "$mount_a/b-only.txt" ]]
+
+    printf 'changed-in-a\n' >"$mount_a/shared-base.txt"
+    grep -qx 'shared-base' "$mount_b/shared-base.txt"
+
+    ln "$mount_a/a-only.txt" "$mount_a/a-hardlink.txt"
+    [[ "$(stat -c %i "$mount_a/a-only.txt")" == "$(stat -c %i "$mount_a/a-hardlink.txt")" ]]
+    [[ ! -e "$mount_b/a-hardlink.txt" ]]
+
+    setfattr -n user.workspace -v a "$mount_a/a-only.txt"
+    [[ "$(getfattr --only-values -n user.workspace "$mount_a/a-only.txt")" == a ]]
+    if getfattr --only-values -n user.workspace "$mount_b/shared-base.txt" >/dev/null 2>&1; then
+        log "workspace B unexpectedly observed workspace A xattr"
+        return 1
+    fi
+
+    python3 - "$mount_a/mmap-base.bin" <<'PY'
+import mmap
+import os
+import sys
+
+fd = os.open(sys.argv[1], os.O_RDWR)
+try:
+    with mmap.mmap(fd, 4096) as mapping:
+        mapping[128:132] = b"AGNT"
+        mapping.flush()
+finally:
+    os.close(fd)
+PY
+    [[ "$(dd if="$mount_a/mmap-base.bin" bs=1 skip=128 count=4 status=none)" == AGNT ]]
+    [[ "$(dd if="$mount_b/mmap-base.bin" bs=1 skip=128 count=4 status=none)" == xxxx ]]
+
+    fallocate --punch-hole --keep-size --offset 4 --length 4 "$mount_a/base-data.bin"
+    python3 - "$mount_a/base-data.bin" "$mount_b/base-data.bin" <<'PY'
+import pathlib
+import sys
+
+a = pathlib.Path(sys.argv[1]).read_bytes()
+b = pathlib.Path(sys.argv[2]).read_bytes()
+assert a == b"0123\0\0\0\089abcdef", a
+assert b == b"0123456789abcdef", b
+PY
+
+    touch "$mount_a/lock.txt" "$mount_b/lock.txt"
+    flock -x "$mount_a/lock.txt" -c 'sleep 2' &
+    local lock_pid=$!
+    sleep 0.2
+    if flock -n -x "$mount_a/lock.txt" -c true; then
+        log "same-workspace lock did not conflict"
+        wait "$lock_pid"
+        return 1
+    fi
+    flock -n -x "$mount_b/lock.txt" -c true
+    wait "$lock_pid"
+
+    sync "$mount_a" "$mount_b"
+    log "dual workspace isolation PASS"
+}
+
+mkdir -p "$state_dir" "$data_dir" "$artifact_dir"
+start_mount "$workspace_a" "$mount_a" "$state_dir/cache-a" "$artifact_dir/mount-a.log"
+pid_a=$last_pid
+wait_for_mount "$pid_a" "$mount_a" "$artifact_dir/mount-a.log"
+
+case "$mode" in
+    seed)
+        seed_base
+        ;;
+    verify)
+        start_mount "$workspace_b" "$mount_b" "$state_dir/cache-b" "$artifact_dir/mount-b.log"
+        pid_b=$last_pid
+        wait_for_mount "$pid_b" "$mount_b" "$artifact_dir/mount-b.log"
+        verify_isolation
+        ;;
+    *)
+        log "unsupported BREWFS_WORKSPACE_HARNESS_MODE: $mode"
+        exit 2
+        ;;
+esac

--- a/docker/compose-xfstests/run_workspace_overlay_suite_in_container.sh
+++ b/docker/compose-xfstests/run_workspace_overlay_suite_in_container.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# Run one filesystem suite against both forked workspaces.  The wrapper is
+# intentionally image-local so Compose can run it without mounting host
+# scripts into a privileged FUSE container.
+set -uo pipefail
+
+suite="${WORKSPACE_OVERLAY_SUITE:?WORKSPACE_OVERLAY_SUITE is required}"
+state_dir="${BREWFS_WORKSPACE_STATE_DIR:-/var/lib/brewfs}"
+artifact_root="${BREWFS_ARTIFACT_ROOT:-/artifacts}"
+
+case "$suite" in
+    xfstests)
+        suite_runner=/usr/local/bin/run_xfstests_in_container.sh
+        ;;
+    ltp)
+        suite_runner=/usr/local/bin/run_ltp_in_container.sh
+        ;;
+    *)
+        printf 'unsupported workspace overlay suite: %s\n' "$suite" >&2
+        exit 2
+        ;;
+esac
+
+status=0
+for workspace_label in a b; do
+    workspace_file="$state_dir/workspace-${workspace_label}.id"
+    if [[ ! -s "$workspace_file" ]]; then
+        printf 'missing workspace id: %s\n' "$workspace_file" >&2
+        status=2
+        continue
+    fi
+
+    workspace_id="$(tr -d '[:space:]' <"$workspace_file")"
+    artifact_dir="$artifact_root/workspace-${workspace_label}/${suite}"
+    mkdir -p "$artifact_dir"
+
+    printf '[workspace-overlay] running %s on workspace %s (%s)\n' \
+        "$suite" "$workspace_label" "$workspace_id"
+    set +e
+    env \
+        BREWFS_VOLUME_FORMAT=workspace-v1 \
+        BREWFS_WORKSPACE_ID="$workspace_id" \
+        BREWFS_ARTIFACT_DIR="$artifact_dir" \
+        BREWFS_ARTIFACT_ROOT="$artifact_root" \
+        BREWFS_WORKSPACE_STATE_DIR="$state_dir" \
+        bash "$suite_runner"
+    suite_status=$?
+    set -e
+    if (( suite_status != 0 )); then
+        printf '[workspace-overlay] %s failed on workspace %s (exit=%s)\n' \
+            "$suite" "$workspace_label" "$suite_status" >&2
+        status=1
+    fi
+done
+
+exit "$status"

--- a/docker/compose-xfstests/run_workspace_overlay_suites.sh
+++ b/docker/compose-xfstests/run_workspace_overlay_suites.sh
@@ -1,0 +1,370 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+ARTIFACT_ROOT="${BREWFS_WORKSPACE_ARTIFACT_ROOT:-$SCRIPT_DIR/artifacts}"
+XFSTESTS_IMAGE="${BREWFS_WORKSPACE_XFSTESTS_IMAGE:-brewfs-workspace-xfstests:local}"
+PJDFSTEST_IMAGE="${BREWFS_WORKSPACE_PJDFSTEST_IMAGE:-brewfs-workspace-pjdfstest:local}"
+FALLBACK_BASE_IMAGE="${BREWFS_WORKSPACE_FALLBACK_BASE_IMAGE:-slayerfs-xfstests:local}"
+XFSTESTS_CASES="generic/001 generic/002 generic/100"
+RUN_XFSTESTS=true
+RUN_PJDFSTEST=true
+BUILD_IMAGES=true
+PARALLEL_SUITES=false
+META_BACKEND="${BREWFS_WORKSPACE_META_BACKEND:-sqlite}"
+WORKSPACE_COUNT=2
+
+log() { printf '[workspace-overlay] %s\n' "$*"; }
+die() { log "ERROR: $*" >&2; exit 2; }
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [options]
+
+Build the feature-enabled BrewFS test images, create two workspaces from one
+sealed base, verify simultaneous FUSE isolation, and run each selected POSIX
+suite against both workspaces.
+
+Options:
+  --xfstests-cases "CASES"  xfstests cases (default: $XFSTESTS_CASES)
+  --skip-xfstests           do not run xfstests
+  --skip-pjdfstest          do not run pjdfstest
+  --reuse-images            reuse existing feature-enabled images
+  --parallel-suites         run workspace A and B suites concurrently
+  --single-workspace        run suites only on workspace A
+  --meta-backend BACKEND    workspace catalog: sqlite, redis or tikv
+  -h, --help                show this help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --xfstests-cases)
+            [[ $# -ge 2 ]] || die "--xfstests-cases requires a value"
+            XFSTESTS_CASES="$2"
+            shift 2
+            ;;
+        --skip-xfstests)
+            RUN_XFSTESTS=false
+            shift
+            ;;
+        --skip-pjdfstest)
+            RUN_PJDFSTEST=false
+            shift
+            ;;
+        --reuse-images)
+            BUILD_IMAGES=false
+            shift
+            ;;
+        --parallel-suites)
+            PARALLEL_SUITES=true
+            shift
+            ;;
+        --single-workspace)
+            WORKSPACE_COUNT=1
+            shift
+            ;;
+        --meta-backend)
+            [[ $# -ge 2 ]] || die "--meta-backend requires a value"
+            META_BACKEND="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            die "unknown option: $1"
+            ;;
+    esac
+done
+
+case "$META_BACKEND" in
+    sqlite|redis|tikv) ;;
+    *) die "--meta-backend must be sqlite, redis or tikv" ;;
+esac
+
+command -v cargo >/dev/null || die "cargo is required"
+command -v docker >/dev/null || die "docker is required"
+command -v python3 >/dev/null || die "python3 is required"
+[[ -e /dev/fuse ]] || die "/dev/fuse is required"
+
+ts="$(date +%Y%m%d-%H%M%S)-$RANDOM"
+run_dir="$ARTIFACT_ROOT/workspace-overlay-$ts"
+state_dir="$run_dir/state"
+mkdir -p "$state_dir" "$run_dir/dual-mount" "$run_dir/xfstests-a" \
+    "$run_dir/xfstests-b" "$run_dir/pjdfstest-a" "$run_dir/pjdfstest-b"
+
+network="brewfs-workspace-$ts"
+dependency_containers=()
+catalog_namespace="workspace-$ts"
+catalog_url="sqlite:///var/lib/brewfs/workspace.db?mode=rwc"
+catalog_cli_backend="sqlx"
+catalog_tikv_endpoints="pd:2379"
+harness_script="$SCRIPT_DIR/run_workspace_overlay_dual_mount_in_container.sh"
+
+cleanup_dependencies() {
+    local status=$?
+    set +e
+    for container in "${dependency_containers[@]}"; do
+        docker rm -f "$container" >/dev/null 2>&1 || true
+    done
+    docker network rm "$network" >/dev/null 2>&1 || true
+    exit "$status"
+}
+trap cleanup_dependencies EXIT INT TERM
+
+docker network create "$network" >/dev/null
+case "$META_BACKEND" in
+    sqlite)
+        ;;
+    redis)
+        catalog_cli_backend="redis"
+        catalog_url="redis://redis:6379"
+        redis_container="brewfs-workspace-redis-$ts"
+        dependency_containers+=("$redis_container")
+        log "starting Redis workspace catalog"
+        docker run --rm -d --name "$redis_container" --network "$network" \
+            --network-alias redis redis:7.2-alpine \
+            redis-server --save '' --appendonly no >/dev/null
+        for _ in $(seq 1 60); do
+            docker exec "$redis_container" redis-cli ping 2>/dev/null | grep -q PONG && break
+            sleep 1
+        done
+        docker exec "$redis_container" redis-cli ping 2>/dev/null | grep -q PONG \
+            || die "Redis did not become ready"
+        ;;
+    tikv)
+        catalog_cli_backend="tikv"
+        pd_container="brewfs-workspace-pd-$ts"
+        tikv_container="brewfs-workspace-tikv-$ts"
+        dependency_containers+=("$tikv_container" "$pd_container")
+        log "starting TiKV workspace catalog"
+        docker run --rm -d --name "$pd_container" --network "$network" \
+            --network-alias pd pingcap/pd:v8.5.0 \
+            --name=pd --data-dir=/data/pd \
+            --client-urls=http://0.0.0.0:2379 \
+            --advertise-client-urls=http://pd:2379 \
+            --peer-urls=http://0.0.0.0:2380 \
+            --advertise-peer-urls=http://pd:2380 \
+            --initial-cluster=pd=http://pd:2380 --log-level=warn >/dev/null
+        docker run --rm -d --name "$tikv_container" --network "$network" \
+            --network-alias tikv pingcap/tikv:v8.5.0 \
+            --addr=0.0.0.0:20160 --advertise-addr=tikv:20160 \
+            --status-addr=0.0.0.0:20180 --pd=pd:2379 \
+            --data-dir=/data/tikv --log-level=warn >/dev/null
+        for _ in $(seq 1 180); do
+            body="$(docker run --rm --network "$network" curlimages/curl:8.10.1 \
+                -fsS http://pd:2379/pd/api/v1/stores 2>/dev/null || true)"
+            grep -Eq '"state_name"[[:space:]]*:[[:space:]]*"Up"' <<<"$body" && break
+            sleep 1
+        done
+        grep -Eq '"state_name"[[:space:]]*:[[:space:]]*"Up"' <<<"${body:-}" \
+            || die "TiKV did not become ready"
+        ;;
+esac
+
+catalog_cli_args=(
+    workspace
+    --meta-backend "$catalog_cli_backend"
+    --workspace-namespace "$catalog_namespace"
+)
+case "$catalog_cli_backend" in
+    sqlx|redis) catalog_cli_args+=(--meta-url "$catalog_url") ;;
+    tikv) catalog_cli_args+=(--meta-tikv-pd-endpoints "$catalog_tikv_endpoints") ;;
+esac
+
+if [[ "$BUILD_IMAGES" == true ]]; then
+    log "building feature-enabled release binary"
+    (
+        cd "$PROJECT_DIR"
+        CARGO_PROFILE_RELEASE_DEBUG=0 cargo build --release -p brewfs --bin brewfs \
+            --features workspace-overlay
+        mkdir -p target/docker
+        install -m 755 target/release/brewfs target/docker/brewfs
+    )
+    log "building xfstests image $XFSTESTS_IMAGE"
+    if docker image inspect "$FALLBACK_BASE_IMAGE" >/dev/null 2>&1; then
+        docker build --pull=false \
+            --build-arg BASE_IMAGE="$FALLBACK_BASE_IMAGE" \
+            -t "$XFSTESTS_IMAGE" \
+            -f "$SCRIPT_DIR/Dockerfile.workspace-overlay-xfstests" "$PROJECT_DIR"
+    else
+        docker build -t "$XFSTESTS_IMAGE" -f "$SCRIPT_DIR/Dockerfile" "$PROJECT_DIR"
+    fi
+    if [[ "$RUN_PJDFSTEST" == true ]]; then
+        log "building pjdfstest image $PJDFSTEST_IMAGE"
+        if docker image inspect "$FALLBACK_BASE_IMAGE" >/dev/null 2>&1; then
+            docker build --pull=false \
+                --build-arg BASE_IMAGE="$FALLBACK_BASE_IMAGE" \
+                -t "$PJDFSTEST_IMAGE" \
+                -f "$SCRIPT_DIR/Dockerfile.workspace-overlay-pjdfstest" "$PROJECT_DIR"
+        else
+            docker build -t "$PJDFSTEST_IMAGE" -f "$SCRIPT_DIR/Dockerfile.pjdfstest" "$PROJECT_DIR"
+        fi
+    fi
+fi
+
+run_cli() {
+    docker run --rm \
+        --network "$network" \
+        --workdir /var/lib/brewfs \
+        -v "$state_dir:/var/lib/brewfs" \
+        --entrypoint /usr/local/bin/brewfs \
+        "$XFSTESTS_IMAGE" "$@"
+}
+
+extract_workspace_id() {
+    python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["workspace_id"])' "$1"
+}
+
+extract_fork_ids() {
+    python3 -c 'import json,sys; print("\n".join(item["workspace_id"] for item in json.load(open(sys.argv[1]))))' "$1"
+}
+
+run_dual_harness() {
+    local mode="$1"
+    local workspace_a="$2"
+    local workspace_b="${3:-}"
+    local artifacts="$4"
+    docker run --rm \
+        --network "$network" \
+        --privileged \
+        --device /dev/fuse:/dev/fuse \
+        --security-opt apparmor=unconfined \
+        --workdir /var/lib/brewfs \
+        -v "$state_dir:/var/lib/brewfs" \
+        -v "$artifacts:/artifacts" \
+        -v "$harness_script:/workspace-harness.sh:ro" \
+        -e BREWFS_WORKSPACE_HARNESS_MODE="$mode" \
+        -e BREWFS_WORKSPACE_A="$workspace_a" \
+        -e BREWFS_WORKSPACE_B="$workspace_b" \
+        -e BREWFS_WORKSPACE_CATALOG_URL="$catalog_url" \
+        -e BREWFS_WORKSPACE_META_BACKEND="$catalog_cli_backend" \
+        -e BREWFS_WORKSPACE_TIKV_PD_ENDPOINTS="$catalog_tikv_endpoints" \
+        -e BREWFS_WORKSPACE_NAMESPACE="$catalog_namespace" \
+        -e BREWFS_FUSE_OP_LOG="${BREWFS_FUSE_OP_LOG:-0}" \
+        -e RUST_LOG="${RUST_LOG:-brewfs=info,asyncfuse=warn}" \
+        --entrypoint /bin/bash \
+        "$XFSTESTS_IMAGE" /workspace-harness.sh
+}
+
+run_suite() {
+    local image="$1"
+    local workspace="$2"
+    local artifacts="$3"
+    local fuse_writeback="${BREWFS_FUSE_WRITEBACK:-}"
+    shift 3
+    # xfstests includes mmap timestamp checks (generic/080, generic/215).
+    # Enable FUSE writeback for the test mount so mmap dirty pages reach the
+    # filesystem release/flush path where mtime/ctime are persisted. Keep it
+    # overridable for debugging and performance comparisons.
+    if [[ "$image" == "$XFSTESTS_IMAGE" && -z "$fuse_writeback" ]]; then
+        fuse_writeback=1
+    fi
+    docker run --rm \
+        --network "$network" \
+        --privileged \
+        --device /dev/fuse:/dev/fuse \
+        --security-opt apparmor=unconfined \
+        --workdir /var/lib/brewfs \
+        -v "$state_dir:/var/lib/brewfs" \
+        -v "$artifacts:/artifacts" \
+        -e BREWFS_VOLUME_FORMAT=workspace-v1 \
+        -e BREWFS_WORKSPACE_ID="$workspace" \
+        -e BREWFS_META_BACKEND="$META_BACKEND" \
+        -e BREWFS_META_URL="$catalog_url" \
+        -e BREWFS_META_TIKV_PD_ENDPOINTS="$catalog_tikv_endpoints" \
+        -e BREWFS_META_TIKV_NAMESPACE="$catalog_namespace" \
+        -e BREWFS_WORKSPACE_NAMESPACE="$catalog_namespace" \
+        -e BREWFS_SQLITE_PATH=/var/lib/brewfs/workspace.db \
+        -e BREWFS_DATA_BACKEND=local-fs \
+        -e BREWFS_DATA_DIR=/var/lib/brewfs/data \
+        -e BREWFS_CACHE_ROOT="/var/lib/brewfs/suite-cache/$workspace" \
+        -e BREWFS_ARTIFACT_ROOT=/artifacts \
+        -e BREWFS_FUSE_WRITEBACK="$fuse_writeback" \
+        -e PJDFSTEST_INCLUDE_PATTERNS="${PJDFSTEST_INCLUDE_PATTERNS:-}" \
+        -e PJDFSTEST_SKIP_PATTERNS="${PJDFSTEST_SKIP_PATTERNS:-}" \
+        -e PJDFSTEST_EXTRA_ARGS="${PJDFSTEST_EXTRA_ARGS:-}" \
+        "$@" \
+        "$image"
+}
+
+log "initializing workspace volume"
+run_cli "${catalog_cli_args[@]}" init-volume --owner workspace-harness \
+    >"$run_dir/init.json"
+root_workspace="$(extract_workspace_id "$run_dir/init.json")"
+
+log "seeding shared base through a real FUSE mount"
+run_dual_harness seed "$root_workspace" "" "$run_dir/dual-mount"
+
+log "sealing the base and creating $WORKSPACE_COUNT O(1) fork(s)"
+run_cli "${catalog_cli_args[@]}" fork "$root_workspace" --count "$WORKSPACE_COUNT" \
+    --owner workspace-harness >"$run_dir/fork.json"
+mapfile -t fork_ids < <(extract_fork_ids "$run_dir/fork.json")
+[[ ${#fork_ids[@]} -eq "$WORKSPACE_COUNT" ]] \
+    || die "expected exactly $WORKSPACE_COUNT forked workspace(s)"
+workspace_a="${fork_ids[0]}"
+printf '%s\n' "$workspace_a" >"$run_dir/workspace-a.id"
+if (( WORKSPACE_COUNT == 2 )); then
+    workspace_b="${fork_ids[1]}"
+    printf '%s\n' "$workspace_b" >"$run_dir/workspace-b.id"
+fi
+
+if (( WORKSPACE_COUNT == 2 )); then
+    log "verifying simultaneous dual-workspace isolation"
+    run_dual_harness verify "$workspace_a" "$workspace_b" "$run_dir/dual-mount"
+else
+    log "single-workspace mode: skipping dual-workspace isolation check"
+fi
+
+status=0
+if [[ "$RUN_XFSTESTS" == true ]]; then
+    if (( WORKSPACE_COUNT == 1 )); then
+        log "running xfstests on workspace A"
+        run_suite "$XFSTESTS_IMAGE" "$workspace_a" "$run_dir/xfstests-a" \
+            -e XFSTESTS_CASES="$XFSTESTS_CASES" || status=1
+    elif [[ "$PARALLEL_SUITES" == true ]]; then
+        log "running xfstests concurrently on workspaces A and B"
+        run_suite "$XFSTESTS_IMAGE" "$workspace_a" "$run_dir/xfstests-a" \
+            -e XFSTESTS_CASES="$XFSTESTS_CASES" &
+        pid_a=$!
+        run_suite "$XFSTESTS_IMAGE" "$workspace_b" "$run_dir/xfstests-b" \
+            -e XFSTESTS_CASES="$XFSTESTS_CASES" &
+        pid_b=$!
+        wait "$pid_a" || status=1
+        wait "$pid_b" || status=1
+    else
+        log "running xfstests on workspace A"
+        run_suite "$XFSTESTS_IMAGE" "$workspace_a" "$run_dir/xfstests-a" \
+            -e XFSTESTS_CASES="$XFSTESTS_CASES" || status=1
+        log "running xfstests on workspace B"
+        run_suite "$XFSTESTS_IMAGE" "$workspace_b" "$run_dir/xfstests-b" \
+            -e XFSTESTS_CASES="$XFSTESTS_CASES" || status=1
+    fi
+fi
+
+if [[ "$RUN_PJDFSTEST" == true ]]; then
+    if (( WORKSPACE_COUNT == 1 )); then
+        log "running pjdfstest on workspace A"
+        run_suite "$PJDFSTEST_IMAGE" "$workspace_a" "$run_dir/pjdfstest-a" || status=1
+    elif [[ "$PARALLEL_SUITES" == true ]]; then
+        log "running pjdfstest concurrently on workspaces A and B"
+        run_suite "$PJDFSTEST_IMAGE" "$workspace_a" "$run_dir/pjdfstest-a" &
+        pid_a=$!
+        run_suite "$PJDFSTEST_IMAGE" "$workspace_b" "$run_dir/pjdfstest-b" &
+        pid_b=$!
+        wait "$pid_a" || status=1
+        wait "$pid_b" || status=1
+    else
+        log "running pjdfstest on workspace A"
+        run_suite "$PJDFSTEST_IMAGE" "$workspace_a" "$run_dir/pjdfstest-a" || status=1
+        log "running pjdfstest on workspace B"
+        run_suite "$PJDFSTEST_IMAGE" "$workspace_b" "$run_dir/pjdfstest-b" || status=1
+    fi
+fi
+
+log "artifacts: $run_dir"
+exit "$status"

--- a/docker/compose-xfstests/run_xfstests_in_container.sh
+++ b/docker/compose-xfstests/run_xfstests_in_container.sh
@@ -7,8 +7,22 @@ info() { log "INFO  $*"; }
 ok()   { log "OK    $*"; }
 err()  { log "ERROR $*" >&2; }
 
+validate_workspace_config() {
+    if [[ "$volume_format" == "workspace-v1" && -z "$workspace_id" ]]; then
+        err "BREWFS_WORKSPACE_ID is required for BREWFS_VOLUME_FORMAT=workspace-v1"
+        exit 2
+    fi
+    if [[ -n "$workspace_id" && "$volume_format" != "workspace-v1" ]]; then
+        err "BREWFS_WORKSPACE_ID requires BREWFS_VOLUME_FORMAT=workspace-v1"
+        exit 2
+    fi
+}
+
 config_path="${BREWFS_CONFIG_PATH:-/run/brewfs/config.yaml}"
 mount_dir="${BREWFS_MOUNT_POINT:-/mnt/brewfs}"
+volume_format="${BREWFS_VOLUME_FORMAT:-}"
+workspace_id="${BREWFS_WORKSPACE_ID:-}"
+workspace_namespace="${BREWFS_WORKSPACE_NAMESPACE:-brewfs}"
 data_backend="${BREWFS_DATA_BACKEND:-local-fs}"
 data_dir="${BREWFS_DATA_DIR:-${BREWFS_HOME:-/var/lib/brewfs}/data}"
 meta_backend="${BREWFS_META_BACKEND:-redis}"
@@ -88,6 +102,13 @@ write_config() {
 
     {
         echo "mount_point: $mount_dir"
+        if [[ -n "$volume_format" ]]; then
+            echo "volume_format: $volume_format"
+        fi
+        if [[ -n "$workspace_id" ]]; then
+            echo "workspace: $workspace_id"
+            echo "workspace_namespace: $workspace_namespace"
+        fi
         echo
         case "$data_backend" in
             local-fs)
@@ -594,6 +615,7 @@ EOF
 }
 
 main() {
+    validate_workspace_config
     local normalized_fuse_op_log
 
     if [[ -z "$artifact_dir" ]]; then

--- a/src/chunk/mod.rs
+++ b/src/chunk/mod.rs
@@ -22,6 +22,8 @@ pub mod compact;
 pub mod compress;
 pub mod layout;
 pub mod page_cache;
+#[cfg(feature = "workspace-overlay")]
+pub mod read_plan;
 pub mod reader;
 pub mod singleflight;
 pub mod slice;

--- a/src/chunk/read_plan.rs
+++ b/src/chunk/read_plan.rs
@@ -1,0 +1,337 @@
+//! Workspace-neutral resolved read plans and their block-store executor.
+
+use async_trait::async_trait;
+use futures_util::StreamExt;
+use futures_util::stream::FuturesUnordered;
+
+use super::{BlockStore, ChunkLayout, SliceOffset, block_span_iter_slice};
+use crate::meta::store::MetaError;
+use crate::utils::NumCastExt;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ReadPlanSegment {
+    Data {
+        logical_offset: u64,
+        length: u64,
+        slice_id: u64,
+        slice_offset: u64,
+    },
+    Zero {
+        logical_offset: u64,
+        length: u64,
+    },
+}
+
+impl ReadPlanSegment {
+    fn logical_offset(&self) -> u64 {
+        match self {
+            Self::Data { logical_offset, .. } | Self::Zero { logical_offset, .. } => {
+                *logical_offset
+            }
+        }
+    }
+
+    fn length(&self) -> u64 {
+        match self {
+            Self::Data { length, .. } | Self::Zero { length, .. } => *length,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ResolvedReadPlan {
+    pub segments: Vec<ReadPlanSegment>,
+}
+
+#[async_trait]
+pub trait WorkspaceReadPlanProvider: Send + Sync {
+    async fn read_plan(
+        &self,
+        ino: i64,
+        chunk_index: u64,
+        offset: u64,
+        len: u64,
+    ) -> Result<ResolvedReadPlan, MetaError>;
+
+    async fn range_has_data(&self, ino: i64, offset: u64, len: u64) -> Result<bool, MetaError>;
+
+    /// Persist an uploaded slice that could not be attached to the workspace head.
+    ///
+    /// Providers used only by tests may keep the no-op default. Production workspace
+    /// providers override this so GC can reclaim data uploaded before a fencing failure.
+    async fn record_orphan_slice(&self, _slice_id: u64, _slice_end: u64) -> Result<(), MetaError> {
+        Ok(())
+    }
+
+    /// Replace a file range with logical zeroes in the effective workspace view.
+    /// `keep_size` implements `FALLOC_FL_KEEP_SIZE`; otherwise the range may extend EOF.
+    async fn apply_hole_range(
+        &self,
+        _ino: i64,
+        _offset: u64,
+        _len: u64,
+        _keep_size: bool,
+    ) -> Result<u64, MetaError> {
+        Err(MetaError::NotSupported(
+            "workspace hole mutations are unavailable".into(),
+        ))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ReadPlanError {
+    #[error("invalid read plan: {0}")]
+    Invalid(String),
+    #[error(transparent)]
+    Backend(#[from] anyhow::Error),
+}
+
+struct SendBuf {
+    ptr: *mut u8,
+    len: usize,
+}
+
+// SAFETY: `execute_into` creates each SendBuf from a disjoint output range and
+// waits for every future before using the output again.
+unsafe impl Send for SendBuf {}
+
+impl SendBuf {
+    unsafe fn as_mut_slice(&mut self) -> &mut [u8] {
+        // SAFETY: upheld by the constructor site in `execute_into`.
+        unsafe { std::slice::from_raw_parts_mut(self.ptr, self.len) }
+    }
+}
+
+pub async fn execute_into<B: BlockStore + Sync>(
+    store: &B,
+    layout: ChunkLayout,
+    requested_offset: u64,
+    plan: &ResolvedReadPlan,
+    output: &mut [u8],
+) -> Result<(), ReadPlanError> {
+    let requested_len = u64::try_from(output.len())
+        .map_err(|_| ReadPlanError::Invalid("output length exceeds u64".into()))?;
+    let requested_end = requested_offset
+        .checked_add(requested_len)
+        .ok_or_else(|| ReadPlanError::Invalid("requested range overflows".into()))?;
+
+    let mut previous_end = requested_offset;
+    for segment in &plan.segments {
+        let start = segment.logical_offset();
+        let length = segment.length();
+        if length == 0 {
+            return Err(ReadPlanError::Invalid("zero-length segment".into()));
+        }
+        let end = start
+            .checked_add(length)
+            .ok_or_else(|| ReadPlanError::Invalid("segment range overflows".into()))?;
+        if start < requested_offset || end > requested_end {
+            return Err(ReadPlanError::Invalid(
+                "segment lies outside the requested range".into(),
+            ));
+        }
+        if start < previous_end {
+            return Err(ReadPlanError::Invalid(
+                "segments overlap or are not sorted".into(),
+            ));
+        }
+        previous_end = end;
+        if let ReadPlanSegment::Data {
+            slice_offset,
+            length,
+            ..
+        } = segment
+        {
+            slice_offset
+                .checked_add(*length)
+                .ok_or_else(|| ReadPlanError::Invalid("slice range overflows".into()))?;
+        }
+    }
+
+    output.fill(0);
+    let mut futures = FuturesUnordered::new();
+    for segment in &plan.segments {
+        let ReadPlanSegment::Data {
+            logical_offset,
+            length,
+            slice_id,
+            slice_offset,
+        } = *segment
+        else {
+            continue;
+        };
+        let output_start = usize::try_from(logical_offset - requested_offset)
+            .map_err(|_| ReadPlanError::Invalid("output offset exceeds usize".into()))?;
+        let output_len = usize::try_from(length)
+            .map_err(|_| ReadPlanError::Invalid("segment length exceeds usize".into()))?;
+        let output_end = output_start
+            .checked_add(output_len)
+            .ok_or_else(|| ReadPlanError::Invalid("output range overflows".into()))?;
+        let segment_output = &mut output[output_start..output_end];
+        let mut consumed = 0usize;
+        for block in block_span_iter_slice(SliceOffset::from(slice_offset), length, layout) {
+            let take = block.len.as_usize();
+            let block_end = consumed
+                .checked_add(take)
+                .ok_or_else(|| ReadPlanError::Invalid("block span overflows".into()))?;
+            let block_output = &mut segment_output[consumed..block_end];
+            consumed = block_end;
+            let mut send_buf = SendBuf {
+                ptr: block_output.as_mut_ptr(),
+                len: block_output.len(),
+            };
+            let key = (slice_id, block.index.as_u32());
+            let block_offset = block.offset;
+            futures.push(async move {
+                // SAFETY: block spans and plan segments were validated as disjoint.
+                store
+                    .read_range(key, block_offset, unsafe { send_buf.as_mut_slice() })
+                    .await
+            });
+        }
+        if consumed != output_len {
+            return Err(ReadPlanError::Invalid(
+                "block spans do not cover the data segment".into(),
+            ));
+        }
+    }
+    while let Some(result) = futures.next().await {
+        result?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
+    use bytes::Bytes;
+    use tokio::sync::Mutex;
+
+    use super::*;
+    use crate::chunk::store::BlockKey;
+
+    #[derive(Default)]
+    struct TestStore {
+        blocks: HashMap<BlockKey, Vec<u8>>,
+        reads: Arc<Mutex<Vec<BlockKey>>>,
+    }
+
+    #[async_trait]
+    impl BlockStore for TestStore {
+        async fn write_fresh_range(
+            &self,
+            _key: BlockKey,
+            _offset: u64,
+            _data: &[u8],
+        ) -> anyhow::Result<u64> {
+            anyhow::bail!("unused")
+        }
+
+        async fn write_fresh_vectored(
+            &self,
+            _key: BlockKey,
+            _offset: u64,
+            _chunks: Vec<Bytes>,
+        ) -> anyhow::Result<u64> {
+            anyhow::bail!("unused")
+        }
+
+        async fn read_range(
+            &self,
+            key: BlockKey,
+            offset: u64,
+            buf: &mut [u8],
+        ) -> anyhow::Result<()> {
+            self.reads.lock().await.push(key);
+            let block = self
+                .blocks
+                .get(&key)
+                .ok_or_else(|| anyhow::anyhow!("missing"))?;
+            let start = usize::try_from(offset)?;
+            buf.copy_from_slice(&block[start..start + buf.len()]);
+            Ok(())
+        }
+
+        async fn delete_range(&self, _key: BlockKey, _block_count: u64) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn executor_reads_only_data_segments_and_preserves_zeroes() {
+        let mut store = TestStore::default();
+        store.blocks.insert((7, 0), b"abcdefgh".to_vec());
+        let plan = ResolvedReadPlan {
+            segments: vec![
+                ReadPlanSegment::Zero {
+                    logical_offset: 2,
+                    length: 2,
+                },
+                ReadPlanSegment::Data {
+                    logical_offset: 4,
+                    length: 3,
+                    slice_id: 7,
+                    slice_offset: 1,
+                },
+                ReadPlanSegment::Zero {
+                    logical_offset: 7,
+                    length: 1,
+                },
+            ],
+        };
+        let mut output = [9; 6];
+        execute_into(
+            &store,
+            ChunkLayout {
+                chunk_size: 16,
+                block_size: 8,
+            },
+            2,
+            &plan,
+            &mut output,
+        )
+        .await
+        .unwrap();
+        assert_eq!(&output, b"\0\0bcd\0");
+        assert_eq!(store.reads.lock().await.as_slice(), &[(7, 0)]);
+    }
+
+    #[tokio::test]
+    async fn executor_rejects_overlap_and_out_of_range_before_io() {
+        let store = TestStore::default();
+        let cases = [
+            ResolvedReadPlan {
+                segments: vec![
+                    ReadPlanSegment::Zero {
+                        logical_offset: 0,
+                        length: 3,
+                    },
+                    ReadPlanSegment::Zero {
+                        logical_offset: 2,
+                        length: 1,
+                    },
+                ],
+            },
+            ResolvedReadPlan {
+                segments: vec![ReadPlanSegment::Data {
+                    logical_offset: 3,
+                    length: 2,
+                    slice_id: 1,
+                    slice_offset: 0,
+                }],
+            },
+        ];
+        for plan in cases {
+            let mut output = [0; 4];
+            assert!(
+                execute_into(&store, ChunkLayout::default(), 0, &plan, &mut output)
+                    .await
+                    .is_err()
+            );
+        }
+        assert!(store.reads.lock().await.is_empty());
+    }
+}

--- a/src/chunk/slice.rs
+++ b/src/chunk/slice.rs
@@ -219,11 +219,12 @@ impl SliceDesc {
 
     /// Decode the delayed deletion binary format into (slice_id, offset, size) tuples.
     pub fn decode_delayed_data(data: &[u8]) -> Option<Vec<(u64, u64, u32)>> {
-        if !data.len().is_multiple_of(20) {
+        let (chunks, remainder) = data.as_chunks::<20>();
+        if !remainder.is_empty() {
             return None;
         }
-        let mut out = Vec::with_capacity(data.len() / 20);
-        for chunk in data.chunks_exact(20) {
+        let mut out = Vec::with_capacity(chunks.len());
+        for chunk in chunks {
             let slice_id = u64::from_le_bytes(chunk[0..8].try_into().unwrap());
             let offset = u64::from_le_bytes(chunk[8..16].try_into().unwrap());
             let size = u32::from_le_bytes(chunk[16..20].try_into().unwrap());

--- a/src/config.rs
+++ b/src/config.rs
@@ -55,6 +55,10 @@ pub enum Command {
     )]
     Mount(Box<MountArgs>),
 
+    /// Manage isolated BrewFS workspaces.
+    #[cfg(feature = "workspace-overlay")]
+    Workspace(WorkspaceArgs),
+
     /// Talk to a mounted BrewFS instance and run orphan gc.
     Gc(GcArgs),
 
@@ -74,6 +78,21 @@ pub struct MountArgs {
     /// YAML config file path.
     #[arg(long, value_name = "FILE")]
     pub config: Option<PathBuf>,
+
+    /// On-disk metadata format. Existing configurations default to flat-v1.
+    #[cfg_attr(feature = "workspace-overlay", arg(long, value_enum))]
+    #[cfg_attr(not(feature = "workspace-overlay"), arg(skip))]
+    pub volume_format: Option<VolumeFormat>,
+
+    /// Workspace mounted by a workspace-v1 volume.
+    #[cfg_attr(feature = "workspace-overlay", arg(long, value_name = "WORKSPACE_ID"))]
+    #[cfg_attr(not(feature = "workspace-overlay"), arg(skip))]
+    pub workspace: Option<uuid::Uuid>,
+
+    /// Key namespace for the workspace overlay catalog.
+    #[cfg_attr(feature = "workspace-overlay", arg(long, value_name = "NAMESPACE"))]
+    #[cfg_attr(not(feature = "workspace-overlay"), arg(skip))]
+    pub workspace_namespace: Option<String>,
 
     /// Directory to mount the filesystem.
     #[arg(value_name = "MOUNT_POINT")]
@@ -156,6 +175,96 @@ pub struct MountArgs {
     /// Uses /dev/fuse directly instead of fusermount3.
     #[arg(long, default_value_t = false)]
     pub privileged: bool,
+}
+
+#[derive(ValueEnum, Deserialize, Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub enum VolumeFormat {
+    #[default]
+    FlatV1,
+    WorkspaceV1,
+}
+
+#[cfg(feature = "workspace-overlay")]
+#[derive(Args, Debug, Clone)]
+pub struct WorkspaceArgs {
+    /// Workspace catalog backend (sqlx, redis or tikv).
+    #[arg(long, global = true, value_enum, default_value = "sqlx")]
+    pub meta_backend: WorkspaceMetaBackendKind,
+
+    /// SQLite or Redis URL containing the workspace-v1 catalog.
+    #[arg(long, global = true, default_value = DEFAULT_META_URL)]
+    pub meta_url: String,
+
+    /// TiKV PD endpoint URLs (comma-separated).
+    #[arg(long, global = true, value_name = "URLS", value_delimiter = ',')]
+    pub meta_tikv_pd_endpoints: Vec<String>,
+
+    /// Key namespace for the workspace overlay catalog.
+    #[arg(long, global = true, default_value = "brewfs")]
+    pub workspace_namespace: String,
+
+    #[command(subcommand)]
+    pub command: WorkspaceCommand,
+}
+
+#[cfg(feature = "workspace-overlay")]
+#[derive(Subcommand, Debug, Clone)]
+pub enum WorkspaceCommand {
+    /// Initialize a new workspace-v1 volume and its default workspace.
+    InitVolume {
+        #[arg(long)]
+        owner: Option<String>,
+    },
+    /// Create a workspace from an exact sealed revision.
+    Create {
+        #[arg(long = "from", value_name = "REVISION")]
+        revision: Option<crate::workspace_overlay::model::BaseRevision>,
+        #[arg(long)]
+        owner: Option<String>,
+    },
+    /// Seal a workspace and create a named snapshot root.
+    Snapshot {
+        workspace: crate::workspace_overlay::ids::WorkspaceId,
+        #[arg(long)]
+        name: Option<String>,
+        #[arg(long)]
+        owner: Option<String>,
+    },
+    /// Fork one or more workspaces from a workspace UUID or exact revision.
+    Fork {
+        source: String,
+        #[arg(long, default_value_t = 1)]
+        count: usize,
+        #[arg(long)]
+        owner: Option<String>,
+    },
+    /// List workspaces.
+    List,
+    /// Inspect one workspace and its active lease/seal state.
+    Inspect {
+        workspace: crate::workspace_overlay::ids::WorkspaceId,
+    },
+    /// Show path-level changes against the fork base or an exact revision.
+    Diff {
+        workspace: crate::workspace_overlay::ids::WorkspaceId,
+        #[arg(long, value_name = "REVISION")]
+        against: Option<crate::workspace_overlay::model::BaseRevision>,
+        #[arg(long, default_value_t = DEFAULT_CHUNK_SIZE)]
+        chunk_size: u64,
+    },
+    /// Mark a workspace for lease-aware garbage collection.
+    Discard {
+        workspace: crate::workspace_overlay::ids::WorkspaceId,
+        #[arg(long)]
+        force: bool,
+    },
+    /// Seal and fast-forward a target workspace if its base is unchanged.
+    Commit {
+        workspace: crate::workspace_overlay::ids::WorkspaceId,
+        #[arg(long = "to")]
+        target: crate::workspace_overlay::ids::WorkspaceId,
+    },
 }
 
 #[derive(Args, Debug, Clone)]
@@ -284,9 +393,21 @@ pub enum MetaBackendKind {
     TiKv,
 }
 
+#[cfg(feature = "workspace-overlay")]
+#[derive(ValueEnum, Clone, Copy, Debug, Eq, PartialEq)]
+pub enum WorkspaceMetaBackendKind {
+    Sqlx,
+    Redis,
+    #[value(name = "tikv", alias = "ti-kv")]
+    TiKv,
+}
+
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct MountFileConfig {
     pub mount_point: Option<PathBuf>,
+    pub volume_format: Option<VolumeFormat>,
+    pub workspace: Option<uuid::Uuid>,
+    pub workspace_namespace: Option<String>,
     pub data: Option<DataFileConfig>,
     pub meta: Option<MetaFileConfig>,
     pub layout: Option<LayoutFileConfig>,
@@ -397,6 +518,9 @@ pub struct BandwidthFileConfig {
 #[derive(Debug, Clone)]
 pub struct MountConfig {
     pub mount_point: PathBuf,
+    pub volume_format: VolumeFormat,
+    pub workspace: Option<uuid::Uuid>,
+    pub workspace_namespace: String,
     pub data_backend: DataBackendKind,
     pub data_dir: PathBuf,
     pub s3_bucket: Option<String>,
@@ -445,6 +569,20 @@ impl MountConfig {
         let fuse_cfg = file_cfg.fuse.unwrap_or_default();
         let cache_cfg = file_cfg.cache.unwrap_or_default();
         let compact = file_cfg.compact.unwrap_or_default();
+        let workspace = args.workspace.or(file_cfg.workspace);
+        let volume_format = args
+            .volume_format
+            .or(file_cfg.volume_format)
+            .unwrap_or_else(|| {
+                if workspace.is_some() {
+                    VolumeFormat::WorkspaceV1
+                } else {
+                    VolumeFormat::FlatV1
+                }
+            });
+        if workspace.is_some() && volume_format == VolumeFormat::FlatV1 {
+            anyhow::bail!("workspace id cannot be used with volume_format=flat-v1");
+        }
         let cache = cache_cfg.into_cache_config()?;
         let data_backend = args
             .data_backend
@@ -475,6 +613,12 @@ impl MountConfig {
 
         Ok(Self {
             mount_point,
+            volume_format,
+            workspace,
+            workspace_namespace: args
+                .workspace_namespace
+                .or(file_cfg.workspace_namespace)
+                .unwrap_or_else(|| "brewfs".to_string()),
             data_backend,
             data_dir: args
                 .data_dir
@@ -674,6 +818,9 @@ mod tests {
     fn empty_mount_args(config: Option<PathBuf>, mount_point: Option<PathBuf>) -> MountArgs {
         MountArgs {
             config,
+            volume_format: None,
+            workspace: None,
+            workspace_namespace: None,
             mount_point,
             data_backend: None,
             data_dir: None,
@@ -812,6 +959,9 @@ mod tests {
     fn mount_config_defaults_use_low_overhead_fuse_dispatch() {
         let config = MountConfig::from_sources(MountArgs {
             config: None,
+            volume_format: None,
+            workspace: None,
+            workspace_namespace: None,
             mount_point: Some(PathBuf::from("/mnt/slayer")),
             data_backend: None,
             data_dir: None,
@@ -837,12 +987,47 @@ mod tests {
 
         assert_eq!(config.fuse_workers, 1);
         assert_eq!(config.fuse_max_background, DEFAULT_FUSE_MAX_BACKGROUND);
+        assert_eq!(config.volume_format, VolumeFormat::FlatV1);
+        assert!(config.workspace.is_none());
+    }
+
+    #[test]
+    fn default_cli_surface_does_not_expose_workspace_commands() {
+        let help = Cli::command().render_long_help().to_string();
+
+        #[cfg(not(feature = "workspace-overlay"))]
+        assert!(!help.contains("workspace"));
+        #[cfg(feature = "workspace-overlay")]
+        assert!(help.contains("workspace"));
+    }
+
+    #[cfg(feature = "workspace-overlay")]
+    #[test]
+    fn workspace_mount_flags_are_feature_gated_and_parse() {
+        let id = uuid::Uuid::from_u128(77);
+        let cli = Cli::parse_from([
+            "brewfs",
+            "mount",
+            "/mnt/workspace",
+            "--volume-format",
+            "workspace-v1",
+            "--workspace",
+            &id.to_string(),
+        ]);
+        let Command::Mount(args) = cli.cmd else {
+            panic!("expected mount command");
+        };
+        assert_eq!(args.volume_format, Some(VolumeFormat::WorkspaceV1));
+        assert_eq!(args.workspace, Some(id));
     }
 
     #[test]
     fn mount_config_defaults_raise_s3_concurrency() {
         let config = MountConfig::from_sources(MountArgs {
             config: None,
+            volume_format: None,
+            workspace: None,
+            workspace_namespace: None,
             mount_point: Some(PathBuf::from("/mnt/slayer")),
             data_backend: None,
             data_dir: None,
@@ -868,6 +1053,43 @@ mod tests {
 
         assert_eq!(config.s3_max_concurrency, DEFAULT_S3_MAX_CONCURRENCY);
         assert_eq!(config.s3_max_concurrency, 32);
+    }
+
+    #[test]
+    fn legacy_config_defaults_flat_but_workspace_marker_is_parseable() {
+        let path = std::env::temp_dir().join(format!(
+            "brewfs-workspace-format-config-{}-{}.yaml",
+            std::process::id(),
+            uuid::Uuid::now_v7()
+        ));
+        std::fs::write(
+            &path,
+            "mount_point: /mnt/workspace\nvolume_format: workspace-v1\nworkspace: 00000000-0000-0000-0000-000000000077\n",
+        )
+        .unwrap();
+        let config = MountConfig::from_sources(empty_mount_args(Some(path.clone()), None)).unwrap();
+        let _ = std::fs::remove_file(path);
+
+        assert_eq!(config.volume_format, VolumeFormat::WorkspaceV1);
+        assert_eq!(config.workspace, Some(uuid::Uuid::from_u128(0x77)));
+    }
+
+    #[test]
+    fn workspace_id_selects_workspace_format_and_rejects_explicit_flat_format() {
+        let workspace = uuid::Uuid::from_u128(88);
+        let mut args = empty_mount_args(None, Some(PathBuf::from("/mnt/workspace")));
+        args.workspace = Some(workspace);
+        let config = MountConfig::from_sources(args.clone()).unwrap();
+        assert_eq!(config.volume_format, VolumeFormat::WorkspaceV1);
+        assert_eq!(config.workspace, Some(workspace));
+
+        args.volume_format = Some(VolumeFormat::FlatV1);
+        assert!(
+            MountConfig::from_sources(args)
+                .unwrap_err()
+                .to_string()
+                .contains("workspace id cannot be used")
+        );
     }
 
     #[test]

--- a/src/fuse/mod.rs
+++ b/src/fuse/mod.rs
@@ -313,6 +313,22 @@ where
     }
 
     #[cfg(target_os = "linux")]
+    fn ioctl_fsgetxattr_reply() -> ReplyIoctl {
+        // xfs_io's `stat` probes FS_IOC_FSGETXATTR before printing the
+        // portable stat fields.  FUSE has no project-specific fsxattr state,
+        // but returning a zeroed structure is the same neutral answer that a
+        // filesystem with no flags/project quota would expose and avoids
+        // leaking an unsupported-ioctl diagnostic into xfstests output.
+        ReplyIoctl {
+            result: 0,
+            flags: 0,
+            in_iovs: 0,
+            out_iovs: 0,
+            data: vec![0; 28], // sizeof(struct fsxattr) on Linux
+        }
+    }
+
+    #[cfg(target_os = "linux")]
     fn parse_clone_range(data: &[u8]) -> Option<FileCloneRange> {
         if data.len() < size_of::<FileCloneRange>() {
             return None;
@@ -433,7 +449,15 @@ where
             .await
         {
             Ok(attr) => Some(attr),
-            Err(_err) => self.stat_ino(ino).await,
+            Err(err) => {
+                warn!(
+                    ino,
+                    error = %err,
+                    error_debug = ?err,
+                    "fuse.apply_new_entry_attrs_failed"
+                );
+                self.stat_ino(ino).await
+            }
         }
     }
 
@@ -1917,7 +1941,18 @@ where
         mode: u32,
     ) -> FuseResult<()> {
         debug!(inode, fh, offset, length, mode, "fuse.fallocate");
-        if mode != 0 {
+        #[cfg(feature = "workspace-overlay")]
+        let workspace_hole_mode = {
+            let keep_size = libc::FALLOC_FL_KEEP_SIZE as u32;
+            let punch_hole = libc::FALLOC_FL_PUNCH_HOLE as u32;
+            let zero_range = libc::FALLOC_FL_ZERO_RANGE as u32;
+            mode == (keep_size | punch_hole)
+                || mode == zero_range
+                || mode == (keep_size | zero_range)
+        };
+        #[cfg(not(feature = "workspace-overlay"))]
+        let workspace_hole_mode = false;
+        if mode != 0 && !workspace_hole_mode {
             return Err(libc::EOPNOTSUPP.into());
         }
         if length > 0 {
@@ -1930,6 +1965,14 @@ where
             .await?;
             self.wait_for_prior_fuse_writes(inode as i64, req.unique)
                 .await;
+        }
+        #[cfg(feature = "workspace-overlay")]
+        if workspace_hole_mode {
+            let keep_size = mode & libc::FALLOC_FL_KEEP_SIZE as u32 != 0;
+            return self
+                .workspace_hole_fallocate_from_fuse(fh, inode as i64, offset, length, keep_size)
+                .await
+                .map_err(Errno::from);
         }
         if fh != 0 {
             // The FALLOCATE reply already updates the initiating kernel's
@@ -2050,6 +2093,9 @@ where
         #[cfg(target_os = "linux")]
         {
             match cmd {
+                // FS_IOC_FSGETXATTR = _IOR('X', 31, struct fsxattr).
+                // xfs_io labels this probe FS_IOC_GETXATTR in diagnostics.
+                0x801c_581f => Ok(Self::ioctl_fsgetxattr_reply()),
                 x if x == libc::FICLONE as u32 => self.ioctl_ficlone(req, inode, arg).await,
                 x if x == libc::FICLONERANGE as u32 => {
                     self.ioctl_ficlonerange(req, inode, in_data).await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,9 @@ pub mod sdk_fs;
 // Expose vfs for E2E testing - tests should rely on design contracts, not impl details
 pub mod vfs;
 
+#[cfg(feature = "workspace-overlay")]
+pub mod workspace_overlay;
+
 pub(crate) mod utils;
 
 // Public SDK surface for external users.

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,8 @@ mod posix;
 mod utils;
 #[allow(dead_code)]
 mod vfs;
+#[cfg(feature = "workspace-overlay")]
+pub mod workspace_overlay;
 
 #[cfg(all(feature = "jemalloc", target_os = "linux"))]
 use tikv_jemallocator::Jemalloc;
@@ -61,6 +63,33 @@ use crate::meta::factory::MetaStoreFactory;
 use crate::meta::layer::MetaLayer;
 use crate::meta::stores::{DatabaseMetaStore, EtcdMetaStore, RedisMetaStore, TiKvMetaStore};
 use crate::vfs::fs::VFS;
+#[cfg(feature = "workspace-overlay")]
+use crate::workspace_overlay::catalog::{CreateVolumeRoot, WorkspaceStore};
+#[cfg(feature = "workspace-overlay")]
+use crate::workspace_overlay::control::WorkspaceControl;
+#[cfg(feature = "workspace-overlay")]
+use crate::workspace_overlay::gc::WorkspaceGc;
+#[cfg(feature = "workspace-overlay")]
+use crate::workspace_overlay::ids::{LayerId, WorkspaceId};
+#[cfg(feature = "workspace-overlay")]
+use crate::workspace_overlay::lifecycle::{
+    DEFAULT_HEARTBEAT_INTERVAL, DEFAULT_LEASE_TTL, NoopDurableRemoteBarrier, WorkspaceLifecycle,
+    WorkspaceMountSession,
+};
+#[cfg(feature = "workspace-overlay")]
+use crate::workspace_overlay::meta_layer::WorkspaceMetaLayer;
+#[cfg(feature = "workspace-overlay")]
+use crate::workspace_overlay::model::WORKSPACE_SCHEMA_VERSION;
+#[cfg(feature = "workspace-overlay")]
+use crate::workspace_overlay::publish::diff::WorkspaceDiff;
+#[cfg(feature = "workspace-overlay")]
+use crate::workspace_overlay::stores::database::SqliteWorkspaceStore;
+#[cfg(feature = "workspace-overlay")]
+use crate::workspace_overlay::stores::kv_store::KvWorkspaceStore;
+#[cfg(feature = "workspace-overlay")]
+use crate::workspace_overlay::stores::redis::RedisWorkspaceBackend;
+#[cfg(feature = "workspace-overlay")]
+use crate::workspace_overlay::stores::tikv::TiKvWorkspaceBackend;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -70,6 +99,8 @@ async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     let result = match cli.cmd {
         Command::Mount(args) => mount_cmd(MountConfig::from_sources(*args)?).await,
+        #[cfg(feature = "workspace-overlay")]
+        Command::Workspace(args) => workspace_cmd(args).await,
         Command::Gc(args) => gc_cmd(args).await,
         Command::Info(args) => info_cmd(args).await,
         Command::Console(args) => console::serve_cmd(args).await,
@@ -323,6 +354,7 @@ fn init_tracing() {
 }
 
 async fn mount_cmd(args: MountConfig) -> anyhow::Result<()> {
+    validate_volume_format_support(args.volume_format)?;
     if !args.mount_point.exists() {
         std::fs::create_dir_all(&args.mount_point)?;
     }
@@ -345,21 +377,49 @@ async fn mount_cmd(args: MountConfig) -> anyhow::Result<()> {
         data_backend = ?args.data_backend,
         "mount startup begin"
     );
-    let meta_store = create_meta_store(&args).await?;
-    tracing::info!("mount startup meta store ready");
-
     match args.data_backend {
         DataBackendKind::LocalFs => {
             let client = create_localfs_client(&args)?;
             tracing::info!("mount startup localfs client ready");
             let store = create_object_store(client, layout, &args.cache).await?;
-            mount_with_store(layout, store, meta_store, &args).await
+            dispatch_mount(layout, store, &args).await
         }
         DataBackendKind::S3 => {
             let client = create_s3_client(&args).await?;
             tracing::info!("mount startup s3 client ready");
             let store = create_object_store(client, layout, &args.cache).await?;
-            mount_with_store(layout, store, meta_store, &args).await
+            dispatch_mount(layout, store, &args).await
+        }
+    }
+}
+
+fn validate_volume_format_support(format: VolumeFormat) -> anyhow::Result<()> {
+    match format {
+        VolumeFormat::FlatV1 => Ok(()),
+        #[cfg(feature = "workspace-overlay")]
+        VolumeFormat::WorkspaceV1 => Ok(()),
+        #[cfg(not(feature = "workspace-overlay"))]
+        VolumeFormat::WorkspaceV1 => {
+            Err(anyhow::anyhow!("feature not compiled: workspace-overlay"))
+        }
+    }
+}
+
+async fn dispatch_mount<S>(layout: ChunkLayout, store: S, args: &MountConfig) -> anyhow::Result<()>
+where
+    S: BlockStore + Send + Sync + 'static,
+{
+    match args.volume_format {
+        VolumeFormat::FlatV1 => {
+            let meta_store = create_meta_store(args).await?;
+            tracing::info!("mount startup meta store ready");
+            mount_with_store(layout, store, meta_store, args).await
+        }
+        #[cfg(feature = "workspace-overlay")]
+        VolumeFormat::WorkspaceV1 => mount_workspace_with_store(layout, store, args).await,
+        #[cfg(not(feature = "workspace-overlay"))]
+        VolumeFormat::WorkspaceV1 => {
+            anyhow::bail!("feature not compiled: workspace-overlay")
         }
     }
 }
@@ -708,6 +768,392 @@ where
     Ok(())
 }
 
+#[cfg(feature = "workspace-overlay")]
+async fn mount_workspace_with_store<S>(
+    layout: ChunkLayout,
+    store: S,
+    args: &MountConfig,
+) -> anyhow::Result<()>
+where
+    S: BlockStore + Send + Sync + 'static,
+{
+    match args.meta_backend {
+        MetaBackendKind::Sqlx => {
+            if !args.meta_url.starts_with("sqlite:") {
+                anyhow::bail!("workspace-v1 sqlx catalog requires a SQLite URL")
+            }
+            let catalog = Arc::new(SqliteWorkspaceStore::connect(&args.meta_url).await?);
+            mount_workspace_with_catalog(layout, store, args, catalog).await
+        }
+        MetaBackendKind::Redis => {
+            let backend =
+                RedisWorkspaceBackend::connect(&args.meta_url, &args.workspace_namespace).await?;
+            let catalog = Arc::new(KvWorkspaceStore::new(backend));
+            mount_workspace_with_catalog(layout, store, args, catalog).await
+        }
+        MetaBackendKind::TiKv => {
+            let backend = TiKvWorkspaceBackend::connect(
+                args.meta_tikv_pd_endpoints.clone(),
+                &args.workspace_namespace,
+            )
+            .await?;
+            let catalog = Arc::new(KvWorkspaceStore::new(backend));
+            mount_workspace_with_catalog(layout, store, args, catalog).await
+        }
+        MetaBackendKind::Etcd => {
+            anyhow::bail!("workspace-v1 does not support the etcd catalog backend")
+        }
+    }
+}
+
+#[cfg(feature = "workspace-overlay")]
+async fn mount_workspace_with_catalog<S, W>(
+    layout: ChunkLayout,
+    store: S,
+    args: &MountConfig,
+    workspace_store: Arc<W>,
+) -> anyhow::Result<()>
+where
+    S: BlockStore + Send + Sync + 'static,
+    W: WorkspaceStore + 'static,
+{
+    let workspace_id = args.workspace.map(WorkspaceId::from_uuid).ok_or_else(|| {
+        anyhow::anyhow!("--workspace is required when volume_format is workspace-v1")
+    })?;
+    let header = workspace_store
+        .load_volume_header()
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("corrupt workspace metadata: volume marker is missing"))?;
+    if header.volume_format != "workspace-v1" {
+        anyhow::bail!(
+            "workspace volume marker mismatch: expected workspace-v1, found {}",
+            header.volume_format
+        )
+    }
+    if header.schema_version != WORKSPACE_SCHEMA_VERSION {
+        anyhow::bail!(
+            "unsupported workspace schema version {}",
+            header.schema_version
+        )
+    }
+    WorkspaceLifecycle::new(workspace_store.clone())
+        .recover_incomplete_seals()
+        .await?;
+
+    let generation = new_workspace_holder_generation();
+    let session = WorkspaceMountSession::acquire(
+        workspace_store.clone(),
+        workspace_id,
+        generation,
+        DEFAULT_LEASE_TTL,
+        DEFAULT_HEARTBEAT_INTERVAL,
+    )
+    .await?;
+    let block_store = Arc::new(store);
+    let gc_cancel = tokio_util::sync::CancellationToken::new();
+    let gc_task = {
+        let cancel = gc_cancel.clone();
+        let gc = WorkspaceGc::new(
+            workspace_store.clone(),
+            block_store.clone(),
+            layout,
+            DEFAULT_LEASE_TTL.saturating_mul(2),
+            DEFAULT_LEASE_TTL.saturating_mul(2),
+        );
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(DEFAULT_LEASE_TTL);
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            interval.tick().await;
+            loop {
+                tokio::select! {
+                    _ = cancel.cancelled() => break,
+                    _ = interval.tick() => {
+                        if let Err(error) = gc.run_once().await {
+                            tracing::warn!(?error, "workspace layer/orphan GC cycle failed");
+                        }
+                    }
+                }
+            }
+        })
+    };
+    let mount_result = async {
+        let meta_layer = Arc::new(WorkspaceMetaLayer::with_chunk_size(
+            workspace_store,
+            session.view.clone(),
+            layout.chunk_size,
+        ));
+        meta_layer.initialize().await?;
+        let writeback_root = crate::workspace_overlay::cache_scope::writeback_root(
+            &args.cache.cache_root,
+            header.volume_id,
+            workspace_id,
+            session.view.head_epoch,
+        )?;
+        let vfs_config =
+            crate::vfs::config::VFSConfig::new_with_cache_config(layout, args.cache.clone())
+                .workspace_writeback_root(writeback_root)
+                .workspace_writer_epoch(session.view.holder_generation);
+        let fs = VFS::from_workspace_components(vfs_config, block_store, meta_layer)?;
+        let concurrency = FuseConcurrencyConfig {
+            worker_count: args.fuse_workers,
+            max_background: args.fuse_max_background,
+        };
+        let handle = if args.privileged {
+            mount_vfs_privileged(fs, &args.mount_point, concurrency).await?
+        } else {
+            mount_vfs_unprivileged(fs, &args.mount_point, concurrency).await?
+        };
+        println!(
+            "mounted workspace {} at {}",
+            workspace_id,
+            args.mount_point.display()
+        );
+        let mut handle = handle;
+        tokio::select! {
+            signal = tokio::signal::ctrl_c() => {
+                signal?;
+                println!("unmounting...");
+                handle.unmount().await?;
+            }
+            result = &mut handle => {
+                result?;
+            }
+        }
+        Ok::<(), anyhow::Error>(())
+    }
+    .await;
+    gc_cancel.cancel();
+    let _ = gc_task.await;
+    let release_result = session.release().await;
+    mount_result?;
+    release_result?;
+    Ok(())
+}
+
+#[cfg(feature = "workspace-overlay")]
+async fn workspace_cmd(args: WorkspaceArgs) -> anyhow::Result<()> {
+    let WorkspaceArgs {
+        meta_backend,
+        meta_url,
+        meta_tikv_pd_endpoints,
+        workspace_namespace,
+        command,
+    } = args;
+    match meta_backend {
+        WorkspaceMetaBackendKind::Sqlx => {
+            if !meta_url.starts_with("sqlite:") {
+                anyhow::bail!("workspace-v1 sqlx catalog requires a SQLite URL")
+            }
+            workspace_cmd_with_catalog(
+                command,
+                Arc::new(SqliteWorkspaceStore::connect(&meta_url).await?),
+            )
+            .await
+        }
+        WorkspaceMetaBackendKind::Redis => {
+            let backend = RedisWorkspaceBackend::connect(&meta_url, &workspace_namespace).await?;
+            workspace_cmd_with_catalog(command, Arc::new(KvWorkspaceStore::new(backend))).await
+        }
+        WorkspaceMetaBackendKind::TiKv => {
+            let backend =
+                TiKvWorkspaceBackend::connect(meta_tikv_pd_endpoints, &workspace_namespace).await?;
+            workspace_cmd_with_catalog(command, Arc::new(KvWorkspaceStore::new(backend))).await
+        }
+    }
+}
+
+#[cfg(feature = "workspace-overlay")]
+async fn workspace_cmd_with_catalog<W>(
+    command: WorkspaceCommand,
+    store: Arc<W>,
+) -> anyhow::Result<()>
+where
+    W: WorkspaceStore + 'static,
+{
+    match command {
+        WorkspaceCommand::InitVolume { owner } => {
+            store.initialize_workspace_schema().await?;
+            if store.load_volume_header().await?.is_some() {
+                anyhow::bail!("workspace volume is already initialized")
+            }
+            let workspace = store
+                .create_volume_root(CreateVolumeRoot {
+                    volume_id: uuid::Uuid::now_v7(),
+                    workspace_id: WorkspaceId::new(),
+                    root_layer_id: LayerId::new(),
+                    writable_layer_id: LayerId::new(),
+                    owner_id: owner,
+                })
+                .await?;
+            print_json(&workspace)?;
+        }
+        WorkspaceCommand::Create { revision, owner } => {
+            validate_workspace_header(&store).await?;
+            let revision = match revision {
+                Some(revision) => revision,
+                None => store
+                    .list_workspaces()
+                    .await?
+                    .into_iter()
+                    .filter_map(|workspace| workspace.fork_base)
+                    .next()
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "volume has no initial sealed revision; pass --from <revision>"
+                        )
+                    })?,
+            };
+            let mut created = WorkspaceLifecycle::new(store)
+                .fork_revision(revision, 1, owner)
+                .await?;
+            print_json(&created.remove(0))?;
+        }
+        WorkspaceCommand::Snapshot {
+            workspace,
+            name,
+            owner,
+        } => {
+            validate_workspace_header(&store).await?;
+            let revision = seal_workspace(store.clone(), workspace).await?;
+            let snapshot = WorkspaceLifecycle::new(store)
+                .snapshot_revision(revision, name, owner)
+                .await?;
+            print_json(&snapshot)?;
+        }
+        WorkspaceCommand::Fork {
+            source,
+            count,
+            owner,
+        } => {
+            validate_workspace_header(&store).await?;
+            if count == 0 {
+                anyhow::bail!("--count must be greater than zero")
+            }
+            let revision = match source.parse() {
+                Ok(revision) => revision,
+                Err(_) => {
+                    let workspace = source.parse::<WorkspaceId>().map_err(|error| {
+                        anyhow::anyhow!(
+                            "source must be a workspace UUID or exact revision: {error}"
+                        )
+                    })?;
+                    seal_workspace(store.clone(), workspace).await?
+                }
+            };
+            let created = WorkspaceLifecycle::new(store)
+                .fork_revision(revision, count, owner)
+                .await?;
+            print_json(&created)?;
+        }
+        WorkspaceCommand::List => {
+            validate_workspace_header(&store).await?;
+            print_json(&store.list_workspaces().await?)?;
+        }
+        WorkspaceCommand::Inspect { workspace } => {
+            validate_workspace_header(&store).await?;
+            print_json(&WorkspaceControl::new(store).inspect(workspace).await?)?;
+        }
+        WorkspaceCommand::Diff {
+            workspace,
+            against,
+            chunk_size,
+        } => {
+            validate_workspace_header(&store).await?;
+            let record = store.load_workspace(workspace).await?;
+            let base = against.or(record.fork_base).ok_or_else(|| {
+                anyhow::anyhow!("workspace has no fork base; pass --against <revision>")
+            })?;
+            let changes = WorkspaceDiff::new(store, chunk_size)
+                .diff(&base, record.head_layer_id)
+                .await?;
+            print_json(&changes)?;
+        }
+        WorkspaceCommand::Discard { workspace, force } => {
+            validate_workspace_header(&store).await?;
+            WorkspaceLifecycle::new(store)
+                .discard(workspace, force)
+                .await?;
+            println!("discarded {workspace}");
+        }
+        WorkspaceCommand::Commit { workspace, target } => {
+            validate_workspace_header(&store).await?;
+            let source = store.load_workspace(workspace).await?;
+            let fork_base = source.fork_base.clone().ok_or_else(|| {
+                anyhow::anyhow!("source workspace has no exact fork-base revision")
+            })?;
+            let revision = seal_workspace(store.clone(), workspace).await?;
+            let target = store.load_workspace(target).await?;
+            let result = WorkspaceLifecycle::new(store)
+                .fast_forward(revision, fork_base, &target)
+                .await?;
+            print_json(&result)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(feature = "workspace-overlay")]
+async fn validate_workspace_header<W: WorkspaceStore + ?Sized>(
+    store: &Arc<W>,
+) -> anyhow::Result<()> {
+    let header = store
+        .load_volume_header()
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("corrupt workspace metadata: volume marker is missing"))?;
+    if header.volume_format != "workspace-v1" {
+        anyhow::bail!("unsupported volume format {}", header.volume_format)
+    }
+    if header.schema_version != WORKSPACE_SCHEMA_VERSION {
+        anyhow::bail!(
+            "unsupported workspace schema version {}",
+            header.schema_version
+        )
+    }
+    Ok(())
+}
+
+#[cfg(feature = "workspace-overlay")]
+async fn seal_workspace<W>(
+    store: Arc<W>,
+    workspace_id: WorkspaceId,
+) -> anyhow::Result<crate::workspace_overlay::model::BaseRevision>
+where
+    W: WorkspaceStore + 'static,
+{
+    let generation = new_workspace_holder_generation();
+    let session = WorkspaceMountSession::acquire(
+        store.clone(),
+        workspace_id,
+        generation,
+        DEFAULT_LEASE_TTL,
+        DEFAULT_HEARTBEAT_INTERVAL,
+    )
+    .await?;
+    let result = WorkspaceLifecycle::new(store)
+        .seal(&session.view, &NoopDurableRemoteBarrier)
+        .await;
+    let release_result = session.release().await;
+    let revision = result?.revision;
+    release_result?;
+    Ok(revision)
+}
+
+#[cfg(feature = "workspace-overlay")]
+fn new_workspace_holder_generation() -> u64 {
+    let suffix = u64::from_be_bytes(
+        uuid::Uuid::now_v7().as_bytes()[8..16]
+            .try_into()
+            .expect("UUID suffix has eight bytes"),
+    );
+    (suffix & i64::MAX as u64).max(1)
+}
+
+#[cfg(feature = "workspace-overlay")]
+fn print_json(value: &impl serde::Serialize) -> anyhow::Result<()> {
+    println!("{}", serde_json::to_string_pretty(value)?);
+    Ok(())
+}
+
 async fn gc_cmd(args: GcArgs) -> anyhow::Result<()> {
     let registry = RuntimeRegistry::new(RuntimeRegistry::default_root());
     let mount_point = args.mount_point.as_ref().map(|path| path.to_string_lossy());
@@ -945,5 +1391,35 @@ fn database_type_from_url(url: &str) -> DatabaseType {
         DatabaseType::Sqlite {
             url: url.to_string(),
         }
+    }
+}
+
+#[cfg(test)]
+mod volume_format_tests {
+    use super::*;
+
+    #[test]
+    fn flat_format_is_always_supported() {
+        validate_volume_format_support(VolumeFormat::FlatV1).unwrap();
+    }
+
+    #[cfg(feature = "workspace-overlay")]
+    #[test]
+    fn workspace_holder_generation_fits_the_sqlite_integer_domain() {
+        for _ in 0..256 {
+            let generation = new_workspace_holder_generation();
+            assert!((1..=i64::MAX as u64).contains(&generation));
+        }
+    }
+
+    #[cfg(not(feature = "workspace-overlay"))]
+    #[test]
+    fn flat_only_binary_fails_closed_for_workspace_format() {
+        assert_eq!(
+            validate_volume_format_support(VolumeFormat::WorkspaceV1)
+                .unwrap_err()
+                .to_string(),
+            "feature not compiled: workspace-overlay"
+        );
     }
 }

--- a/src/vfs/backend.rs
+++ b/src/vfs/backend.rs
@@ -5,6 +5,8 @@ use std::sync::Arc;
 pub(crate) struct Backend<B, M> {
     store: Arc<B>,
     meta: Arc<M>,
+    #[cfg(feature = "workspace-overlay")]
+    workspace_read_plan: Option<Arc<dyn crate::chunk::read_plan::WorkspaceReadPlanProvider>>,
 }
 
 impl<B, M> Backend<B, M>
@@ -13,7 +15,25 @@ where
     M: MetaLayer,
 {
     pub(crate) fn new(store: Arc<B>, meta: Arc<M>) -> Self {
-        Self { store, meta }
+        Self {
+            store,
+            meta,
+            #[cfg(feature = "workspace-overlay")]
+            workspace_read_plan: None,
+        }
+    }
+
+    #[cfg(feature = "workspace-overlay")]
+    pub(crate) fn new_workspace(
+        store: Arc<B>,
+        meta: Arc<M>,
+        workspace_read_plan: Arc<dyn crate::chunk::read_plan::WorkspaceReadPlanProvider>,
+    ) -> Self {
+        Self {
+            store,
+            meta,
+            workspace_read_plan: Some(workspace_read_plan),
+        }
     }
 
     pub(crate) fn meta(&self) -> &M {
@@ -22,5 +42,12 @@ where
 
     pub(crate) fn store(&self) -> &B {
         &self.store
+    }
+
+    #[cfg(feature = "workspace-overlay")]
+    pub(crate) fn workspace_read_plan(
+        &self,
+    ) -> Option<&dyn crate::chunk::read_plan::WorkspaceReadPlanProvider> {
+        self.workspace_read_plan.as_deref()
     }
 }

--- a/src/vfs/cache/write_back.rs
+++ b/src/vfs/cache/write_back.rs
@@ -451,13 +451,13 @@ impl WriteBackCache for FsWriteBackCache {
 
         let slice_path = key.slice_path(&self.root);
 
-        if self.allocation_unit > 0 {
+        if let Some(allocation_unit) = std::num::NonZeroU64::new(self.allocation_unit) {
+            let allocation_unit = allocation_unit.get();
             let data_len = data.iter().map(Bytes::len).sum::<usize>() as u64;
-            let allocation_start = slice_offset / self.allocation_unit * self.allocation_unit;
+            let allocation_start = slice_offset / allocation_unit * allocation_unit;
             let data_end = slice_offset.saturating_add(data_len);
-            let allocation_end = data_end.saturating_add(self.allocation_unit - 1)
-                / self.allocation_unit
-                * self.allocation_unit;
+            let allocation_end =
+                data_end.saturating_add(allocation_unit - 1) / allocation_unit * allocation_unit;
             let allocation_len = allocation_end.saturating_sub(allocation_start);
             let allocation_path = slice_path.clone();
             tokio::task::spawn_blocking(move || {

--- a/src/vfs/config.rs
+++ b/src/vfs/config.rs
@@ -1,5 +1,7 @@
 use crate::chunk::ChunkLayout;
 use crate::vfs::cache::config::CacheConfig;
+#[cfg(feature = "workspace-overlay")]
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -263,6 +265,10 @@ pub struct VFSConfig {
     pub read: Arc<ReadConfig>,
     pub write: Arc<WriteConfig>,
     pub cache: Arc<CacheConfig>,
+    #[cfg(feature = "workspace-overlay")]
+    pub workspace_writeback_root: Option<PathBuf>,
+    #[cfg(feature = "workspace-overlay")]
+    pub workspace_writer_epoch: u64,
 }
 
 #[allow(dead_code)]
@@ -311,7 +317,27 @@ impl VFSConfig {
                 .writeback_require_stage_before_commit(cache.writeback_require_stage_before_commit),
         );
 
-        Self { read, write, cache }
+        Self {
+            read,
+            write,
+            cache,
+            #[cfg(feature = "workspace-overlay")]
+            workspace_writeback_root: None,
+            #[cfg(feature = "workspace-overlay")]
+            workspace_writer_epoch: 0,
+        }
+    }
+
+    #[cfg(feature = "workspace-overlay")]
+    pub fn workspace_writeback_root(mut self, root: PathBuf) -> Self {
+        self.workspace_writeback_root = Some(root);
+        self
+    }
+
+    #[cfg(feature = "workspace-overlay")]
+    pub fn workspace_writer_epoch(mut self, epoch: u64) -> Self {
+        self.workspace_writer_epoch = epoch;
+        self
     }
 }
 

--- a/src/vfs/fs/mod.rs
+++ b/src/vfs/fs/mod.rs
@@ -435,6 +435,29 @@ where
                             };
                             let backend = backend.clone();
                             tasks.push(tokio::spawn(async move {
+                                #[cfg(feature = "workspace-overlay")]
+                                if let Some(provider) = backend.workspace_read_plan() {
+                                    let Ok(plan) = provider
+                                        .read_plan(ino, span.index, span.offset, span.len)
+                                        .await
+                                    else {
+                                        return;
+                                    };
+                                    let Ok(len) = usize::try_from(span.len) else {
+                                        return;
+                                    };
+                                    let mut output = vec![0; len];
+                                    let _ = crate::chunk::read_plan::execute_into(
+                                        backend.store(),
+                                        layout,
+                                        span.offset,
+                                        &plan,
+                                        &mut output,
+                                    )
+                                    .await;
+                                    return;
+                                }
+
                                 let mut fetcher = DataFetcher::new(layout, cid, &*backend);
                                 if fetcher.prepare_slices().await.is_err() {
                                     return;
@@ -467,6 +490,12 @@ where
             config.cache.writeback_mode,
             crate::vfs::cache::config::WriteBackMode::CommitBeforeUpload
         ) {
+            #[cfg(feature = "workspace-overlay")]
+            let cache_root = config
+                .workspace_writeback_root
+                .clone()
+                .unwrap_or_else(|| config.cache.cache_root.join("writeback"));
+            #[cfg(not(feature = "workspace-overlay"))]
             let cache_root = config.cache.cache_root.join("writeback");
             let _ = std::fs::create_dir_all(&cache_root);
             let wb = Arc::new(if config.cache.persist_write_cache_after_upload {
@@ -502,6 +531,10 @@ where
 
         let mut writer_builder =
             DataWriter::new(config.write.clone(), backend, reader.clone(), write_back);
+        #[cfg(feature = "workspace-overlay")]
+        {
+            writer_builder = writer_builder.with_writeback_epoch(config.workspace_writer_epoch);
+        }
         if let Some(memory_budget) = memory_budget.clone() {
             writer_builder = writer_builder.with_memory_budget(memory_budget);
         }
@@ -579,6 +612,28 @@ where
         }
     }
 
+    async fn record_recovery_orphan(
+        backend: &Arc<Backend<S, M>>,
+        slice_id: u64,
+        slice_end: u64,
+    ) -> bool {
+        #[cfg(not(feature = "workspace-overlay"))]
+        let _ = (backend, slice_id, slice_end);
+        #[cfg(feature = "workspace-overlay")]
+        if let Some(provider) = backend.workspace_read_plan()
+            && let Err(error) = provider.record_orphan_slice(slice_id, slice_end).await
+        {
+            tracing::error!(
+                slice_id,
+                slice_end,
+                error = ?error,
+                "failed to persist recovered workspace orphan; retaining dirty record"
+            );
+            return false;
+        }
+        true
+    }
+
     async fn reupload_recovered_slice(
         wb: &crate::vfs::cache::write_back::FsWriteBackCache,
         backend: &Arc<Backend<S, M>>,
@@ -634,7 +689,9 @@ where
                     slice_id,
                     "recovery skipped: inode deleted, removing orphan dirty record"
                 );
-                let _ = wb.remove(&record.key).await;
+                if Self::record_recovery_orphan(backend, slice_id, record.length).await {
+                    let _ = wb.remove(&record.key).await;
+                }
                 return;
             }
             Err(e) => {
@@ -648,14 +705,23 @@ where
             .write(ino, record.chunk_id, desc, new_size)
             .await
         {
-            // If the inode was deleted between stat and write, clean up and move on.
-            if matches!(e, MetaError::NotFound(_)) {
+            // If the inode disappeared or this workspace generation was fenced,
+            // the uploaded object can never be attached to this mutation.
+            #[cfg(feature = "workspace-overlay")]
+            let workspace_fenced = backend.workspace_read_plan().is_some()
+                && matches!(&e, MetaError::Io(error) if error.raw_os_error() == Some(libc::ESTALE));
+            #[cfg(not(feature = "workspace-overlay"))]
+            let workspace_fenced = false;
+            if matches!(&e, MetaError::NotFound(_)) || workspace_fenced {
                 tracing::warn!(
                     ino,
                     slice_id,
-                    "recovery metadata commit: inode gone, removing orphan dirty record"
+                    workspace_fenced,
+                    "recovery metadata commit is terminal; recording uploaded orphan"
                 );
-                let _ = wb.remove(&record.key).await;
+                if Self::record_recovery_orphan(backend, slice_id, record.length).await {
+                    let _ = wb.remove(&record.key).await;
+                }
                 return;
             }
             tracing::warn!(ino, slice_id, error = ?e, "recovery metadata commit failed");
@@ -900,10 +966,39 @@ where
         meta_layer: Arc<M>,
         background_tasks: Option<VfsBackgroundTasks>,
     ) -> Result<Self, VfsError> {
+        let backend = Arc::new(Backend::new(store.clone(), meta_layer.clone()));
+        Self::from_components_with_backend(config, store, meta_layer, background_tasks, backend)
+    }
+
+    #[cfg(feature = "workspace-overlay")]
+    pub(crate) fn from_workspace_components(
+        config: VFSConfig,
+        store: Arc<S>,
+        meta_layer: Arc<M>,
+    ) -> Result<Self, VfsError>
+    where
+        M: crate::chunk::read_plan::WorkspaceReadPlanProvider,
+    {
+        let provider: Arc<dyn crate::chunk::read_plan::WorkspaceReadPlanProvider> =
+            meta_layer.clone();
+        let backend = Arc::new(Backend::new_workspace(
+            store.clone(),
+            meta_layer.clone(),
+            provider,
+        ));
+        Self::from_components_with_backend(config, store, meta_layer, None, backend)
+    }
+
+    fn from_components_with_backend(
+        config: VFSConfig,
+        store: Arc<S>,
+        meta_layer: Arc<M>,
+        background_tasks: Option<VfsBackgroundTasks>,
+        backend: Arc<Backend<S, M>>,
+    ) -> Result<Self, VfsError> {
         let layout = config.write.layout;
         let root_ino = meta_layer.root_ino();
         let meta_metrics = meta_layer.metrics();
-        let backend = Arc::new(Backend::new(store.clone(), meta_layer.clone()));
         let core = Arc::new(VfsCore::new(layout, backend.clone(), meta_layer, root_ino));
         let config = Arc::new(config);
         let state = Arc::new(VfsState::new(config, backend));
@@ -1455,6 +1550,14 @@ where
         offset: u64,
         len: usize,
     ) -> Result<bool, VfsError> {
+        #[cfg(feature = "workspace-overlay")]
+        if let Some(provider) = self.core.backend.workspace_read_plan() {
+            return provider
+                .range_has_data(ino, offset, len as u64)
+                .await
+                .map_err(|err| VfsError::from_meta(PathHint::none(), err));
+        }
+
         let layout = self.core.layout;
         for span in split_chunk_spans(layout, offset, len) {
             let chunk_id = chunk_id_for(ino, span.index).map_err(VfsError::from)?;
@@ -2745,6 +2848,78 @@ where
             .await
     }
 
+    #[cfg(feature = "workspace-overlay")]
+    pub(crate) async fn workspace_hole_fallocate_from_fuse(
+        &self,
+        fh: u64,
+        ino: i64,
+        offset: u64,
+        length: u64,
+        keep_size: bool,
+    ) -> Result<(), VfsError> {
+        let Some(provider) = self.core.backend.workspace_read_plan() else {
+            return Err(VfsError::Unsupported);
+        };
+        if fh != 0 {
+            let handle = self.file_handle_required(fh)?;
+            if handle.ino != ino {
+                return Err(VfsError::StaleNetworkFileHandle);
+            }
+            if !handle.flags.write {
+                return Err(VfsError::PermissionDenied {
+                    path: PathHint::none(),
+                });
+            }
+            if handle.attr().kind != FileType::File {
+                return Err(VfsError::InvalidInput);
+            }
+        } else if self.meta_stat_required(ino, PathHint::none()).await?.kind != FileType::File {
+            return Err(VfsError::InvalidInput);
+        }
+        if length == 0 {
+            return Ok(());
+        }
+
+        self.flush_before_truncate(ino, offset, "workspace_hole_fallocate")
+            .await?;
+        let mutation_lock = self.state.append_lock(ino);
+        let _mutation_guard = mutation_lock.lock_owned().await;
+        let handles = self.file_handles_for_inode(ino);
+        let mut guards = Vec::with_capacity(handles.len());
+        for handle in handles {
+            guards.push(handle.lock_write().await);
+        }
+        // A write may have completed between the optimistic pre-flush and lock
+        // acquisition. Drain it while all inode writers are excluded so the hole
+        // is ordered after every previously accepted write.
+        self.state.writer.flush_if_exists(ino as u64).await;
+
+        let size = provider
+            .apply_hole_range(ino, offset, length, keep_size)
+            .await
+            .map_err(|error| VfsError::from_meta(PathHint::none(), error))?;
+        let _ = self
+            .state
+            .reader
+            .invalidate(
+                ino as u64,
+                offset,
+                usize::try_from(length).map_err(|_| VfsError::FileTooLarge)?,
+            )
+            .await;
+        let inode = self.ensure_inode_registered(ino).await?;
+        inode.set_size(size);
+        inode.set_committed_size(size);
+        inode.invalidate_allocated_blocks();
+        inode.bump_data_epoch();
+        if let Some(mut attr) = self.state.handles.attr_for_inode(ino) {
+            attr.size = size;
+            self.state.handles.update_attr_for_inode(ino, &attr);
+        }
+        drop(guards);
+        Ok(())
+    }
+
     async fn fallocate_handle_inner(
         &self,
         fh: u64,
@@ -3607,12 +3782,13 @@ where
         write: bool,
         append: bool,
     ) -> Result<u64, VfsError> {
-        let fh = self
-            .open_with_attr_refresh(ino, attr.clone(), read, write, append, false)
+        // `allocate` is infallible, so record the metadata open first. If a
+        // stale cached attr loses a race with unlink/final-close, no VFS handle
+        // is left behind when the metadata layer rejects the open.
+        self.meta_record_open(ino, attr.clone(), read, write, append)
             .await?;
-        self.meta_record_open(ino, attr, read, write, append)
-            .await?;
-        Ok(fh)
+        self.open_with_attr_refresh(ino, attr, read, write, append, false)
+            .await
     }
 
     pub(crate) async fn open_fresh_ino(
@@ -3641,12 +3817,10 @@ where
             });
         }
 
-        let fh = self
-            .open_with_attr_refresh(ino, attr.clone(), read, write, append, false)
+        self.meta_record_open(ino, attr.clone(), read, write, append)
             .await?;
-        self.meta_record_open(ino, attr, read, write, append)
-            .await?;
-        Ok(fh)
+        self.open_with_attr_refresh(ino, attr, read, write, append, false)
+            .await
     }
 
     async fn open_with_attr_refresh(
@@ -3668,12 +3842,26 @@ where
                     latest_attr = fresh;
                     record_open = true;
                 }
-                Ok(None) => {}
+                Ok(None) => {
+                    return Err(VfsError::NotFound {
+                        path: PathHint::none(),
+                    });
+                }
                 Err(err) => {
                     tracing::warn!("open: stat_fresh failed for ino {}: {}", ino, err);
                     return Err(VfsError::StaleNetworkFileHandle);
                 }
             }
+        }
+
+        if record_open {
+            if let Some(inode) = self.state.inodes.get(&ino)
+                && inode.file_size() > latest_attr.size
+            {
+                latest_attr.size = inode.file_size();
+            }
+            self.meta_record_open(ino, latest_attr.clone(), read, write, append)
+                .await?;
         }
 
         let guard = self
@@ -3685,15 +3873,10 @@ where
             latest_attr.size = guard.file_size();
         }
 
-        let record_attr = record_open.then(|| latest_attr.clone());
         let handle =
             self.state
                 .handles
                 .allocate(ino, latest_attr, HandleFlags::new(read, write, append));
-        if let Some(attr) = record_attr {
-            self.meta_record_open(ino, attr, read, write, append)
-                .await?;
-        }
         Ok(handle.fh)
     }
 
@@ -3813,16 +3996,34 @@ where
             return Ok(());
         }
 
-        let flushed_pending = self
+        let flushed_pending = match self
             .state
             .writer
             .flush_required_snapshot(handle.ino as u64)
             .await
-            .map_err(VfsError::from)?;
+        {
+            Ok(flushed_pending) => flushed_pending,
+            Err(error) => {
+                tracing::warn!(
+                    fh,
+                    ino = handle.ino,
+                    error = %error,
+                    error_debug = ?error,
+                    "vfs.flush_dirty_snapshot_failed"
+                );
+                return Err(VfsError::from(error));
+            }
+        };
 
         if Self::flush_needs_mtime_ctime_update(dirty_state, flushed_pending)
             && let Err(err) = self.update_mtime_ctime(handle.ino).await
         {
+            tracing::warn!(
+                fh,
+                ino = handle.ino,
+                error = %err,
+                "vfs.flush_dirty_snapshot_timestamp_failed"
+            );
             handle.mark_write_dirty();
             return Err(err);
         }
@@ -3840,12 +4041,19 @@ where
 
         tracing::info!(fh, ino = handle.ino, "vfs.flush_handle_start");
         let dirty_state = self.state.handles.take_write_dirty_for_inode(handle.ino);
-        let flushed_pending = self
-            .state
-            .writer
-            .flush_required(handle.ino as u64)
-            .await
-            .map_err(VfsError::from)?;
+        let flushed_pending = match self.state.writer.flush_required(handle.ino as u64).await {
+            Ok(flushed_pending) => flushed_pending,
+            Err(error) => {
+                tracing::warn!(
+                    fh,
+                    ino = handle.ino,
+                    error = %error,
+                    error_debug = ?error,
+                    "vfs.flush_handle_failed"
+                );
+                return Err(VfsError::from(error));
+            }
+        };
         tracing::trace!(fh, ino = handle.ino, "vfs.flush_handle_done");
 
         if Self::flush_needs_mtime_ctime_update(dirty_state, flushed_pending)
@@ -3912,17 +4120,35 @@ where
 
         tracing::info!(fh, ino = handle.ino, "vfs.flush_handle_start");
         let dirty_state = self.state.handles.take_write_dirty_for_inode(handle.ino);
-        let flushed_pending = self
+        let flushed_pending = match self
             .state
             .writer
             .flush_required_snapshot(handle.ino as u64)
             .await
-            .map_err(VfsError::from)?;
+        {
+            Ok(flushed_pending) => flushed_pending,
+            Err(error) => {
+                tracing::warn!(
+                    fh,
+                    ino = handle.ino,
+                    error = %error,
+                    error_debug = ?error,
+                    "vfs.fsync_snapshot_failed"
+                );
+                return Err(VfsError::from(error));
+            }
+        };
         tracing::trace!(fh, ino = handle.ino, "vfs.flush_handle_done");
 
         if Self::flush_needs_mtime_ctime_update(dirty_state, flushed_pending)
             && let Err(err) = self.update_mtime_ctime(handle.ino).await
         {
+            tracing::warn!(
+                fh,
+                ino = handle.ino,
+                error = %err,
+                "vfs.fsync_snapshot_timestamp_failed"
+            );
             if dirty_state.dirty {
                 handle.mark_write_dirty();
             }

--- a/src/vfs/io/reader.rs
+++ b/src/vfs/io/reader.rs
@@ -863,6 +863,22 @@ where
 
         for attempt in 0..MAX_SLICE_READ_RETRIES {
             let result = async {
+                #[cfg(feature = "workspace-overlay")]
+                if let Some(provider) = self.backend.workspace_read_plan() {
+                    let plan = provider
+                        .read_plan(self.inode.ino(), index, offset, u64::try_from(out.len())?)
+                        .await?;
+                    crate::chunk::read_plan::execute_into(
+                        self.backend.store(),
+                        self.config.layout,
+                        offset,
+                        &plan,
+                        out,
+                    )
+                    .await?;
+                    return Ok::<(), anyhow::Error>(());
+                }
+
                 let slices_arc = match self.chunk_slices.get(&chunk_id) {
                     Some(cached) => cached.clone(),
                     None => {
@@ -1030,6 +1046,84 @@ mod tests {
             chunk_size: 8 * 1024,
             block_size: 4 * 1024,
         }
+    }
+
+    #[cfg(feature = "workspace-overlay")]
+    struct StaticWorkspacePlan {
+        plan: crate::chunk::read_plan::ResolvedReadPlan,
+        calls: AtomicUsize,
+    }
+
+    #[cfg(feature = "workspace-overlay")]
+    #[async_trait::async_trait]
+    impl crate::chunk::read_plan::WorkspaceReadPlanProvider for StaticWorkspacePlan {
+        async fn read_plan(
+            &self,
+            _ino: i64,
+            _chunk_index: u64,
+            _offset: u64,
+            _len: u64,
+        ) -> Result<crate::chunk::read_plan::ResolvedReadPlan, crate::meta::store::MetaError>
+        {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            Ok(self.plan.clone())
+        }
+
+        async fn range_has_data(
+            &self,
+            _ino: i64,
+            _offset: u64,
+            _len: u64,
+        ) -> Result<bool, crate::meta::store::MetaError> {
+            Ok(true)
+        }
+    }
+
+    #[cfg(feature = "workspace-overlay")]
+    #[tokio::test]
+    async fn workspace_reader_executes_read_plan_without_flat_slice_metadata() {
+        use crate::chunk::read_plan::{ReadPlanSegment, ResolvedReadPlan};
+
+        let layout = ChunkLayout {
+            chunk_size: 16,
+            block_size: 8,
+        };
+        let block_store = Arc::new(InMemoryBlockStore::new());
+        block_store
+            .write_fresh_range((99, 0), 0, b"workspace")
+            .await
+            .unwrap();
+        let meta = create_meta_store_from_url("sqlite::memory:")
+            .await
+            .unwrap()
+            .layer();
+        let provider = Arc::new(StaticWorkspacePlan {
+            plan: ResolvedReadPlan {
+                segments: vec![
+                    ReadPlanSegment::Zero {
+                        logical_offset: 0,
+                        length: 2,
+                    },
+                    ReadPlanSegment::Data {
+                        logical_offset: 2,
+                        length: 4,
+                        slice_id: 99,
+                        slice_offset: 1,
+                    },
+                    ReadPlanSegment::Zero {
+                        logical_offset: 6,
+                        length: 2,
+                    },
+                ],
+            },
+            calls: AtomicUsize::new(0),
+        });
+        let backend = Arc::new(Backend::new_workspace(block_store, meta, provider.clone()));
+        let inode = Inode::new(123, 8);
+        let reader = DataReader::new(Arc::new(ReadConfig::new(layout)), backend);
+        let output = reader.open_for_handle(inode, 1).read(0, 8).await.unwrap();
+        assert_eq!(&output, b"\0\0orks\0\0");
+        assert_eq!(provider.calls.load(Ordering::Relaxed), 1);
     }
 
     #[derive(Default)]

--- a/src/vfs/io/writer.rs
+++ b/src/vfs/io/writer.rs
@@ -214,6 +214,44 @@ fn should_retry_meta_write(err: &MetaError) -> bool {
     }
 }
 
+async fn record_uploaded_orphan<B, M>(shared: &Shared<B, M>, desc: SliceDesc) -> bool
+where
+    B: BlockStore + Send + Sync + 'static,
+    M: MetaLayer + Send + Sync + 'static,
+{
+    #[cfg(not(feature = "workspace-overlay"))]
+    let _ = (shared, desc);
+    #[cfg(feature = "workspace-overlay")]
+    if let Some(provider) = shared.backend.workspace_read_plan()
+        && let Err(error) = provider
+            .record_orphan_slice(desc.slice_id, desc.length)
+            .await
+    {
+        tracing::error!(
+            slice_id = desc.slice_id,
+            slice_end = desc.length,
+            error = ?error,
+            "failed to persist uploaded workspace orphan; retaining local dirty record"
+        );
+        return false;
+    }
+    true
+}
+
+fn dirty_slice_key(
+    ino: i64,
+    chunk_id: u64,
+    local_seq: u64,
+    epoch: u64,
+) -> crate::vfs::cache::keys::DirtySliceKey {
+    crate::vfs::cache::keys::DirtySliceKey {
+        ino,
+        chunk_id,
+        local_seq,
+        epoch,
+    }
+}
+
 struct UploadPlan {
     chunk_id: u64,
     data: Vec<(usize, Vec<Bytes>)>,
@@ -951,12 +989,7 @@ where
             let slice_id = s.slice_id?;
             s.writeback_record_sealing = true;
             Some((
-                crate::vfs::cache::keys::DirtySliceKey {
-                    ino,
-                    chunk_id: s.chunk_id,
-                    local_seq: slice_id,
-                    epoch: 0,
-                },
+                dirty_slice_key(ino, s.chunk_id, slice_id, self.shared.writeback_epoch),
                 s.offset,
                 s.data.len(),
             ))
@@ -1083,6 +1116,11 @@ where
             return;
         }
 
+        let desc = match self.desc_for_commit() {
+            Some(desc) => desc,
+            None => return,
+        };
+
         let slice_epoch = self.slice.lock().frozen_epoch;
         if slice_epoch != 0 && self.shared.inode.data_epoch() != slice_epoch {
             tracing::warn!(
@@ -1091,6 +1129,16 @@ where
                 current_epoch = self.shared.inode.data_epoch(),
                 "skipping stale try_commit after inode epoch change"
             );
+            let orphan_recorded = record_uploaded_orphan(self.shared, desc).await;
+            if orphan_recorded && let Some(wb) = &self.shared.write_back {
+                let key = dirty_slice_key(
+                    self.shared.inode.ino(),
+                    desc.chunk_id,
+                    desc.slice_id,
+                    self.shared.writeback_epoch,
+                );
+                let _ = wb.remove(&key).await;
+            }
             self.mark_committed();
             return;
         }
@@ -1124,11 +1172,6 @@ where
                 return;
             }
         }
-
-        let desc = match self.desc_for_commit() {
-            Some(d) => d,
-            None => return,
-        };
 
         let (ino, chunk_index) = crate::vfs::extract_ino_and_chunk_index(desc.chunk_id);
         let new_size =
@@ -1164,12 +1207,12 @@ where
                     self.mark_committed();
 
                     if let Some(wb) = &self.shared.write_back {
-                        let key = crate::vfs::cache::keys::DirtySliceKey {
+                        let key = dirty_slice_key(
                             ino,
-                            chunk_id: desc.chunk_id,
-                            local_seq: desc.slice_id,
-                            epoch: 0,
-                        };
+                            desc.chunk_id,
+                            desc.slice_id,
+                            self.shared.writeback_epoch,
+                        );
                         let _ = wb.remove(&key).await;
                     }
                     return;
@@ -1193,18 +1236,19 @@ where
                         // Reset so commit_chunk can pick this up.
                         self.slice.lock().meta_write_started = false;
                     } else {
+                        let orphan_recorded = record_uploaded_orphan(self.shared, desc).await;
                         self.mark_failed(anyhow::anyhow!(
                             "try_commit failed for ino {ino}, chunk {}, slice {}: {err}",
                             desc.chunk_id,
                             desc.slice_id
                         ));
-                        if let Some(wb) = &self.shared.write_back {
-                            let key = crate::vfs::cache::keys::DirtySliceKey {
+                        if orphan_recorded && let Some(wb) = &self.shared.write_back {
+                            let key = dirty_slice_key(
                                 ino,
-                                chunk_id: desc.chunk_id,
-                                local_seq: desc.slice_id,
-                                epoch: 0,
-                            };
+                                desc.chunk_id,
+                                desc.slice_id,
+                                self.shared.writeback_epoch,
+                            );
                             let _ = wb.remove(&key).await;
                         }
                     }
@@ -1522,6 +1566,8 @@ struct Shared<B, M> {
     reader: Arc<DataReader<B, M>>,
     /// Local SSD write-back cache for persisting frozen slices before upload.
     write_back: Option<Arc<crate::vfs::cache::write_back::FsWriteBackCache>>,
+    /// Mount/session generation embedded in durable dirty keys. Flat mounts use zero.
+    writeback_epoch: u64,
     memory_budget: Option<MemoryBudget>,
     /// Monotonically incremented for dirty-slice ordering.
     write_order: AtomicU64,
@@ -2052,6 +2098,7 @@ where
         reader: Arc<DataReader<B, M>>,
         buffer_usage: Arc<AtomicU64>,
         write_back: Option<Arc<crate::vfs::cache::write_back::FsWriteBackCache>>,
+        writeback_epoch: u64,
         memory_budget: Option<MemoryBudget>,
         recent_pending_upload: Arc<RecentPendingUploadState>,
     ) -> Self {
@@ -2072,6 +2119,7 @@ where
             backend,
             reader,
             write_back,
+            writeback_epoch,
             memory_budget,
             write_order: AtomicU64::new(0),
             write_gen: AtomicU64::new(0),
@@ -2559,6 +2607,7 @@ where
             reader,
             buffer_usage,
             write_back,
+            0,
             None,
             Arc::new(RecentPendingUploadState::new()),
         )
@@ -2572,6 +2621,7 @@ where
         reader: Arc<DataReader<B, M>>,
         buffer_usage: Arc<AtomicU64>,
         write_back: Option<Arc<crate::vfs::cache::write_back::FsWriteBackCache>>,
+        writeback_epoch: u64,
         memory_budget: Option<MemoryBudget>,
         recent_pending_upload: Arc<RecentPendingUploadState>,
     ) -> Self {
@@ -2582,6 +2632,7 @@ where
             reader,
             buffer_usage,
             write_back,
+            writeback_epoch,
             memory_budget,
             recent_pending_upload,
         ));
@@ -3887,12 +3938,12 @@ where
                             let chunks = all_chunks.clone();
                             let shared_for_persist = shared2.clone();
                             let slice_for_persist = slice_for_persist.clone();
-                            let key = crate::vfs::cache::keys::DirtySliceKey {
+                            let key = dirty_slice_key(
                                 ino,
                                 chunk_id,
-                                local_seq: slice_id,
-                                epoch: 0,
-                            };
+                                slice_id,
+                                shared_for_persist.writeback_epoch,
+                            );
                             async move {
                                 let stage_start = shared_for_persist
                                     .recent_pending_upload
@@ -4150,12 +4201,12 @@ where
             let Some(slice_id) = state.slice_id else {
                 return;
             };
-            crate::vfs::cache::keys::DirtySliceKey {
-                ino: shared.inode.ino(),
-                chunk_id: state.chunk_id,
-                local_seq: slice_id,
-                epoch: 0,
-            }
+            dirty_slice_key(
+                shared.inode.ino(),
+                state.chunk_id,
+                slice_id,
+                shared.writeback_epoch,
+            )
         };
 
         if let Some(wb) = &shared.write_back {
@@ -4667,6 +4718,23 @@ where
                         current_epoch = shared.inode.data_epoch(),
                         "skipping stale commit after truncate"
                     );
+                    if let Some(desc) = (SliceHandle {
+                        slice: &slice,
+                        shared: &shared,
+                    })
+                    .desc_for_commit()
+                    {
+                        let orphan_recorded = record_uploaded_orphan(&shared, desc).await;
+                        if orphan_recorded && let Some(wb) = &shared.write_back {
+                            let key = dirty_slice_key(
+                                shared.inode.ino(),
+                                desc.chunk_id,
+                                desc.slice_id,
+                                shared.writeback_epoch,
+                            );
+                            let _ = wb.remove(&key).await;
+                        }
+                    }
                     SliceHandle {
                         slice: &slice,
                         shared: &shared,
@@ -4728,6 +4796,7 @@ where
                             }
 
                             if !retryable || commit_failures >= COMMIT_META_MAX_RETRIES {
+                                let orphan_recorded = record_uploaded_orphan(&shared, desc).await;
                                 let message = if retryable {
                                     format!(
                                         "metadata commit failed after {commit_failures} attempts for ino {ino}, chunk {}, slice {}: {err}",
@@ -4760,13 +4829,13 @@ where
                                 // Clean up local SSD dirty record so a future
                                 // recovery scan does not re-upload a slice that
                                 // will fail the same metadata commit again.
-                                if let Some(wb) = &shared.write_back {
-                                    let key = crate::vfs::cache::keys::DirtySliceKey {
+                                if orphan_recorded && let Some(wb) = &shared.write_back {
+                                    let key = dirty_slice_key(
                                         ino,
-                                        chunk_id: desc.chunk_id,
-                                        local_seq: desc.slice_id,
-                                        epoch: 0,
-                                    };
+                                        desc.chunk_id,
+                                        desc.slice_id,
+                                        shared.writeback_epoch,
+                                    );
                                     let _ = wb.remove(&key).await;
                                 }
 
@@ -4802,12 +4871,12 @@ where
 
                             // Clean up local SSD dirty copy now that data is committed.
                             if let Some(wb) = &shared.write_back {
-                                let key = crate::vfs::cache::keys::DirtySliceKey {
+                                let key = dirty_slice_key(
                                     ino,
-                                    chunk_id: desc.chunk_id,
-                                    local_seq: desc.slice_id,
-                                    epoch: 0,
-                                };
+                                    desc.chunk_id,
+                                    desc.slice_id,
+                                    shared.writeback_epoch,
+                                );
                                 let _ = wb.remove(&key).await;
                             }
 
@@ -5153,6 +5222,7 @@ pub(crate) struct DataWriter<B, M> {
     files: DashMap<u64, Arc<FileWriter<B, M>>>,
     buffer_usage: Arc<AtomicU64>,
     write_back: Option<Arc<crate::vfs::cache::write_back::FsWriteBackCache>>,
+    writeback_epoch: u64,
     memory_budget: Option<MemoryBudget>,
     recent_pending_upload: Arc<RecentPendingUploadState>,
 }
@@ -5284,6 +5354,7 @@ where
             files: DashMap::new(),
             buffer_usage: Arc::new(AtomicU64::new(0)),
             write_back,
+            writeback_epoch: 0,
             memory_budget: None,
             recent_pending_upload: Arc::new(RecentPendingUploadState::new()),
         }
@@ -5291,6 +5362,12 @@ where
 
     pub(crate) fn with_memory_budget(mut self, memory_budget: MemoryBudget) -> Self {
         self.memory_budget = Some(memory_budget);
+        self
+    }
+
+    #[cfg(feature = "workspace-overlay")]
+    pub(crate) fn with_writeback_epoch(mut self, epoch: u64) -> Self {
+        self.writeback_epoch = epoch;
         self
     }
 
@@ -5306,6 +5383,7 @@ where
                     self.reader.clone(),
                     self.buffer_usage.clone(),
                     self.write_back.clone(),
+                    self.writeback_epoch,
                     self.memory_budget.clone(),
                     self.recent_pending_upload.clone(),
                 ))
@@ -6083,6 +6161,15 @@ mod tests {
             WriteBackMode::UploadBeforeCommit,
             Duration::from_secs(60),
         )
+    }
+
+    #[test]
+    fn dirty_slice_key_preserves_the_mount_writer_epoch() {
+        let key = dirty_slice_key(7, 11, 13, 17);
+        assert_eq!(key.ino, 7);
+        assert_eq!(key.chunk_id, 11);
+        assert_eq!(key.local_seq, 13);
+        assert_eq!(key.epoch, 17);
     }
 
     #[test]

--- a/src/workspace_overlay/cache.rs
+++ b/src/workspace_overlay/cache.rs
@@ -1,0 +1,52 @@
+//! Epoch- and inode-version-scoped resolver caches.
+
+use dashmap::DashMap;
+
+use crate::chunk::read_plan::ResolvedReadPlan;
+
+use super::ids::WorkspaceId;
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct ReadPlanCacheKey {
+    pub workspace_id: WorkspaceId,
+    pub head_epoch: u64,
+    pub ino: i64,
+    pub chunk_index: u64,
+    pub inode_data_version: u64,
+    pub range_start: u64,
+    pub range_end: u64,
+}
+
+#[derive(Default)]
+pub struct WorkspaceResolverCache {
+    read_plans: DashMap<ReadPlanCacheKey, ResolvedReadPlan>,
+}
+
+impl WorkspaceResolverCache {
+    pub fn get_read_plan(&self, key: &ReadPlanCacheKey) -> Option<ResolvedReadPlan> {
+        self.read_plans.get(key).map(|entry| entry.clone())
+    }
+
+    pub fn insert_read_plan(&self, key: ReadPlanCacheKey, plan: ResolvedReadPlan) {
+        self.read_plans.insert(key, plan);
+    }
+
+    pub fn invalidate_inode(&self, workspace_id: WorkspaceId, ino: i64) {
+        self.read_plans
+            .retain(|key, _| key.workspace_id != workspace_id || key.ino != ino);
+    }
+
+    pub fn invalidate_workspace(&self, workspace_id: WorkspaceId) {
+        self.read_plans
+            .retain(|key, _| key.workspace_id != workspace_id);
+    }
+
+    #[cfg(test)]
+    pub fn len(&self) -> usize {
+        self.read_plans.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.read_plans.is_empty()
+    }
+}

--- a/src/workspace_overlay/cache_scope.rs
+++ b/src/workspace_overlay/cache_scope.rs
@@ -1,0 +1,54 @@
+//! Workspace-specific durable staging paths.
+
+use std::path::{Path, PathBuf};
+
+use uuid::Uuid;
+
+use super::error::WorkspaceError;
+use super::ids::WorkspaceId;
+
+pub fn writeback_root(
+    cache_root: &Path,
+    volume_id: Uuid,
+    workspace_id: WorkspaceId,
+    head_epoch: u64,
+) -> Result<PathBuf, WorkspaceError> {
+    std::fs::create_dir_all(cache_root)?;
+    let cache_root = cache_root.canonicalize()?;
+    let candidate = cache_root
+        .join("workspace-v1")
+        .join(volume_id.to_string())
+        .join(workspace_id.to_string())
+        .join(head_epoch.to_string());
+    std::fs::create_dir_all(&candidate)?;
+    let candidate = candidate.canonicalize()?;
+    candidate.strip_prefix(&cache_root).map_err(|_| {
+        WorkspaceError::CorruptMetadata(
+            "workspace writeback path escapes the configured cache root".into(),
+        )
+    })?;
+    Ok(candidate)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn writeback_path_contains_the_complete_workspace_scope() {
+        let root = tempfile::tempdir().unwrap();
+        let volume = Uuid::from_u128(41);
+        let workspace = WorkspaceId::from_uuid(Uuid::from_u128(42));
+        let path = writeback_root(root.path(), volume, workspace, 7).unwrap();
+
+        assert!(path.starts_with(root.path().canonicalize().unwrap()));
+        assert!(
+            path.ends_with(
+                Path::new("workspace-v1")
+                    .join(volume.to_string())
+                    .join(workspace.to_string())
+                    .join("7")
+            )
+        );
+    }
+}

--- a/src/workspace_overlay/catalog.rs
+++ b/src/workspace_overlay/catalog.rs
@@ -1,0 +1,383 @@
+//! Persistence contract for workspace metadata.
+
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use super::digest::CanonicalLayerDelta;
+use super::error::WorkspaceError;
+use super::ids::{JournalId, LayerId, LeaseId, SnapshotId, WorkspaceId};
+use super::model::{
+    AclDelta, BaseRevision, CommitResult, DataExtentDelta, DentryDelta, InodeDelta, LayerRecord,
+    SealJournal, SealPhase, SealResult, SnapshotLease, SnapshotRecord, VolumeHeader,
+    WorkspaceRecord, XattrDelta,
+};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct WorkspaceStoreCapabilities {
+    pub atomic_head_switch: bool,
+    pub durable_lease: bool,
+    pub transactional_namespace_mutation: bool,
+    pub transactional_rename: bool,
+    pub watch_head_change: bool,
+}
+
+impl WorkspaceStoreCapabilities {
+    pub fn validate_for_v1_mount(self) -> Result<(), WorkspaceError> {
+        for (available, name) in [
+            (self.atomic_head_switch, "atomic_head_switch"),
+            (self.durable_lease, "durable_lease"),
+            (
+                self.transactional_namespace_mutation,
+                "transactional_namespace_mutation",
+            ),
+            (self.transactional_rename, "transactional_rename"),
+        ] {
+            if !available {
+                return Err(WorkspaceError::UnsupportedCapability(name));
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HeadGuard {
+    pub workspace_id: WorkspaceId,
+    pub expected_head_layer_id: LayerId,
+    pub expected_head_epoch: u64,
+    pub lease_id: LeaseId,
+    pub holder_generation: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CreateVolumeRoot {
+    pub volume_id: Uuid,
+    pub workspace_id: WorkspaceId,
+    pub root_layer_id: LayerId,
+    pub writable_layer_id: LayerId,
+    pub owner_id: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AcquireLease {
+    pub workspace_id: WorkspaceId,
+    pub lease_id: LeaseId,
+    pub holder_generation: u64,
+    pub ttl_ns: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RenewLease {
+    pub lease_id: LeaseId,
+    pub holder_generation: u64,
+    pub ttl_ns: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReleaseLease {
+    pub lease_id: LeaseId,
+    pub holder_generation: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CreateWorkspace {
+    pub workspace_id: WorkspaceId,
+    pub head_layer_id: LayerId,
+    pub base_revision: BaseRevision,
+    pub owner_id: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CreateSnapshot {
+    pub snapshot_id: SnapshotId,
+    pub name: Option<String>,
+    pub revision: BaseRevision,
+    pub owner_id: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BeginSeal {
+    pub guard: HeadGuard,
+    pub journal_id: JournalId,
+    pub new_head_layer_id: LayerId,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdvanceSeal {
+    pub journal_id: JournalId,
+    pub expected_phase: SealPhase,
+    pub next_phase: SealPhase,
+    pub pending_bytes: Option<u64>,
+    pub last_error: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AbortSeal {
+    pub journal_id: JournalId,
+    pub reason: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FastForwardCommit {
+    pub source_revision: BaseRevision,
+    pub source_fork_base: BaseRevision,
+    pub target_workspace_id: WorkspaceId,
+    pub target_expected_head_layer_id: LayerId,
+    pub target_expected_head_epoch: u64,
+    pub new_head_layer_id: LayerId,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MarkDeleting {
+    pub workspace_id: WorkspaceId,
+    pub force_fence_lease: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SliceReference {
+    pub layer_id: LayerId,
+    pub slice_id: u64,
+    pub slice_end: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RecordOrphanSlice {
+    pub orphan_layer_id: LayerId,
+    pub slice_id: u64,
+    pub slice_end: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GcSnapshot {
+    pub root_layers: Vec<LayerId>,
+    pub layers: Vec<LayerRecord>,
+    pub slice_references: Vec<SliceReference>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DeleteLayerMetadata {
+    pub layer_ids: Vec<LayerId>,
+    pub now_ns: i64,
+    pub lease_grace_ns: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct InstallCompaction {
+    pub workspace_id: WorkspaceId,
+    pub expected_head_layer_id: LayerId,
+    pub expected_head_epoch: u64,
+    pub expected_parent_layer_id: LayerId,
+    pub compacted_layer_id: LayerId,
+    pub replacement_head_layer_id: LayerId,
+    pub delta: CanonicalLayerDelta,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CompactionResult {
+    pub revision: BaseRevision,
+    pub replacement_head_layer_id: LayerId,
+    pub head_epoch: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DentryQuery {
+    pub layer_ids: Vec<LayerId>,
+    pub parent_ino: i64,
+    pub name: Option<Vec<u8>>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct InodeQuery {
+    pub layer_ids: Vec<LayerId>,
+    pub ino: i64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ExtentQuery {
+    pub layer_ids: Vec<LayerId>,
+    pub ino: i64,
+    pub chunk_index: u64,
+    pub range_start: u64,
+    pub range_end: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct XattrQuery {
+    pub layer_ids: Vec<LayerId>,
+    pub ino: i64,
+    pub name: Option<Vec<u8>>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AclQuery {
+    pub layer_ids: Vec<LayerId>,
+    pub ino: i64,
+    pub acl_type: Option<u8>,
+    pub acl_id: Option<i64>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct NamespaceMutation {
+    pub guard: HeadGuard,
+    pub dentries: Vec<DentryDelta>,
+    pub inodes: Vec<InodeDelta>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct InodeMutation {
+    pub guard: HeadGuard,
+    pub inode: InodeDelta,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AppendDataExtent {
+    pub guard: HeadGuard,
+    pub extent: DataExtentDelta,
+    pub chunk_size: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DataMutation {
+    pub guard: HeadGuard,
+    pub inode: InodeDelta,
+    pub extents: Vec<DataExtentDelta>,
+    pub chunk_size: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DataMutationResult {
+    pub inode: InodeDelta,
+    pub extents: Vec<DataExtentDelta>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct XattrMutation {
+    pub guard: HeadGuard,
+    /// Full inode snapshot carrying the ctime change for this xattr operation.
+    /// Both records are committed atomically by the backend.
+    pub inode: InodeDelta,
+    pub xattr: XattrDelta,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AclMutation {
+    pub guard: HeadGuard,
+    pub acl: AclDelta,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MutationResult {
+    pub first_sequence: Option<u64>,
+    pub last_sequence: Option<u64>,
+}
+
+#[async_trait]
+pub trait WorkspaceStore: Send + Sync {
+    fn name(&self) -> &'static str;
+    fn capabilities(&self) -> WorkspaceStoreCapabilities;
+
+    async fn initialize_workspace_schema(&self) -> Result<(), WorkspaceError>;
+    async fn load_volume_header(&self) -> Result<Option<VolumeHeader>, WorkspaceError>;
+    async fn load_workspace(&self, id: WorkspaceId) -> Result<WorkspaceRecord, WorkspaceError>;
+    async fn load_layer(&self, id: LayerId) -> Result<LayerRecord, WorkspaceError>;
+    async fn load_layer_chain(&self, head: LayerId) -> Result<Vec<LayerRecord>, WorkspaceError>;
+    async fn allocate_id(&self, name: &str) -> Result<i64, WorkspaceError>;
+    async fn create_volume_root(
+        &self,
+        request: CreateVolumeRoot,
+    ) -> Result<WorkspaceRecord, WorkspaceError>;
+    async fn create_workspace(
+        &self,
+        request: CreateWorkspace,
+    ) -> Result<WorkspaceRecord, WorkspaceError>;
+    async fn list_workspaces(&self) -> Result<Vec<WorkspaceRecord>, WorkspaceError>;
+    async fn create_snapshot(
+        &self,
+        request: CreateSnapshot,
+    ) -> Result<SnapshotRecord, WorkspaceError>;
+    async fn load_snapshot(&self, id: SnapshotId) -> Result<SnapshotRecord, WorkspaceError>;
+    async fn list_snapshots(&self) -> Result<Vec<SnapshotRecord>, WorkspaceError>;
+    async fn delete_snapshot(&self, id: SnapshotId) -> Result<(), WorkspaceError>;
+
+    async fn acquire_lease(&self, request: AcquireLease) -> Result<SnapshotLease, WorkspaceError>;
+    async fn renew_lease(&self, request: RenewLease) -> Result<SnapshotLease, WorkspaceError>;
+    async fn release_lease(&self, request: ReleaseLease) -> Result<(), WorkspaceError>;
+    async fn reap_expired_leases(&self) -> Result<u64, WorkspaceError>;
+    async fn list_leases(
+        &self,
+        workspace_id: WorkspaceId,
+    ) -> Result<Vec<SnapshotLease>, WorkspaceError>;
+
+    async fn get_dentry_deltas(
+        &self,
+        request: DentryQuery,
+    ) -> Result<Vec<DentryDelta>, WorkspaceError>;
+    async fn get_inode_deltas(
+        &self,
+        request: InodeQuery,
+    ) -> Result<Vec<InodeDelta>, WorkspaceError>;
+    async fn get_extent_deltas(
+        &self,
+        request: ExtentQuery,
+    ) -> Result<Vec<DataExtentDelta>, WorkspaceError>;
+    async fn get_xattr_deltas(
+        &self,
+        request: XattrQuery,
+    ) -> Result<Vec<XattrDelta>, WorkspaceError>;
+    async fn get_acl_deltas(&self, request: AclQuery) -> Result<Vec<AclDelta>, WorkspaceError>;
+
+    async fn apply_namespace_mutation(
+        &self,
+        request: NamespaceMutation,
+    ) -> Result<MutationResult, WorkspaceError>;
+    async fn apply_inode_mutation(
+        &self,
+        request: InodeMutation,
+    ) -> Result<InodeDelta, WorkspaceError>;
+    async fn append_data_extent(
+        &self,
+        request: AppendDataExtent,
+    ) -> Result<DataExtentDelta, WorkspaceError>;
+    async fn apply_data_mutation(
+        &self,
+        request: DataMutation,
+    ) -> Result<DataMutationResult, WorkspaceError>;
+    async fn apply_xattr_mutation(&self, request: XattrMutation) -> Result<(), WorkspaceError>;
+    async fn apply_acl_mutation(&self, request: AclMutation) -> Result<(), WorkspaceError>;
+
+    async fn load_layer_delta(
+        &self,
+        layer_id: LayerId,
+    ) -> Result<CanonicalLayerDelta, WorkspaceError>;
+    async fn begin_seal(&self, request: BeginSeal) -> Result<SealJournal, WorkspaceError>;
+    async fn advance_seal(&self, request: AdvanceSeal) -> Result<SealJournal, WorkspaceError>;
+    async fn hash_seal(&self, journal_id: JournalId) -> Result<SealJournal, WorkspaceError>;
+    async fn commit_seal(&self, journal_id: JournalId) -> Result<SealResult, WorkspaceError>;
+    async fn abort_recoverable_seal(&self, request: AbortSeal) -> Result<(), WorkspaceError>;
+    async fn load_seal_journal(&self, journal_id: JournalId)
+    -> Result<SealJournal, WorkspaceError>;
+    async fn list_incomplete_seal_journals(&self) -> Result<Vec<SealJournal>, WorkspaceError>;
+    async fn fast_forward_commit(
+        &self,
+        request: FastForwardCommit,
+    ) -> Result<CommitResult, WorkspaceError>;
+    async fn mark_workspace_deleting(&self, request: MarkDeleting) -> Result<(), WorkspaceError>;
+    async fn record_orphan_slice(&self, request: RecordOrphanSlice) -> Result<(), WorkspaceError>;
+    async fn gc_snapshot(
+        &self,
+        now_ns: i64,
+        lease_grace_ns: u64,
+    ) -> Result<GcSnapshot, WorkspaceError>;
+    async fn delete_layer_metadata(
+        &self,
+        request: DeleteLayerMetadata,
+    ) -> Result<(), WorkspaceError>;
+    async fn finalize_layer_metadata_deletion(
+        &self,
+        layer_ids: Vec<LayerId>,
+    ) -> Result<(), WorkspaceError>;
+    async fn install_compaction(
+        &self,
+        request: InstallCompaction,
+    ) -> Result<CompactionResult, WorkspaceError>;
+}

--- a/src/workspace_overlay/compaction.rs
+++ b/src/workspace_overlay/compaction.rs
@@ -1,0 +1,347 @@
+//! Seal-time materialization of a workspace into a flat immutable base.
+
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use super::catalog::{CompactionResult, InstallCompaction, WorkspaceStore};
+use super::digest::CanonicalLayerDelta;
+use super::error::WorkspaceError;
+use super::ids::{LayerId, WorkspaceId};
+use super::model::{
+    AclDelta, DataExtentDelta, DentryDelta, ExtentKind, InodeState, LayerState, ValueOp, XattrDelta,
+};
+use super::resolver::{resolve_acl, resolve_dentry, resolve_extents, resolve_inode, resolve_xattr};
+
+pub struct WorkspaceCompactor<W> {
+    store: Arc<W>,
+}
+
+impl<W: WorkspaceStore + 'static> WorkspaceCompactor<W> {
+    pub fn new(store: Arc<W>) -> Self {
+        Self { store }
+    }
+
+    pub async fn compact(
+        &self,
+        workspace_id: WorkspaceId,
+    ) -> Result<CompactionResult, WorkspaceError> {
+        let workspace = self.store.load_workspace(workspace_id).await?;
+        let head = self.store.load_layer(workspace.head_layer_id).await?;
+        if head.state != LayerState::Writable || head.next_sequence != 1 {
+            return Err(WorkspaceError::Busy);
+        }
+        let parent = head.parent_layer_id.ok_or_else(|| {
+            WorkspaceError::CorruptMetadata("writable head lacks sealed parent".into())
+        })?;
+        let chain = self.store.load_layer_chain(parent).await?;
+        if chain.iter().any(|layer| layer.state != LayerState::Sealed) {
+            return Err(WorkspaceError::CorruptMetadata(
+                "compaction source contains a non-sealed layer".into(),
+            ));
+        }
+        let compacted_layer_id = LayerId::new();
+        let delta = self.materialize(compacted_layer_id, &chain).await?;
+        let compacted_bytes = delta
+            .extents
+            .iter()
+            .map(|extent| extent.length)
+            .fold(0u64, u64::saturating_add);
+        let result = self
+            .store
+            .install_compaction(InstallCompaction {
+                workspace_id,
+                expected_head_layer_id: workspace.head_layer_id,
+                expected_head_epoch: workspace.head_epoch,
+                expected_parent_layer_id: parent,
+                compacted_layer_id,
+                replacement_head_layer_id: LayerId::new(),
+                delta,
+            })
+            .await;
+        if result.is_ok() {
+            super::metrics::global_workspace_metrics().add_compaction_bytes(compacted_bytes);
+        }
+        result
+    }
+
+    async fn materialize(
+        &self,
+        output_layer: LayerId,
+        chain: &[super::model::LayerRecord],
+    ) -> Result<CanonicalLayerDelta, WorkspaceError> {
+        let mut input = CanonicalLayerDelta::default();
+        for layer in chain {
+            let delta = self.store.load_layer_delta(layer.layer_id).await?;
+            input.dentries.extend(delta.dentries);
+            input.inodes.extend(delta.inodes);
+            input.xattrs.extend(delta.xattrs);
+            input.acls.extend(delta.acls);
+            input.extents.extend(delta.extents);
+        }
+
+        let mut output = CanonicalLayerDelta::default();
+        let dentry_keys = input
+            .dentries
+            .iter()
+            .map(|row| (row.parent_ino, row.name.clone()))
+            .collect::<BTreeSet<_>>();
+        for (parent, name) in dentry_keys {
+            if let Some(entry) = resolve_dentry(chain, &input.dentries, parent, &name)? {
+                output.dentries.push(DentryDelta::put(
+                    output_layer,
+                    parent,
+                    name,
+                    entry.ino,
+                    entry.entry_type,
+                    0,
+                ));
+            }
+        }
+        let inode_keys = input
+            .inodes
+            .iter()
+            .map(|row| row.ino)
+            .collect::<BTreeSet<_>>();
+        for ino in inode_keys {
+            if let Some(mut inode) =
+                resolve_inode(chain, &input.inodes, ino)?.map(|value| value.inode)
+            {
+                inode.layer_id = output_layer;
+                inode.state = InodeState::Present;
+                inode.sequence = 0;
+                output.inodes.push(inode);
+            }
+        }
+        let xattr_keys = input
+            .xattrs
+            .iter()
+            .map(|row| (row.ino, row.name.clone()))
+            .collect::<BTreeSet<_>>();
+        for (ino, name) in xattr_keys {
+            if let Some(value) = resolve_xattr(chain, &input.xattrs, ino, &name)? {
+                output.xattrs.push(XattrDelta {
+                    layer_id: output_layer,
+                    ino,
+                    name,
+                    op: ValueOp::Put,
+                    value: Some(value.value),
+                    sequence: 0,
+                });
+            }
+        }
+        let acl_keys = input
+            .acls
+            .iter()
+            .map(|row| (row.ino, row.acl_type, row.acl_id))
+            .collect::<BTreeSet<_>>();
+        for (ino, acl_type, acl_id) in acl_keys {
+            if let Some(value) = resolve_acl(chain, &input.acls, ino, acl_type, acl_id)? {
+                output.acls.push(AclDelta {
+                    layer_id: output_layer,
+                    ino,
+                    acl_type,
+                    acl_id,
+                    op: ValueOp::Put,
+                    value: Some(value.value),
+                    sequence: 0,
+                });
+            }
+        }
+        let extent_keys = input
+            .extents
+            .iter()
+            .map(|row| (row.ino, row.chunk_index))
+            .collect::<BTreeSet<_>>();
+        for (ino, chunk_index) in extent_keys {
+            let range_end = input
+                .extents
+                .iter()
+                .filter(|row| row.ino == ino && row.chunk_index == chunk_index)
+                .try_fold(0_u64, |end, row| {
+                    row.logical_offset
+                        .checked_add(row.length)
+                        .map(|row_end| end.max(row_end))
+                        .ok_or_else(|| {
+                            WorkspaceError::CorruptMetadata(
+                                "extent range overflows during seal materialization".into(),
+                            )
+                        })
+                })?;
+            for extent in resolve_extents(chain, &input.extents, ino, chunk_index, 0..range_end)? {
+                if let ExtentKind::Data {
+                    slice_id,
+                    slice_offset,
+                } = extent.kind
+                {
+                    output.extents.push(DataExtentDelta::data(
+                        output_layer,
+                        ino,
+                        chunk_index,
+                        extent.logical_offset,
+                        extent.length,
+                        slice_id,
+                        slice_offset,
+                        0,
+                    ));
+                }
+            }
+        }
+
+        let mut sequence = 1u64;
+        for row in &mut output.dentries {
+            row.sequence = sequence;
+            sequence = next_sequence(sequence)?;
+        }
+        for row in &mut output.inodes {
+            row.sequence = sequence;
+            sequence = next_sequence(sequence)?;
+        }
+        for row in &mut output.xattrs {
+            row.sequence = sequence;
+            sequence = next_sequence(sequence)?;
+        }
+        for row in &mut output.acls {
+            row.sequence = sequence;
+            sequence = next_sequence(sequence)?;
+        }
+        for row in &mut output.extents {
+            row.sequence = sequence;
+            sequence = next_sequence(sequence)?;
+        }
+        Ok(output)
+    }
+}
+
+fn next_sequence(sequence: u64) -> Result<u64, WorkspaceError> {
+    sequence
+        .checked_add(1)
+        .ok_or_else(|| WorkspaceError::CorruptMetadata("compaction sequence overflows".into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::chunk::SliceDesc;
+    use crate::chunk::read_plan::WorkspaceReadPlanProvider;
+    use crate::meta::MetaLayer;
+    use crate::workspace_overlay::catalog::{CreateVolumeRoot, WorkspaceStore};
+    use crate::workspace_overlay::ids::{LayerId, WorkspaceId};
+    use crate::workspace_overlay::lifecycle::{
+        DEFAULT_HEARTBEAT_INTERVAL, DEFAULT_LEASE_TTL, NoopDurableRemoteBarrier,
+        WorkspaceLifecycle, WorkspaceMountSession,
+    };
+    use crate::workspace_overlay::meta_layer::WorkspaceMetaLayer;
+    use crate::workspace_overlay::model::ViewContext;
+    use crate::workspace_overlay::stores::database::SqliteWorkspaceStore;
+
+    #[tokio::test]
+    async fn compaction_preserves_namespace_attributes_and_extent_plan() {
+        let store = Arc::new(
+            SqliteWorkspaceStore::connect("sqlite::memory:")
+                .await
+                .unwrap(),
+        );
+        store.initialize_workspace_schema().await.unwrap();
+        let workspace_id = WorkspaceId::from_uuid(Uuid::from_u128(901));
+        store
+            .create_volume_root(CreateVolumeRoot {
+                volume_id: Uuid::from_u128(902),
+                workspace_id,
+                root_layer_id: LayerId::from_uuid(Uuid::from_u128(903)),
+                writable_layer_id: LayerId::from_uuid(Uuid::from_u128(904)),
+                owner_id: None,
+            })
+            .await
+            .unwrap();
+        let session = WorkspaceMountSession::acquire(
+            store.clone(),
+            workspace_id,
+            1,
+            DEFAULT_LEASE_TTL,
+            DEFAULT_HEARTBEAT_INTERVAL,
+        )
+        .await
+        .unwrap();
+        let meta = WorkspaceMetaLayer::new(store.clone(), session.view.clone());
+        let dir = meta.mkdir(meta.root_ino(), "work".into()).await.unwrap();
+        let ino = meta.create_file(dir, "old".into()).await.unwrap();
+        let chunk_id = crate::vfs::chunk_id_for(ino, 0).unwrap();
+        meta.write(
+            ino,
+            chunk_id,
+            SliceDesc {
+                slice_id: 41,
+                chunk_id,
+                offset: 0,
+                length: 8,
+            },
+            8,
+        )
+        .await
+        .unwrap();
+        let lifecycle = WorkspaceLifecycle::new(store.clone());
+        let mut view = session.view.clone();
+        for step in 0..3 {
+            let sealed = lifecycle
+                .seal(&view, &NoopDurableRemoteBarrier)
+                .await
+                .unwrap();
+            view = ViewContext {
+                head_layer_id: sealed.new_head_layer_id,
+                head_epoch: sealed.head_epoch,
+                ..view
+            };
+            meta.replace_view_context(view.clone()).await;
+            match step {
+                0 => {
+                    meta.rename(dir, "old", dir, "new".into()).await.unwrap();
+                }
+                1 => {
+                    meta.set_xattr(ino, "user.compacted", b"yes", 0)
+                        .await
+                        .unwrap();
+                }
+                _ => {}
+            }
+        }
+        let expected_plan = meta.read_plan(ino, 0, 0, 8).await.unwrap();
+        session.release().await.unwrap();
+
+        let result = WorkspaceCompactor::new(store.clone())
+            .compact(workspace_id)
+            .await
+            .unwrap();
+        assert_eq!(
+            store
+                .load_layer_chain(result.replacement_head_layer_id)
+                .await
+                .unwrap()
+                .len(),
+            2
+        );
+        let mounted = WorkspaceMountSession::acquire(
+            store.clone(),
+            workspace_id,
+            2,
+            DEFAULT_LEASE_TTL,
+            DEFAULT_HEARTBEAT_INTERVAL,
+        )
+        .await
+        .unwrap();
+        let compacted = WorkspaceMetaLayer::new(store, mounted.view.clone());
+        assert_eq!(compacted.lookup(dir, "new").await.unwrap(), Some(ino));
+        assert_eq!(
+            compacted.get_xattr(ino, "user.compacted").await.unwrap(),
+            Some(b"yes".to_vec())
+        );
+        assert_eq!(
+            compacted.read_plan(ino, 0, 0, 8).await.unwrap(),
+            expected_plan
+        );
+        mounted.release().await.unwrap();
+    }
+}

--- a/src/workspace_overlay/control.rs
+++ b/src/workspace_overlay/control.rs
@@ -1,0 +1,170 @@
+//! Workspace control-plane read models used by CLI/API adapters.
+
+use std::sync::Arc;
+
+use serde::Serialize;
+
+use super::catalog::WorkspaceStore;
+use super::error::WorkspaceError;
+use super::ids::{JournalId, LayerId, LeaseId, WorkspaceId};
+use super::model::{BaseRevision, LeaseState, SealPhase, WorkspaceState};
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct WorkspaceInspection {
+    pub workspace_id: WorkspaceId,
+    pub state: WorkspaceState,
+    pub owner_id: Option<String>,
+    pub head_layer_id: LayerId,
+    pub head_epoch: u64,
+    pub base_revision: Option<BaseRevision>,
+    pub layer_depth: u32,
+    pub lease_id: Option<LeaseId>,
+    pub holder_generation: Option<u64>,
+    pub lease_expires_at_ns: Option<i64>,
+    pub private_metadata_rows: u64,
+    pub private_bytes: u64,
+    pub shared_bytes: u64,
+    pub pending_writeback_bytes: u64,
+    pub last_seal_journal_id: Option<JournalId>,
+    pub last_seal_phase: Option<SealPhase>,
+    pub last_seal_error: Option<String>,
+}
+
+pub struct WorkspaceControl<W> {
+    store: Arc<W>,
+}
+
+impl<W: WorkspaceStore + 'static> WorkspaceControl<W> {
+    pub fn new(store: Arc<W>) -> Self {
+        Self { store }
+    }
+
+    pub async fn inspect(
+        &self,
+        workspace_id: WorkspaceId,
+    ) -> Result<WorkspaceInspection, WorkspaceError> {
+        let workspace = self.store.load_workspace(workspace_id).await?;
+        let chain = self.store.load_layer_chain(workspace.head_layer_id).await?;
+        let head = chain.first().ok_or_else(|| {
+            WorkspaceError::CorruptMetadata("workspace has an empty layer chain".into())
+        })?;
+        let delta = self.store.load_layer_delta(head.layer_id).await?;
+        let private_metadata_rows = u64::try_from(
+            delta.dentries.len()
+                + delta.inodes.len()
+                + delta.xattrs.len()
+                + delta.acls.len()
+                + delta.extents.len(),
+        )
+        .map_err(|_| WorkspaceError::CorruptMetadata("row count exceeds u64".into()))?;
+        let mut private_bytes = head.owned_bytes;
+        for row in &delta.dentries {
+            private_bytes = private_bytes.saturating_add(row.name.len() as u64);
+        }
+        for row in &delta.xattrs {
+            private_bytes = private_bytes
+                .saturating_add(row.name.len() as u64)
+                .saturating_add(row.value.as_ref().map_or(0, |value| value.len()) as u64);
+        }
+        for row in &delta.acls {
+            private_bytes = private_bytes
+                .saturating_add(row.value.as_ref().map_or(0, |value| value.len()) as u64);
+        }
+        let shared_bytes = chain
+            .iter()
+            .skip(1)
+            .fold(0u64, |total, layer| total.saturating_add(layer.owned_bytes));
+        let lease = self
+            .store
+            .list_leases(workspace_id)
+            .await?
+            .into_iter()
+            .filter(|lease| lease.state == LeaseState::Active)
+            .max_by_key(|lease| lease.updated_at_ns);
+        let journal = self
+            .store
+            .list_incomplete_seal_journals()
+            .await?
+            .into_iter()
+            .filter(|journal| journal.workspace_id == workspace_id)
+            .max_by_key(|journal| journal.updated_at_ns);
+        Ok(WorkspaceInspection {
+            workspace_id,
+            state: workspace.state,
+            owner_id: workspace.owner_id,
+            head_layer_id: workspace.head_layer_id,
+            head_epoch: workspace.head_epoch,
+            base_revision: workspace.fork_base,
+            layer_depth: head.depth,
+            lease_id: lease.as_ref().map(|lease| lease.lease_id),
+            holder_generation: lease.as_ref().map(|lease| lease.holder_generation),
+            lease_expires_at_ns: lease.as_ref().map(|lease| lease.expires_at_ns),
+            private_metadata_rows,
+            private_bytes,
+            shared_bytes,
+            pending_writeback_bytes: journal.as_ref().map_or(0, |journal| journal.pending_bytes),
+            last_seal_journal_id: journal.as_ref().map(|journal| journal.journal_id),
+            last_seal_phase: journal.as_ref().map(|journal| journal.phase),
+            last_seal_error: journal.and_then(|journal| journal.last_error),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::meta::MetaLayer;
+    use crate::workspace_overlay::catalog::{CreateVolumeRoot, WorkspaceStore};
+    use crate::workspace_overlay::ids::LayerId;
+    use crate::workspace_overlay::lifecycle::{
+        DEFAULT_HEARTBEAT_INTERVAL, DEFAULT_LEASE_TTL, WorkspaceMountSession,
+    };
+    use crate::workspace_overlay::meta_layer::WorkspaceMetaLayer;
+    use crate::workspace_overlay::stores::database::SqliteWorkspaceStore;
+
+    #[tokio::test]
+    async fn inspect_reports_private_rows_and_active_lease() {
+        let store = Arc::new(
+            SqliteWorkspaceStore::connect("sqlite::memory:")
+                .await
+                .unwrap(),
+        );
+        store.initialize_workspace_schema().await.unwrap();
+        let workspace_id = WorkspaceId::from_uuid(Uuid::from_u128(1001));
+        store
+            .create_volume_root(CreateVolumeRoot {
+                volume_id: Uuid::from_u128(1002),
+                workspace_id,
+                root_layer_id: LayerId::from_uuid(Uuid::from_u128(1003)),
+                writable_layer_id: LayerId::from_uuid(Uuid::from_u128(1004)),
+                owner_id: Some("agent".into()),
+            })
+            .await
+            .unwrap();
+        let session = WorkspaceMountSession::acquire(
+            store.clone(),
+            workspace_id,
+            7,
+            DEFAULT_LEASE_TTL,
+            DEFAULT_HEARTBEAT_INTERVAL,
+        )
+        .await
+        .unwrap();
+        let meta = WorkspaceMetaLayer::new(store.clone(), session.view.clone());
+        meta.create_file(meta.root_ino(), "private".into())
+            .await
+            .unwrap();
+        let inspection = WorkspaceControl::new(store)
+            .inspect(workspace_id)
+            .await
+            .unwrap();
+        assert_eq!(inspection.owner_id.as_deref(), Some("agent"));
+        assert_eq!(inspection.holder_generation, Some(7));
+        assert!(inspection.private_metadata_rows >= 2);
+        session.release().await.unwrap();
+    }
+}

--- a/src/workspace_overlay/digest.rs
+++ b/src/workspace_overlay/digest.rs
@@ -1,0 +1,199 @@
+use super::error::WorkspaceError;
+use super::model::{
+    AclDelta, DataExtentDelta, DentryDelta, ExtentKind, InodeDelta, ValueOp,
+    WORKSPACE_SCHEMA_VERSION, XattrDelta,
+};
+
+const MAGIC: &[u8; 8] = b"BWSDELTA";
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct CanonicalLayerDelta {
+    pub dentries: Vec<DentryDelta>,
+    pub inodes: Vec<InodeDelta>,
+    pub xattrs: Vec<XattrDelta>,
+    pub acls: Vec<AclDelta>,
+    pub extents: Vec<DataExtentDelta>,
+}
+
+#[derive(Default)]
+struct CanonicalEncoder {
+    bytes: Vec<u8>,
+}
+
+impl CanonicalEncoder {
+    fn u8(&mut self, value: u8) {
+        self.bytes.push(value);
+    }
+
+    fn u32(&mut self, value: u32) {
+        self.bytes.extend_from_slice(&value.to_be_bytes());
+    }
+
+    fn u64(&mut self, value: u64) {
+        self.bytes.extend_from_slice(&value.to_be_bytes());
+    }
+
+    fn i64(&mut self, value: i64) {
+        self.bytes.extend_from_slice(&value.to_be_bytes());
+    }
+
+    fn bytes(&mut self, value: &[u8]) {
+        self.u64(value.len() as u64);
+        self.bytes.extend_from_slice(value);
+    }
+
+    fn optional<T>(&mut self, value: Option<&T>, encode: impl FnOnce(&mut Self, &T)) {
+        match value {
+            Some(value) => {
+                self.u8(1);
+                encode(self, value);
+            }
+            None => self.u8(0),
+        }
+    }
+
+    fn layer_id(&mut self, id: &super::ids::LayerId) {
+        self.bytes.extend_from_slice(id.as_bytes());
+    }
+
+    fn table(&mut self, tag: u8, rows: usize) {
+        self.u8(tag);
+        self.u64(rows as u64);
+    }
+}
+
+pub fn canonical_delta_bytes(delta: &CanonicalLayerDelta) -> Result<Vec<u8>, WorkspaceError> {
+    let mut encoder = CanonicalEncoder::default();
+    encoder.bytes.extend_from_slice(MAGIC);
+    encoder.u32(WORKSPACE_SCHEMA_VERSION);
+
+    let mut dentries = delta.dentries.iter().collect::<Vec<_>>();
+    dentries.sort_by(|left, right| {
+        (left.layer_id, left.parent_ino, left.name.as_slice()).cmp(&(
+            right.layer_id,
+            right.parent_ino,
+            right.name.as_slice(),
+        ))
+    });
+    encoder.table(1, dentries.len());
+    for row in dentries {
+        row.validate()?;
+        encoder.layer_id(&row.layer_id);
+        encoder.i64(row.parent_ino);
+        encoder.bytes(&row.name);
+        encoder.u8(row.op.discriminant());
+        encoder.optional(row.ino.as_ref(), |encoder, value| encoder.i64(*value));
+        encoder.optional(row.entry_type.as_ref(), |encoder, value| encoder.u8(*value));
+        encoder.u64(row.sequence);
+    }
+
+    let mut inodes = delta.inodes.iter().collect::<Vec<_>>();
+    inodes.sort_by_key(|row| (row.layer_id, row.ino));
+    encoder.table(2, inodes.len());
+    for row in inodes {
+        encoder.layer_id(&row.layer_id);
+        encoder.i64(row.ino);
+        encoder.u8(row.state.discriminant());
+        encoder.u8(row.kind);
+        encoder.u64(row.size);
+        encoder.u32(row.mode);
+        encoder.u32(row.uid);
+        encoder.u32(row.gid);
+        encoder.u32(row.rdev);
+        encoder.u32(row.nlink);
+        encoder.i64(row.atime_ns);
+        encoder.i64(row.mtime_ns);
+        encoder.i64(row.ctime_ns);
+        encoder.optional(row.symlink_target.as_ref(), |encoder, value| {
+            encoder.bytes(value)
+        });
+        encoder.optional(row.parent_hint.as_ref(), |encoder, value| {
+            encoder.i64(*value)
+        });
+        encoder.u64(row.data_version);
+        encoder.u64(row.sequence);
+    }
+
+    let mut xattrs = delta.xattrs.iter().collect::<Vec<_>>();
+    xattrs.sort_by(|left, right| {
+        (left.layer_id, left.ino, left.name.as_slice()).cmp(&(
+            right.layer_id,
+            right.ino,
+            right.name.as_slice(),
+        ))
+    });
+    encoder.table(3, xattrs.len());
+    for row in xattrs {
+        validate_value(row.op, row.value.as_deref(), "xattr")?;
+        encoder.layer_id(&row.layer_id);
+        encoder.i64(row.ino);
+        encoder.bytes(&row.name);
+        encoder.u8(row.op.discriminant());
+        encoder.optional(row.value.as_ref(), |encoder, value| encoder.bytes(value));
+        encoder.u64(row.sequence);
+    }
+
+    let mut acls = delta.acls.iter().collect::<Vec<_>>();
+    acls.sort_by_key(|row| (row.layer_id, row.ino, row.acl_type, row.acl_id));
+    encoder.table(4, acls.len());
+    for row in acls {
+        validate_value(row.op, row.value.as_deref(), "acl")?;
+        encoder.layer_id(&row.layer_id);
+        encoder.i64(row.ino);
+        encoder.u8(row.acl_type);
+        encoder.i64(row.acl_id);
+        encoder.u8(row.op.discriminant());
+        encoder.optional(row.value.as_ref(), |encoder, value| encoder.bytes(value));
+        encoder.u64(row.sequence);
+    }
+
+    let mut extents = delta.extents.iter().collect::<Vec<_>>();
+    extents.sort_by_key(|row| (row.layer_id, row.ino, row.chunk_index, row.sequence));
+    encoder.table(5, extents.len());
+    for row in extents {
+        row.validate()?;
+        encoder.layer_id(&row.layer_id);
+        encoder.i64(row.ino);
+        encoder.u64(row.chunk_index);
+        encoder.u64(row.logical_offset);
+        encoder.u64(row.length);
+        encoder.u8(row.kind.discriminant());
+        match row.kind {
+            ExtentKind::Data {
+                slice_id,
+                slice_offset,
+            } => {
+                encoder.optional(Some(&slice_id), |encoder, value| encoder.u64(*value));
+                encoder.optional(Some(&slice_offset), |encoder, value| encoder.u64(*value));
+            }
+            ExtentKind::Hole => {
+                encoder.optional(None::<&u64>, |_, _| {});
+                encoder.optional(None::<&u64>, |_, _| {});
+            }
+        }
+        encoder.u64(row.sequence);
+    }
+
+    Ok(encoder.bytes)
+}
+
+fn validate_value(op: ValueOp, value: Option<&[u8]>, kind: &str) -> Result<(), WorkspaceError> {
+    match (op, value) {
+        (ValueOp::Put, Some(_)) | (ValueOp::Whiteout, None) => Ok(()),
+        _ => Err(WorkspaceError::CorruptMetadata(format!(
+            "{kind} op/payload mismatch"
+        ))),
+    }
+}
+
+pub fn delta_digest(delta: &CanonicalLayerDelta) -> Result<[u8; 32], WorkspaceError> {
+    Ok(*blake3::hash(&canonical_delta_bytes(delta)?).as_bytes())
+}
+
+pub fn root_hash(parent_root_hash: [u8; 32], delta_digest: [u8; 32]) -> [u8; 32] {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(&WORKSPACE_SCHEMA_VERSION.to_be_bytes());
+    hasher.update(&parent_root_hash);
+    hasher.update(&delta_digest);
+    *hasher.finalize().as_bytes()
+}

--- a/src/workspace_overlay/error.rs
+++ b/src/workspace_overlay/error.rs
@@ -1,0 +1,45 @@
+use thiserror::Error;
+
+use super::ids::{LayerId, LeaseId, WorkspaceId};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ConflictDetail {
+    pub path: Vec<u8>,
+    pub reason: String,
+}
+
+#[derive(Debug, Error)]
+pub enum WorkspaceError {
+    #[error("feature not compiled: {0}")]
+    FeatureNotCompiled(&'static str),
+    #[error("unsupported volume format: {0}")]
+    UnsupportedVolumeFormat(String),
+    #[error("unsupported workspace schema version: {0}")]
+    UnsupportedSchemaVersion(u32),
+    #[error("workspace backend lacks required capability: {0}")]
+    UnsupportedCapability(&'static str),
+    #[error("workspace not found: {0}")]
+    WorkspaceNotFound(WorkspaceId),
+    #[error("layer not found: {0}")]
+    LayerNotFound(LayerId),
+    #[error("lease not found: {0}")]
+    LeaseNotFound(LeaseId),
+    #[error("workspace is busy")]
+    Busy,
+    #[error("workspace writer was fenced")]
+    Fenced,
+    #[error("workspace commit conflict at {path:?}: {reason}", path = .0.path, reason = .0.reason)]
+    Conflict(ConflictDetail),
+    #[error("layer depth {depth} exceeds hard limit {hard_limit}")]
+    LayerDepthLimit { depth: u32, hard_limit: u32 },
+    #[error("corrupt workspace metadata: {0}")]
+    CorruptMetadata(String),
+    #[error("invalid read plan: {0}")]
+    InvalidReadPlan(String),
+    #[error("invalid state transition from {from} to {to}")]
+    InvalidStateTransition { from: String, to: String },
+    #[error("workspace backend error: {0}")]
+    Backend(String),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}

--- a/src/workspace_overlay/gc.rs
+++ b/src/workspace_overlay/gc.rs
@@ -1,0 +1,323 @@
+//! Lease-aware layer and immutable-slice mark-and-sweep.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use crate::chunk::{BlockStore, ChunkLayout};
+
+use super::catalog::{DeleteLayerMetadata, WorkspaceStore};
+use super::error::WorkspaceError;
+use super::ids::LayerId;
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct GcReport {
+    pub reachable_layers: usize,
+    pub deleted_layers: Vec<LayerId>,
+    pub deleted_slices: Vec<u64>,
+    pub orphan_bytes: u64,
+}
+
+pub struct WorkspaceGc<W, B> {
+    store: Arc<W>,
+    blocks: Arc<B>,
+    layout: ChunkLayout,
+    layer_grace: Duration,
+    lease_grace: Duration,
+}
+
+impl<W, B> WorkspaceGc<W, B>
+where
+    W: WorkspaceStore + 'static,
+    B: BlockStore + Send + Sync + 'static,
+{
+    pub fn new(
+        store: Arc<W>,
+        blocks: Arc<B>,
+        layout: ChunkLayout,
+        layer_grace: Duration,
+        lease_grace: Duration,
+    ) -> Self {
+        Self {
+            store,
+            blocks,
+            layout,
+            layer_grace,
+            lease_grace,
+        }
+    }
+
+    pub async fn run_once(&self) -> Result<GcReport, WorkspaceError> {
+        self.run_at(now_ns()?).await
+    }
+
+    pub async fn run_at(&self, now_ns: i64) -> Result<GcReport, WorkspaceError> {
+        let lease_grace_ns = duration_ns(self.lease_grace)?;
+        let snapshot = self.store.gc_snapshot(now_ns, lease_grace_ns).await?;
+        let parents = snapshot
+            .layers
+            .iter()
+            .map(|layer| (layer.layer_id, layer.parent_layer_id))
+            .collect::<BTreeMap<_, _>>();
+        let mut reachable = BTreeSet::new();
+        let mut pending = snapshot.root_layers.clone();
+        while let Some(layer_id) = pending.pop() {
+            if !reachable.insert(layer_id) {
+                continue;
+            }
+            if let Some(Some(parent)) = parents.get(&layer_id) {
+                pending.push(*parent);
+            }
+        }
+
+        let layer_cutoff = now_ns.saturating_sub(to_i64(duration_ns(self.layer_grace)?)?);
+        let deletable = snapshot
+            .layers
+            .iter()
+            .filter(|layer| {
+                !reachable.contains(&layer.layer_id) && layer.created_at_ns <= layer_cutoff
+            })
+            .map(|layer| layer.layer_id)
+            .collect::<BTreeSet<_>>();
+        let reachable_slices = snapshot
+            .slice_references
+            .iter()
+            .filter(|reference| reachable.contains(&reference.layer_id))
+            .map(|reference| reference.slice_id)
+            .collect::<BTreeSet<_>>();
+        let mut orphan_slices = BTreeMap::<u64, u64>::new();
+        for reference in &snapshot.slice_references {
+            if deletable.contains(&reference.layer_id)
+                && !reachable_slices.contains(&reference.slice_id)
+            {
+                orphan_slices
+                    .entry(reference.slice_id)
+                    .and_modify(|end| *end = (*end).max(reference.slice_end))
+                    .or_insert(reference.slice_end);
+            }
+        }
+
+        let deleted_layers = deletable.into_iter().collect::<Vec<_>>();
+        self.store
+            .delete_layer_metadata(DeleteLayerMetadata {
+                layer_ids: deleted_layers.clone(),
+                now_ns,
+                lease_grace_ns,
+            })
+            .await?;
+
+        let mut deleted_slices = Vec::with_capacity(orphan_slices.len());
+        let mut orphan_bytes = 0u64;
+        for (slice_id, slice_end) in orphan_slices {
+            let blocks = slice_end.div_ceil(u64::from(self.layout.block_size));
+            if blocks != 0 {
+                self.blocks
+                    .delete_range((slice_id, 0), blocks)
+                    .await
+                    .map_err(|error| WorkspaceError::Backend(error.to_string()))?;
+            }
+            orphan_bytes = orphan_bytes.saturating_add(slice_end);
+            deleted_slices.push(slice_id);
+        }
+        self.store
+            .finalize_layer_metadata_deletion(deleted_layers.clone())
+            .await?;
+        let report = GcReport {
+            reachable_layers: reachable.len(),
+            deleted_layers,
+            deleted_slices,
+            orphan_bytes,
+        };
+        super::metrics::global_workspace_metrics()
+            .set_gc(report.reachable_layers as u64, report.orphan_bytes);
+        Ok(report)
+    }
+}
+
+fn now_ns() -> Result<i64, WorkspaceError> {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|error| WorkspaceError::Backend(error.to_string()))?
+        .as_nanos();
+    i64::try_from(nanos)
+        .map_err(|_| WorkspaceError::CorruptMetadata("timestamp exceeds i64".into()))
+}
+
+fn duration_ns(duration: Duration) -> Result<u64, WorkspaceError> {
+    u64::try_from(duration.as_nanos())
+        .map_err(|_| WorkspaceError::CorruptMetadata("duration exceeds u64 nanoseconds".into()))
+}
+
+fn to_i64(value: u64) -> Result<i64, WorkspaceError> {
+    i64::try_from(value)
+        .map_err(|_| WorkspaceError::CorruptMetadata("duration exceeds i64 nanoseconds".into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::chunk::{InMemoryBlockStore, SliceDesc};
+    use crate::meta::MetaLayer;
+    use crate::workspace_overlay::catalog::{CreateVolumeRoot, RecordOrphanSlice, WorkspaceStore};
+    use crate::workspace_overlay::ids::{LayerId, WorkspaceId};
+    use crate::workspace_overlay::lifecycle::{
+        DEFAULT_HEARTBEAT_INTERVAL, DEFAULT_LEASE_TTL, NoopDurableRemoteBarrier,
+        WorkspaceLifecycle, WorkspaceMountSession,
+    };
+    use crate::workspace_overlay::meta_layer::WorkspaceMetaLayer;
+    use crate::workspace_overlay::stores::database::SqliteWorkspaceStore;
+
+    async fn setup() -> (
+        Arc<SqliteWorkspaceStore>,
+        WorkspaceMountSession<SqliteWorkspaceStore>,
+    ) {
+        let store = Arc::new(
+            SqliteWorkspaceStore::connect("sqlite::memory:")
+                .await
+                .unwrap(),
+        );
+        store.initialize_workspace_schema().await.unwrap();
+        let workspace_id = WorkspaceId::from_uuid(Uuid::from_u128(801));
+        store
+            .create_volume_root(CreateVolumeRoot {
+                volume_id: Uuid::from_u128(802),
+                workspace_id,
+                root_layer_id: LayerId::from_uuid(Uuid::from_u128(803)),
+                writable_layer_id: LayerId::from_uuid(Uuid::from_u128(804)),
+                owner_id: None,
+            })
+            .await
+            .unwrap();
+        let session = WorkspaceMountSession::acquire(
+            store.clone(),
+            workspace_id,
+            1,
+            DEFAULT_LEASE_TTL,
+            DEFAULT_HEARTBEAT_INTERVAL,
+        )
+        .await
+        .unwrap();
+        (store, session)
+    }
+
+    #[tokio::test]
+    async fn deleting_ninety_nine_children_keeps_the_shared_base() {
+        let (store, session) = setup().await;
+        let lifecycle = WorkspaceLifecycle::new(store.clone());
+        let base = store
+            .load_workspace(session.view.workspace_id)
+            .await
+            .unwrap()
+            .fork_base
+            .unwrap();
+        let base_layer = base.layer_id;
+        let children = lifecycle.fork_revision(base, 100, None).await.unwrap();
+        for child in &children[..99] {
+            lifecycle.discard(child.workspace_id, false).await.unwrap();
+        }
+        let gc = WorkspaceGc::new(
+            store.clone(),
+            Arc::new(InMemoryBlockStore::new()),
+            ChunkLayout::default(),
+            Duration::ZERO,
+            Duration::from_secs(60),
+        );
+        let report = gc.run_at(i64::MAX / 2).await.unwrap();
+        assert_eq!(report.deleted_layers.len(), 99);
+        assert!(store.load_layer(base_layer).await.is_ok());
+        assert!(
+            store
+                .load_workspace(children[99].workspace_id)
+                .await
+                .is_ok()
+        );
+        session.release().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn reachable_child_prevents_shared_slice_collection() {
+        let (store, session) = setup().await;
+        let lifecycle = WorkspaceLifecycle::new(store.clone());
+        let meta = WorkspaceMetaLayer::new(store.clone(), session.view.clone());
+        let ino = meta
+            .create_file(meta.root_ino(), "shared".into())
+            .await
+            .unwrap();
+        let chunk_id = crate::vfs::chunk_id_for(ino, 0).unwrap();
+        meta.write(
+            ino,
+            chunk_id,
+            SliceDesc {
+                slice_id: 77,
+                chunk_id,
+                offset: 0,
+                length: 4096,
+            },
+            4096,
+        )
+        .await
+        .unwrap();
+        let sealed = lifecycle
+            .seal(&session.view, &NoopDurableRemoteBarrier)
+            .await
+            .unwrap();
+        lifecycle
+            .fork_revision(sealed.revision, 1, None)
+            .await
+            .unwrap();
+        let source_workspace_id = session.view.workspace_id;
+        session.release().await.unwrap();
+        lifecycle.discard(source_workspace_id, false).await.unwrap();
+        let gc = WorkspaceGc::new(
+            store,
+            Arc::new(InMemoryBlockStore::new()),
+            ChunkLayout::default(),
+            Duration::ZERO,
+            Duration::from_secs(60),
+        );
+        let report = gc.run_at(i64::MAX / 2).await.unwrap();
+        assert!(!report.deleted_slices.contains(&77));
+    }
+
+    #[tokio::test]
+    async fn persisted_upload_orphan_is_deleted_end_to_end() {
+        let (store, session) = setup().await;
+        let blocks = Arc::new(InMemoryBlockStore::new());
+        blocks
+            .write_fresh_range((88, 0), 0, b"orphan")
+            .await
+            .unwrap();
+        let mut before = [0; 6];
+        blocks.read_range((88, 0), 0, &mut before).await.unwrap();
+        assert_eq!(&before, b"orphan");
+        let orphan_layer_id = LayerId::from_uuid(Uuid::from_u128(805));
+        store
+            .record_orphan_slice(RecordOrphanSlice {
+                orphan_layer_id,
+                slice_id: 88,
+                slice_end: 6,
+            })
+            .await
+            .unwrap();
+
+        let gc = WorkspaceGc::new(
+            store.clone(),
+            blocks.clone(),
+            ChunkLayout::default(),
+            Duration::ZERO,
+            Duration::from_secs(60),
+        );
+        let report = gc.run_at(i64::MAX / 2).await.unwrap();
+        assert_eq!(report.deleted_slices, vec![88]);
+        assert!(report.deleted_layers.contains(&orphan_layer_id));
+        assert!(store.load_layer(orphan_layer_id).await.is_err());
+        let mut output = [9; 6];
+        blocks.read_range((88, 0), 0, &mut output).await.unwrap();
+        assert_eq!(output, [9; 6]);
+        session.release().await.unwrap();
+    }
+}

--- a/src/workspace_overlay/ids.rs
+++ b/src/workspace_overlay/ids.rs
@@ -1,0 +1,70 @@
+use std::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+macro_rules! workspace_id {
+    ($name:ident) => {
+        #[derive(
+            Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize, Deserialize,
+        )]
+        #[serde(transparent)]
+        pub struct $name(Uuid);
+
+        #[allow(clippy::new_without_default)]
+        impl $name {
+            pub fn new() -> Self {
+                Self(Uuid::now_v7())
+            }
+
+            pub const fn from_uuid(value: Uuid) -> Self {
+                Self(value)
+            }
+
+            pub const fn as_uuid(&self) -> &Uuid {
+                &self.0
+            }
+
+            pub const fn into_uuid(self) -> Uuid {
+                self.0
+            }
+
+            pub fn as_bytes(&self) -> &[u8; 16] {
+                self.0.as_bytes()
+            }
+        }
+
+        impl From<Uuid> for $name {
+            fn from(value: Uuid) -> Self {
+                Self::from_uuid(value)
+            }
+        }
+
+        impl From<$name> for Uuid {
+            fn from(value: $name) -> Self {
+                value.into_uuid()
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                self.0.fmt(formatter)
+            }
+        }
+
+        impl FromStr for $name {
+            type Err = uuid::Error;
+
+            fn from_str(value: &str) -> Result<Self, Self::Err> {
+                Uuid::parse_str(value).map(Self::from_uuid)
+            }
+        }
+    };
+}
+
+workspace_id!(WorkspaceId);
+workspace_id!(LayerId);
+workspace_id!(LeaseId);
+workspace_id!(JournalId);
+workspace_id!(SnapshotId);

--- a/src/workspace_overlay/lifecycle/mod.rs
+++ b/src/workspace_overlay/lifecycle/mod.rs
@@ -1,0 +1,439 @@
+//! Workspace lifecycle orchestration over atomic `WorkspaceStore` primitives.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+use super::catalog::{
+    AbortSeal, AcquireLease, AdvanceSeal, BeginSeal, CreateSnapshot, CreateWorkspace,
+    FastForwardCommit, HeadGuard, MarkDeleting, ReleaseLease, RenewLease, WorkspaceStore,
+};
+use super::compaction::WorkspaceCompactor;
+use super::error::WorkspaceError;
+use super::ids::{JournalId, LayerId, LeaseId, SnapshotId, WorkspaceId};
+use super::metrics::{WorkspaceMetrics, global_workspace_metrics};
+use super::model::{
+    BaseRevision, CommitResult, LayerRecord, LayerState, SealPhase, SealResult, SnapshotLease,
+    SnapshotRecord, ViewContext, WorkspaceRecord,
+};
+
+pub const DEFAULT_LEASE_TTL: Duration = Duration::from_secs(30);
+pub const DEFAULT_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(10);
+
+#[async_trait]
+pub trait DurableRemoteBarrier: Send + Sync {
+    async fn drain(&self, workspace_id: WorkspaceId, head_epoch: u64)
+    -> Result<(), WorkspaceError>;
+}
+
+pub struct NoopDurableRemoteBarrier;
+
+#[async_trait]
+impl DurableRemoteBarrier for NoopDurableRemoteBarrier {
+    async fn drain(
+        &self,
+        _workspace_id: WorkspaceId,
+        _head_epoch: u64,
+    ) -> Result<(), WorkspaceError> {
+        Ok(())
+    }
+}
+
+pub struct WorkspaceLifecycle<W> {
+    store: Arc<W>,
+    metrics: Arc<WorkspaceMetrics>,
+}
+
+impl<W: WorkspaceStore + 'static> WorkspaceLifecycle<W> {
+    pub fn new(store: Arc<W>) -> Self {
+        Self {
+            store,
+            metrics: global_workspace_metrics(),
+        }
+    }
+
+    pub fn store(&self) -> &Arc<W> {
+        &self.store
+    }
+
+    pub async fn seal(
+        &self,
+        view: &ViewContext,
+        barrier: &dyn DurableRemoteBarrier,
+    ) -> Result<SealResult, WorkspaceError> {
+        let started = Instant::now();
+        let result = self.seal_inner(view, barrier).await;
+        self.metrics.record_seal(result.is_ok());
+        self.metrics
+            .add_quiesce_latency_ns(started.elapsed().as_nanos().min(u128::from(u64::MAX)) as u64);
+        result
+    }
+
+    async fn seal_inner(
+        &self,
+        view: &ViewContext,
+        barrier: &dyn DurableRemoteBarrier,
+    ) -> Result<SealResult, WorkspaceError> {
+        let journal_id = JournalId::new();
+        self.store
+            .begin_seal(BeginSeal {
+                guard: HeadGuard {
+                    workspace_id: view.workspace_id,
+                    expected_head_layer_id: view.head_layer_id,
+                    expected_head_epoch: view.head_epoch,
+                    lease_id: view.lease_id,
+                    holder_generation: view.holder_generation,
+                },
+                journal_id,
+                new_head_layer_id: LayerId::new(),
+            })
+            .await?;
+        self.store
+            .advance_seal(AdvanceSeal {
+                journal_id,
+                expected_phase: SealPhase::Prepare,
+                next_phase: SealPhase::Quiesced,
+                pending_bytes: None,
+                last_error: None,
+            })
+            .await?;
+        if let Err(error) = barrier.drain(view.workspace_id, view.head_epoch).await {
+            let _ = self
+                .store
+                .abort_recoverable_seal(AbortSeal {
+                    journal_id,
+                    reason: error.to_string(),
+                })
+                .await;
+            return Err(error);
+        }
+        self.store
+            .advance_seal(AdvanceSeal {
+                journal_id,
+                expected_phase: SealPhase::Quiesced,
+                next_phase: SealPhase::DataDrained,
+                pending_bytes: Some(0),
+                last_error: None,
+            })
+            .await?;
+        self.store.hash_seal(journal_id).await?;
+        self.store.commit_seal(journal_id).await?;
+        self.flatten_sealed_workspace(view.workspace_id).await
+    }
+
+    async fn flatten_sealed_workspace(
+        &self,
+        workspace_id: WorkspaceId,
+    ) -> Result<SealResult, WorkspaceError> {
+        let compacted = WorkspaceCompactor::new(self.store.clone())
+            .compact(workspace_id)
+            .await?;
+        Ok(SealResult {
+            revision: compacted.revision,
+            new_head_layer_id: compacted.replacement_head_layer_id,
+            head_epoch: compacted.head_epoch,
+        })
+    }
+
+    pub async fn fork_revision(
+        &self,
+        revision: BaseRevision,
+        count: usize,
+        owner_id: Option<String>,
+    ) -> Result<Vec<WorkspaceRecord>, WorkspaceError> {
+        let started = Instant::now();
+        let result = self.fork_revision_inner(revision, count, owner_id).await;
+        self.metrics.record_fork(result.is_ok());
+        self.metrics.add_fork_control_latency_ns(
+            started.elapsed().as_nanos().min(u128::from(u64::MAX)) as u64,
+        );
+        result
+    }
+
+    async fn fork_revision_inner(
+        &self,
+        revision: BaseRevision,
+        count: usize,
+        owner_id: Option<String>,
+    ) -> Result<Vec<WorkspaceRecord>, WorkspaceError> {
+        let mut workspaces = Vec::with_capacity(count);
+        for _ in 0..count {
+            workspaces.push(
+                self.store
+                    .create_workspace(CreateWorkspace {
+                        workspace_id: WorkspaceId::new(),
+                        head_layer_id: LayerId::new(),
+                        base_revision: revision.clone(),
+                        owner_id: owner_id.clone(),
+                    })
+                    .await?,
+            );
+        }
+        Ok(workspaces)
+    }
+
+    pub async fn snapshot_revision(
+        &self,
+        revision: BaseRevision,
+        name: Option<String>,
+        owner_id: Option<String>,
+    ) -> Result<SnapshotRecord, WorkspaceError> {
+        self.store
+            .create_snapshot(CreateSnapshot {
+                snapshot_id: SnapshotId::new(),
+                name,
+                revision,
+                owner_id,
+            })
+            .await
+    }
+
+    pub async fn seal_and_snapshot(
+        &self,
+        view: &ViewContext,
+        barrier: &dyn DurableRemoteBarrier,
+        name: Option<String>,
+        owner_id: Option<String>,
+    ) -> Result<(SealResult, SnapshotRecord), WorkspaceError> {
+        let sealed = self.seal(view, barrier).await?;
+        let snapshot = self
+            .snapshot_revision(sealed.revision.clone(), name, owner_id)
+            .await?;
+        Ok((sealed, snapshot))
+    }
+
+    pub async fn discard(
+        &self,
+        workspace_id: WorkspaceId,
+        force_fence_lease: bool,
+    ) -> Result<(), WorkspaceError> {
+        self.store
+            .mark_workspace_deleting(MarkDeleting {
+                workspace_id,
+                force_fence_lease,
+            })
+            .await
+    }
+
+    pub async fn fast_forward(
+        &self,
+        source_revision: BaseRevision,
+        source_fork_base: BaseRevision,
+        target: &WorkspaceRecord,
+    ) -> Result<CommitResult, WorkspaceError> {
+        let result = self
+            .store
+            .fast_forward_commit(FastForwardCommit {
+                source_revision,
+                source_fork_base,
+                target_workspace_id: target.workspace_id,
+                target_expected_head_layer_id: target.head_layer_id,
+                target_expected_head_epoch: target.head_epoch,
+                new_head_layer_id: LayerId::new(),
+            })
+            .await;
+        self.metrics.record_publish(result.is_ok());
+        result
+    }
+
+    pub async fn recover_incomplete_seals(&self) -> Result<Vec<SealResult>, WorkspaceError> {
+        let journals = self.store.list_incomplete_seal_journals().await?;
+        let mut completed = Vec::new();
+        for journal in journals {
+            match journal.phase {
+                SealPhase::Prepare | SealPhase::Quiesced => {
+                    self.store
+                        .abort_recoverable_seal(AbortSeal {
+                            journal_id: journal.journal_id,
+                            reason: "recovery restored the pre-switch view".into(),
+                        })
+                        .await?;
+                }
+                SealPhase::DataDrained => {
+                    self.store.hash_seal(journal.journal_id).await?;
+                    self.store.commit_seal(journal.journal_id).await?;
+                    completed.push(self.flatten_sealed_workspace(journal.workspace_id).await?);
+                }
+                SealPhase::Hashed | SealPhase::HeadSwitched => {
+                    self.store.commit_seal(journal.journal_id).await?;
+                    completed.push(self.flatten_sealed_workspace(journal.workspace_id).await?);
+                }
+                SealPhase::Completed | SealPhase::Aborted => {}
+            }
+        }
+        Ok(completed)
+    }
+}
+
+pub struct WorkspaceMountSession<W> {
+    store: Arc<W>,
+    pub lease: SnapshotLease,
+    pub view: ViewContext,
+    heartbeat: LeaseHeartbeat,
+}
+
+impl<W: WorkspaceStore + 'static> WorkspaceMountSession<W> {
+    pub async fn acquire(
+        store: Arc<W>,
+        workspace_id: WorkspaceId,
+        holder_generation: u64,
+        ttl: Duration,
+        heartbeat_interval: Duration,
+    ) -> Result<Self, WorkspaceError> {
+        let metrics = global_workspace_metrics();
+        let result = Self::acquire_inner(
+            store,
+            workspace_id,
+            holder_generation,
+            ttl,
+            heartbeat_interval,
+        )
+        .await;
+        metrics.record_mount(result.is_ok());
+        if result.is_ok() {
+            metrics.add_active_lease();
+        }
+        result
+    }
+
+    async fn acquire_inner(
+        store: Arc<W>,
+        workspace_id: WorkspaceId,
+        holder_generation: u64,
+        ttl: Duration,
+        heartbeat_interval: Duration,
+    ) -> Result<Self, WorkspaceError> {
+        store.capabilities().validate_for_v1_mount()?;
+        let mut workspace = store.load_workspace(workspace_id).await?;
+        let mut chain = store.load_layer_chain(workspace.head_layer_id).await?;
+        if !is_fixed_layer_pair(&chain) {
+            WorkspaceCompactor::new(store.clone())
+                .compact(workspace_id)
+                .await?;
+            workspace = store.load_workspace(workspace_id).await?;
+            chain = store.load_layer_chain(workspace.head_layer_id).await?;
+        }
+        if !is_fixed_layer_pair(&chain) {
+            return Err(WorkspaceError::CorruptMetadata(
+                "workspace mount requires one flat sealed base and one writable overlay".into(),
+            ));
+        }
+        let ttl_ns = duration_ns(ttl)?;
+        let lease = store
+            .acquire_lease(AcquireLease {
+                workspace_id,
+                lease_id: LeaseId::new(),
+                holder_generation,
+                ttl_ns,
+            })
+            .await?;
+        let view = ViewContext {
+            workspace_id,
+            head_layer_id: workspace.head_layer_id,
+            head_epoch: workspace.head_epoch,
+            lease_id: lease.lease_id,
+            holder_generation,
+        };
+        let heartbeat = LeaseHeartbeat::spawn(
+            store.clone(),
+            lease.lease_id,
+            holder_generation,
+            ttl,
+            heartbeat_interval,
+        );
+        Ok(Self {
+            store,
+            lease,
+            view,
+            heartbeat,
+        })
+    }
+
+    pub async fn release(self) -> Result<(), WorkspaceError> {
+        self.heartbeat.stop().await;
+        let result = self
+            .store
+            .release_lease(ReleaseLease {
+                lease_id: self.lease.lease_id,
+                holder_generation: self.lease.holder_generation,
+            })
+            .await;
+        if result.is_ok() {
+            global_workspace_metrics().remove_active_lease();
+        }
+        result
+    }
+}
+
+fn is_fixed_layer_pair(chain: &[LayerRecord]) -> bool {
+    let [head, base] = chain else {
+        return false;
+    };
+    head.state == LayerState::Writable
+        && head.parent_layer_id == Some(base.layer_id)
+        && head.depth == 2
+        && base.state == LayerState::Sealed
+        && base.parent_layer_id.is_none()
+        && base.depth == 1
+}
+
+struct LeaseHeartbeat {
+    cancel: CancellationToken,
+    task: JoinHandle<()>,
+}
+
+impl LeaseHeartbeat {
+    fn spawn<W: WorkspaceStore + 'static>(
+        store: Arc<W>,
+        lease_id: LeaseId,
+        holder_generation: u64,
+        ttl: Duration,
+        interval: Duration,
+    ) -> Self {
+        let cancel = CancellationToken::new();
+        let task_cancel = cancel.clone();
+        let task = tokio::spawn(async move {
+            let ttl_ns = match duration_ns(ttl) {
+                Ok(value) => value,
+                Err(_) => return,
+            };
+            let mut timer = tokio::time::interval(interval);
+            timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            timer.tick().await;
+            loop {
+                tokio::select! {
+                    _ = task_cancel.cancelled() => break,
+                    _ = timer.tick() => {
+                        if let Err(error) = store.reap_expired_leases().await {
+                            tracing::warn!(?error, "workspace expired-lease reaper failed");
+                        }
+                        if store.renew_lease(RenewLease {
+                            lease_id,
+                            holder_generation,
+                            ttl_ns,
+                        }).await.is_err() {
+                            break;
+                        }
+                    }
+                }
+            }
+        });
+        Self { cancel, task }
+    }
+
+    async fn stop(self) {
+        self.cancel.cancel();
+        let _ = self.task.await;
+    }
+}
+
+fn duration_ns(duration: Duration) -> Result<u64, WorkspaceError> {
+    u64::try_from(duration.as_nanos())
+        .map_err(|_| WorkspaceError::CorruptMetadata("duration exceeds u64 nanoseconds".into()))
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/workspace_overlay/lifecycle/tests.rs
+++ b/src/workspace_overlay/lifecycle/tests.rs
@@ -1,0 +1,306 @@
+use std::sync::Arc;
+
+use uuid::Uuid;
+
+use crate::meta::MetaLayer;
+use crate::workspace_overlay::catalog::{CreateVolumeRoot, WorkspaceStore};
+use crate::workspace_overlay::ids::{LayerId, WorkspaceId};
+use crate::workspace_overlay::meta_layer::WorkspaceMetaLayer;
+use crate::workspace_overlay::model::{LayerState, ViewContext, WorkspaceState};
+use crate::workspace_overlay::stores::database::SqliteWorkspaceStore;
+
+use super::*;
+
+async fn setup() -> (
+    Arc<SqliteWorkspaceStore>,
+    WorkspaceMountSession<SqliteWorkspaceStore>,
+) {
+    let store = Arc::new(
+        SqliteWorkspaceStore::connect("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
+    store.initialize_workspace_schema().await.unwrap();
+    let workspace_id = WorkspaceId::from_uuid(Uuid::from_u128(501));
+    store
+        .create_volume_root(CreateVolumeRoot {
+            volume_id: Uuid::from_u128(502),
+            workspace_id,
+            root_layer_id: LayerId::from_uuid(Uuid::from_u128(503)),
+            writable_layer_id: LayerId::from_uuid(Uuid::from_u128(504)),
+            owner_id: None,
+        })
+        .await
+        .unwrap();
+    let session = WorkspaceMountSession::acquire(
+        store.clone(),
+        workspace_id,
+        1,
+        DEFAULT_LEASE_TTL,
+        Duration::from_secs(3600),
+    )
+    .await
+    .unwrap();
+    (store, session)
+}
+
+#[tokio::test]
+async fn seal_installs_a_flat_base_and_fences_the_old_view() {
+    let (store, session) = setup().await;
+    let meta = WorkspaceMetaLayer::new(store.clone(), session.view.clone());
+    meta.create_file(meta.root_ino(), "before-seal".into())
+        .await
+        .unwrap();
+    let lifecycle = WorkspaceLifecycle::new(store.clone());
+    let sealed = lifecycle
+        .seal(&session.view, &NoopDurableRemoteBarrier)
+        .await
+        .unwrap();
+    assert_eq!(
+        store
+            .load_layer(sealed.revision.layer_id)
+            .await
+            .unwrap()
+            .state,
+        LayerState::Sealed
+    );
+    assert_eq!(
+        store
+            .load_layer(sealed.new_head_layer_id)
+            .await
+            .unwrap()
+            .state,
+        LayerState::Writable
+    );
+    let pair = store
+        .load_layer_chain(sealed.new_head_layer_id)
+        .await
+        .unwrap();
+    assert_eq!(pair.len(), 2);
+    assert_eq!(pair[0].state, LayerState::Writable);
+    assert_eq!(pair[0].depth, 2);
+    assert_eq!(pair[1].state, LayerState::Sealed);
+    assert_eq!(pair[1].depth, 1);
+    assert!(pair[1].parent_layer_id.is_none());
+    assert!(
+        meta.create_file(meta.root_ino(), "stale".into())
+            .await
+            .is_err()
+    );
+    let current_view = ViewContext {
+        head_layer_id: sealed.new_head_layer_id,
+        head_epoch: sealed.head_epoch,
+        ..session.view.clone()
+    };
+    meta.replace_view_context(current_view.clone()).await;
+    meta.create_file(meta.root_ino(), "after-seal".into())
+        .await
+        .unwrap();
+    let resealed = lifecycle
+        .seal(&current_view, &NoopDurableRemoteBarrier)
+        .await
+        .unwrap();
+    let resealed_pair = store
+        .load_layer_chain(resealed.new_head_layer_id)
+        .await
+        .unwrap();
+    assert_eq!(resealed_pair.len(), 2);
+    assert_eq!(resealed_pair[0].depth, 2);
+    assert_eq!(resealed_pair[1].depth, 1);
+    assert!(resealed_pair[1].parent_layer_id.is_none());
+    session.release().await.unwrap();
+}
+
+#[tokio::test]
+async fn fork_snapshot_discard_and_fast_forward_are_revision_checked() {
+    let (store, session) = setup().await;
+    let lifecycle = WorkspaceLifecycle::new(store.clone());
+    let source_meta = WorkspaceMetaLayer::new(store.clone(), session.view.clone());
+    source_meta
+        .create_file(source_meta.root_ino(), "source-change".into())
+        .await
+        .unwrap();
+    let sealed = lifecycle
+        .seal(&session.view, &NoopDurableRemoteBarrier)
+        .await
+        .unwrap();
+    let fork_base = store
+        .load_workspace(session.view.workspace_id)
+        .await
+        .unwrap()
+        .fork_base
+        .unwrap();
+    let snapshot = lifecycle
+        .snapshot_revision(sealed.revision.clone(), Some("release".into()), None)
+        .await
+        .unwrap();
+    assert_eq!(
+        store.load_snapshot(snapshot.snapshot_id).await.unwrap(),
+        snapshot
+    );
+
+    let children = lifecycle
+        .fork_revision(fork_base.clone(), 2, Some("agent".into()))
+        .await
+        .unwrap();
+    let target = children[0].clone();
+    let committed = lifecycle
+        .fast_forward(sealed.revision.clone(), fork_base, &target)
+        .await
+        .unwrap();
+    assert_eq!(committed.revision, sealed.revision);
+    let stale = lifecycle
+        .fast_forward(
+            committed.revision.clone(),
+            target.fork_base.clone().unwrap(),
+            &target,
+        )
+        .await;
+    assert!(stale.is_err());
+
+    lifecycle
+        .discard(children[1].workspace_id, false)
+        .await
+        .unwrap();
+    assert_eq!(
+        store
+            .load_workspace(children[1].workspace_id)
+            .await
+            .unwrap()
+            .state,
+        WorkspaceState::Deleting
+    );
+    session.release().await.unwrap();
+}
+
+#[tokio::test]
+async fn recovery_aborts_pre_hash_journal_to_the_old_view() {
+    let (store, session) = setup().await;
+    store
+        .begin_seal(BeginSeal {
+            guard: HeadGuard {
+                workspace_id: session.view.workspace_id,
+                expected_head_layer_id: session.view.head_layer_id,
+                expected_head_epoch: session.view.head_epoch,
+                lease_id: session.view.lease_id,
+                holder_generation: session.view.holder_generation,
+            },
+            journal_id: JournalId::new(),
+            new_head_layer_id: LayerId::new(),
+        })
+        .await
+        .unwrap();
+    let lifecycle = WorkspaceLifecycle::new(store.clone());
+    assert!(
+        lifecycle
+            .recover_incomplete_seals()
+            .await
+            .unwrap()
+            .is_empty()
+    );
+    let workspace = store
+        .load_workspace(session.view.workspace_id)
+        .await
+        .unwrap();
+    assert_eq!(workspace.state, WorkspaceState::Active);
+    assert_eq!(workspace.head_layer_id, session.view.head_layer_id);
+    session.release().await.unwrap();
+}
+
+#[tokio::test]
+async fn recovery_completes_data_drained_and_hashed_journals_exactly_once() {
+    for stop_phase in [SealPhase::DataDrained, SealPhase::Hashed] {
+        let (store, session) = setup().await;
+        let journal_id = JournalId::new();
+        store
+            .begin_seal(BeginSeal {
+                guard: HeadGuard {
+                    workspace_id: session.view.workspace_id,
+                    expected_head_layer_id: session.view.head_layer_id,
+                    expected_head_epoch: session.view.head_epoch,
+                    lease_id: session.view.lease_id,
+                    holder_generation: session.view.holder_generation,
+                },
+                journal_id,
+                new_head_layer_id: LayerId::new(),
+            })
+            .await
+            .unwrap();
+        store
+            .advance_seal(AdvanceSeal {
+                journal_id,
+                expected_phase: SealPhase::Prepare,
+                next_phase: SealPhase::Quiesced,
+                pending_bytes: None,
+                last_error: None,
+            })
+            .await
+            .unwrap();
+        store
+            .advance_seal(AdvanceSeal {
+                journal_id,
+                expected_phase: SealPhase::Quiesced,
+                next_phase: SealPhase::DataDrained,
+                pending_bytes: Some(0),
+                last_error: None,
+            })
+            .await
+            .unwrap();
+        if stop_phase == SealPhase::Hashed {
+            store.hash_seal(journal_id).await.unwrap();
+        }
+
+        let completed = WorkspaceLifecycle::new(store.clone())
+            .recover_incomplete_seals()
+            .await
+            .unwrap();
+        assert_eq!(completed.len(), 1);
+        assert_eq!(
+            store.load_seal_journal(journal_id).await.unwrap().phase,
+            SealPhase::Completed
+        );
+        assert!(
+            WorkspaceLifecycle::new(store.clone())
+                .recover_incomplete_seals()
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        session.release().await.unwrap();
+    }
+}
+
+struct FailingBarrier;
+
+#[async_trait::async_trait]
+impl DurableRemoteBarrier for FailingBarrier {
+    async fn drain(
+        &self,
+        _workspace_id: WorkspaceId,
+        _head_epoch: u64,
+    ) -> Result<(), WorkspaceError> {
+        Err(WorkspaceError::Backend("injected drain failure".into()))
+    }
+}
+
+#[tokio::test]
+async fn failed_durable_barrier_restores_active_old_view() {
+    let (store, session) = setup().await;
+    let old = store
+        .load_workspace(session.view.workspace_id)
+        .await
+        .unwrap();
+    let error = WorkspaceLifecycle::new(store.clone())
+        .seal(&session.view, &FailingBarrier)
+        .await
+        .unwrap_err();
+    assert!(matches!(error, WorkspaceError::Backend(_)));
+    let restored = store
+        .load_workspace(session.view.workspace_id)
+        .await
+        .unwrap();
+    assert_eq!(restored.state, WorkspaceState::Active);
+    assert_eq!(restored.head_layer_id, old.head_layer_id);
+    assert_eq!(restored.head_epoch, old.head_epoch);
+    session.release().await.unwrap();
+}

--- a/src/workspace_overlay/meta_layer/mod.rs
+++ b/src/workspace_overlay/meta_layer/mod.rs
@@ -1,0 +1,1910 @@
+//! `MetaLayer` implementation backed exclusively by workspace deltas.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use async_trait::async_trait;
+use dashmap::DashMap;
+use tokio::sync::{Mutex, RwLock};
+
+use crate::chunk::SliceDesc;
+use crate::chunk::layout::DEFAULT_CHUNK_SIZE;
+use crate::chunk::read_plan::{ReadPlanSegment, ResolvedReadPlan, WorkspaceReadPlanProvider};
+use crate::meta::client::session::SessionInfo;
+use crate::meta::file_lock::{
+    FileLockInfo, FileLockQuery, FileLockRange, FileLockType, PlockRecord,
+};
+use crate::meta::layer::MetaLayer;
+use crate::meta::store::{
+    AclRule, CreateEntryResult, DirEntry, FileAttr, FileType, MetaError, OpenFlags, SetAttrFlags,
+    SetAttrRequest, StatFsSnapshot,
+};
+use crate::vfs::handles::DirHandle;
+
+use super::cache::{ReadPlanCacheKey, WorkspaceResolverCache};
+use super::catalog::{
+    AclMutation, AclQuery, DataMutation, DentryQuery, ExtentQuery, HeadGuard, InodeMutation,
+    InodeQuery, NamespaceMutation, RecordOrphanSlice, WorkspaceStore, XattrMutation, XattrQuery,
+};
+use super::error::WorkspaceError;
+use super::ids::LayerId;
+use super::metrics::{WorkspaceMetrics, global_workspace_metrics};
+use super::model::{
+    AclDelta, DataExtentDelta, DentryDelta, InodeDelta, InodeState, LayerRecord, LayerState,
+    ValueOp, ViewContext, XattrDelta,
+};
+use super::resolver::{
+    ResolvedDentry, resolve_acl, resolve_dentry, resolve_directory, resolve_extents, resolve_inode,
+    resolve_xattr,
+};
+
+pub struct WorkspaceMetaLayer<W> {
+    store: Arc<W>,
+    view: Arc<RwLock<ViewContext>>,
+    layer_pair: RwLock<Option<(LayerId, u64, Vec<LayerRecord>)>>,
+    root_ino: AtomicI64,
+    chunk_size: u64,
+    open_counts: DashMap<i64, u64>,
+    resolver_cache: WorkspaceResolverCache,
+    locks: Mutex<WorkspaceLocks>,
+    mutation_gate: Mutex<()>,
+    metrics: Arc<WorkspaceMetrics>,
+}
+
+fn validate_fixed_layer_pair(chain: &[LayerRecord]) -> Result<(), WorkspaceError> {
+    let [head, base] = chain else {
+        return Err(WorkspaceError::CorruptMetadata(format!(
+            "workspace view must contain exactly one writable layer and one sealed base; found {} layers",
+            chain.len()
+        )));
+    };
+    if head.state != LayerState::Writable
+        || head.parent_layer_id != Some(base.layer_id)
+        || head.depth != 2
+        || base.state != LayerState::Sealed
+        || base.parent_layer_id.is_some()
+        || base.depth != 1
+    {
+        return Err(WorkspaceError::CorruptMetadata(
+            "workspace view is not a fixed sealed base plus writable overlay".into(),
+        ));
+    }
+    Ok(())
+}
+
+#[derive(Default)]
+struct WorkspaceLocks {
+    plocks: BTreeMap<(i64, i64), Vec<PlockRecord>>,
+    flocks: BTreeMap<(i64, i64), FileLockType>,
+}
+
+impl<W: WorkspaceStore + 'static> WorkspaceMetaLayer<W> {
+    pub fn new(store: Arc<W>, view: ViewContext) -> Self {
+        Self {
+            store,
+            view: Arc::new(RwLock::new(view)),
+            layer_pair: RwLock::new(None),
+            root_ino: AtomicI64::new(1),
+            chunk_size: DEFAULT_CHUNK_SIZE,
+            open_counts: DashMap::new(),
+            resolver_cache: WorkspaceResolverCache::default(),
+            locks: Mutex::new(WorkspaceLocks::default()),
+            mutation_gate: Mutex::new(()),
+            metrics: global_workspace_metrics(),
+        }
+    }
+
+    pub fn with_chunk_size(store: Arc<W>, view: ViewContext, chunk_size: u64) -> Self {
+        let mut layer = Self::new(store, view);
+        layer.chunk_size = chunk_size;
+        layer
+    }
+
+    pub fn store(&self) -> &Arc<W> {
+        &self.store
+    }
+
+    pub async fn view_context(&self) -> ViewContext {
+        self.view.read().await.clone()
+    }
+
+    pub async fn replace_view_context(&self, view: ViewContext) {
+        let old_workspace = self.view.read().await.workspace_id;
+        self.resolver_cache.invalidate_workspace(old_workspace);
+        *self.view.write().await = view;
+        *self.layer_pair.write().await = None;
+    }
+
+    async fn chain(&self) -> Result<Vec<LayerRecord>, MetaError> {
+        let view = self.view.read().await.clone();
+        if let Some((head, epoch, layers)) = self.layer_pair.read().await.as_ref()
+            && *head == view.head_layer_id
+            && *epoch == view.head_epoch
+        {
+            return Ok(layers.clone());
+        }
+        let chain = self
+            .store
+            .load_layer_chain(view.head_layer_id)
+            .await
+            .map_err(workspace_to_meta)?;
+        validate_fixed_layer_pair(&chain).map_err(workspace_to_meta)?;
+        self.metrics.add_resolver_steps(chain.len() as u64);
+        if let Some(head) = chain.first() {
+            self.metrics.set_layer_depth(u64::from(head.depth));
+        }
+        *self.layer_pair.write().await = Some((view.head_layer_id, view.head_epoch, chain.clone()));
+        Ok(chain)
+    }
+
+    async fn guard(&self) -> HeadGuard {
+        let view = self.view.read().await;
+        HeadGuard {
+            workspace_id: view.workspace_id,
+            expected_head_layer_id: view.head_layer_id,
+            expected_head_epoch: view.head_epoch,
+            lease_id: view.lease_id,
+            holder_generation: view.holder_generation,
+        }
+    }
+
+    async fn resolve_inode_delta(&self, ino: i64) -> Result<Option<InodeDelta>, MetaError> {
+        let chain = self.chain().await?;
+        let rows = self
+            .store
+            .get_inode_deltas(InodeQuery {
+                layer_ids: chain.iter().map(|layer| layer.layer_id).collect(),
+                ino,
+            })
+            .await
+            .map_err(workspace_to_meta)?;
+        Ok(resolve_inode(&chain, &rows, ino)
+            .map_err(workspace_to_meta)?
+            .map(|resolved| resolved.inode))
+    }
+
+    async fn resolve_dentry_entry(
+        &self,
+        parent: i64,
+        name: &[u8],
+    ) -> Result<Option<ResolvedDentry>, MetaError> {
+        let chain = self.chain().await?;
+        let rows = self
+            .store
+            .get_dentry_deltas(DentryQuery {
+                layer_ids: chain.iter().map(|layer| layer.layer_id).collect(),
+                parent_ino: parent,
+                name: Some(name.to_vec()),
+            })
+            .await
+            .map_err(workspace_to_meta)?;
+        resolve_dentry(&chain, &rows, parent, name).map_err(workspace_to_meta)
+    }
+
+    async fn mutate_inode(&self, mut inode: InodeDelta) -> Result<InodeDelta, MetaError> {
+        let guard = self.guard().await;
+        inode.layer_id = guard.expected_head_layer_id;
+        inode.sequence = 0;
+        self.store
+            .apply_inode_mutation(InodeMutation { guard, inode })
+            .await
+            .map_err(|error| self.mutation_error(error))
+    }
+
+    async fn mutate_data(
+        &self,
+        mut inode: InodeDelta,
+        mut extents: Vec<DataExtentDelta>,
+    ) -> Result<InodeDelta, MetaError> {
+        let guard = self.guard().await;
+        inode.layer_id = guard.expected_head_layer_id;
+        inode.sequence = 0;
+        for extent in &mut extents {
+            extent.layer_id = guard.expected_head_layer_id;
+            extent.ino = inode.ino;
+            extent.sequence = 0;
+        }
+        let workspace_id = guard.workspace_id;
+        let ino = inode.ino;
+        let private_bytes = extents
+            .iter()
+            .filter_map(|extent| {
+                matches!(extent.kind, super::model::ExtentKind::Data { .. })
+                    .then_some(extent.length)
+            })
+            .fold(0u64, u64::saturating_add);
+        let result = self
+            .store
+            .apply_data_mutation(DataMutation {
+                guard,
+                inode,
+                extents,
+                chunk_size: self.chunk_size,
+            })
+            .await
+            .map_err(|error| self.mutation_error(error))?;
+        self.metrics.add_private_bytes_written(private_bytes);
+        self.resolver_cache.invalidate_inode(workspace_id, ino);
+        Ok(result.inode)
+    }
+
+    fn mutation_error(&self, error: WorkspaceError) -> MetaError {
+        if matches!(error, WorkspaceError::Fenced) {
+            self.metrics.record_fenced_write();
+        }
+        workspace_to_meta(error)
+    }
+
+    fn hole_extents(
+        &self,
+        layer_id: super::ids::LayerId,
+        ino: i64,
+        start: u64,
+        end: u64,
+    ) -> Result<Vec<DataExtentDelta>, MetaError> {
+        let mut extents = Vec::new();
+        let mut cursor = start;
+        while cursor < end {
+            let chunk_index = cursor / self.chunk_size;
+            let logical_offset = cursor % self.chunk_size;
+            let length = (end - cursor).min(self.chunk_size - logical_offset);
+            extents.push(DataExtentDelta::hole(
+                layer_id,
+                ino,
+                chunk_index,
+                logical_offset,
+                length,
+                0,
+            ));
+            cursor = cursor
+                .checked_add(length)
+                .ok_or_else(|| MetaError::Internal("truncate range overflows".into()))?;
+        }
+        Ok(extents)
+    }
+
+    async fn reverse_entries(&self, target: i64) -> Result<Vec<(i64, String, String)>, MetaError> {
+        if target == self.root_ino() {
+            return Ok(vec![(self.root_ino(), String::new(), "/".into())]);
+        }
+        let mut found = Vec::new();
+        let mut pending = vec![(self.root_ino(), String::new())];
+        let mut visited_dirs = BTreeSet::new();
+        while let Some((dir, prefix)) = pending.pop() {
+            if !visited_dirs.insert(dir) {
+                continue;
+            }
+            if visited_dirs.len() > 1_000_000 {
+                return Err(MetaError::Internal(
+                    "workspace reverse path scan exceeded safety limit".into(),
+                ));
+            }
+            for entry in self.readdir(dir).await? {
+                let path = if prefix.is_empty() {
+                    format!("/{}", entry.name)
+                } else {
+                    format!("{prefix}/{}", entry.name)
+                };
+                if entry.ino == target {
+                    found.push((dir, entry.name.clone(), path.clone()));
+                }
+                if entry.kind == FileType::Dir {
+                    pending.push((entry.ino, path));
+                }
+            }
+        }
+        found.sort_by(|left, right| left.2.cmp(&right.2));
+        Ok(found)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn create_entry(
+        &self,
+        parent: i64,
+        name: String,
+        kind: FileType,
+        mode: u32,
+        uid: u32,
+        gid: u32,
+        rdev: u32,
+        symlink_target: Option<Vec<u8>>,
+    ) -> Result<(i64, FileAttr), MetaError> {
+        let _mutation_guard = self.mutation_gate.lock().await;
+        validate_name(&name)?;
+        let mut parent_inode = self
+            .resolve_inode_delta(parent)
+            .await?
+            .ok_or(MetaError::ParentNotFound(parent))?;
+        if file_type_from_code(parent_inode.kind)? != FileType::Dir {
+            return Err(MetaError::NotDirectory(parent));
+        }
+        if self
+            .resolve_dentry_entry(parent, name.as_bytes())
+            .await?
+            .is_some()
+        {
+            return Err(MetaError::AlreadyExists { parent, name });
+        }
+
+        let ino = self
+            .store
+            .allocate_id("inode")
+            .await
+            .map_err(|error| self.mutation_error(error))?;
+        let guard = self.guard().await;
+        let now = now_ns()?;
+        let inode = InodeDelta {
+            layer_id: guard.expected_head_layer_id,
+            ino,
+            state: InodeState::Present,
+            kind: file_type_code(kind),
+            size: symlink_target
+                .as_ref()
+                .map_or(0, |target| target.len() as u64),
+            mode: mode & 0o7777,
+            uid,
+            gid,
+            rdev,
+            nlink: if kind == FileType::Dir { 2 } else { 1 },
+            atime_ns: now,
+            mtime_ns: now,
+            ctime_ns: now,
+            symlink_target,
+            parent_hint: Some(parent),
+            data_version: 1,
+            sequence: 0,
+        };
+        parent_inode.layer_id = guard.expected_head_layer_id;
+        parent_inode.mtime_ns = now;
+        parent_inode.ctime_ns = now;
+        parent_inode.sequence = 0;
+        if kind == FileType::Dir {
+            parent_inode.nlink = parent_inode.nlink.checked_add(1).ok_or_else(|| {
+                MetaError::Internal("parent directory link count overflow".into())
+            })?;
+        }
+        self.store
+            .apply_namespace_mutation(NamespaceMutation {
+                guard,
+                dentries: vec![DentryDelta::put(
+                    inode.layer_id,
+                    parent,
+                    name.into_bytes(),
+                    ino,
+                    inode.kind,
+                    0,
+                )],
+                inodes: vec![inode.clone(), parent_inode],
+            })
+            .await
+            .map_err(workspace_to_meta)?;
+        Ok((ino, file_attr(&inode)?))
+    }
+
+    async fn remove_entry(
+        &self,
+        parent: i64,
+        name: &str,
+        directory: bool,
+    ) -> Result<(), MetaError> {
+        let _mutation_guard = self.mutation_gate.lock().await;
+        validate_name(name)?;
+        let entry = self
+            .resolve_dentry_entry(parent, name.as_bytes())
+            .await?
+            .ok_or(MetaError::NotFound(parent))?;
+        let mut inode = self
+            .resolve_inode_delta(entry.ino)
+            .await?
+            .ok_or(MetaError::NotFound(entry.ino))?;
+        let kind = file_type_from_code(inode.kind)?;
+        if directory && kind != FileType::Dir {
+            return Err(MetaError::NotDirectory(entry.ino));
+        }
+        if !directory && kind == FileType::Dir {
+            return Err(MetaError::Io(std::io::Error::from_raw_os_error(
+                libc::EISDIR,
+            )));
+        }
+        if directory && !self.readdir(entry.ino).await?.is_empty() {
+            return Err(MetaError::DirectoryNotEmpty(entry.ino));
+        }
+        let mut parent_inode = self
+            .resolve_inode_delta(parent)
+            .await?
+            .ok_or(MetaError::ParentNotFound(parent))?;
+        let guard = self.guard().await;
+        let now = now_ns()?;
+        parent_inode.layer_id = guard.expected_head_layer_id;
+        parent_inode.mtime_ns = now;
+        parent_inode.ctime_ns = now;
+        parent_inode.sequence = 0;
+        if directory {
+            parent_inode.nlink = parent_inode.nlink.checked_sub(1).ok_or_else(|| {
+                MetaError::Internal("parent directory link count underflow".into())
+            })?;
+        }
+        inode.layer_id = guard.expected_head_layer_id;
+        inode.ctime_ns = now;
+        inode.sequence = 0;
+        if directory {
+            inode.state = InodeState::Deleted;
+            inode.nlink = 0;
+        } else {
+            inode.nlink = inode
+                .nlink
+                .checked_sub(1)
+                .ok_or_else(|| MetaError::Internal("inode link count underflow".into()))?;
+            if inode.nlink == 0 && !self.open_counts.contains_key(&entry.ino) {
+                inode.state = InodeState::Deleted;
+            }
+        }
+        self.store
+            .apply_namespace_mutation(NamespaceMutation {
+                guard,
+                dentries: vec![DentryDelta::whiteout(
+                    parent_inode.layer_id,
+                    parent,
+                    name.as_bytes().to_vec(),
+                    0,
+                )],
+                inodes: vec![inode, parent_inode],
+            })
+            .await
+            .map_err(workspace_to_meta)?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl<W: WorkspaceStore + 'static> MetaLayer for WorkspaceMetaLayer<W> {
+    fn name(&self) -> &'static str {
+        "workspace-overlay"
+    }
+
+    fn root_ino(&self) -> i64 {
+        self.root_ino.load(Ordering::Acquire)
+    }
+
+    fn chroot(&self, inode: i64) {
+        self.root_ino.store(inode, Ordering::Release);
+    }
+
+    async fn initialize(&self) -> Result<(), MetaError> {
+        self.store
+            .capabilities()
+            .validate_for_v1_mount()
+            .map_err(workspace_to_meta)?;
+        let header = self
+            .store
+            .load_volume_header()
+            .await
+            .map_err(workspace_to_meta)?
+            .ok_or_else(|| MetaError::Internal("workspace volume marker is missing".into()))?;
+        if header.volume_format != "workspace-v1" {
+            return Err(MetaError::NotSupported(header.volume_format));
+        }
+        self.chain().await?;
+        Ok(())
+    }
+
+    async fn stat_fs(&self) -> Result<StatFsSnapshot, MetaError> {
+        // A correct effective-view count would require enumerating both layers
+        // while blocking mutations. That O(N) scan is forbidden on the hot
+        // `statfs` path and becomes unbounded for large workspaces. Report the
+        // limitation explicitly until usage counters are persisted and updated
+        // atomically with workspace mutations.
+        Err(MetaError::NotSupported(
+            "workspace statfs requires persistent usage counters".into(),
+        ))
+    }
+
+    async fn stat(&self, ino: i64) -> Result<Option<FileAttr>, MetaError> {
+        self.resolve_inode_delta(ino)
+            .await?
+            .as_ref()
+            .map(file_attr)
+            .transpose()
+    }
+
+    async fn stat_fresh(&self, ino: i64) -> Result<Option<FileAttr>, MetaError> {
+        self.stat(ino).await
+    }
+
+    async fn record_open(
+        &self,
+        ino: i64,
+        _attr: FileAttr,
+        _read: bool,
+        _write: bool,
+        _append: bool,
+    ) -> Result<(), MetaError> {
+        let _mutation_guard = self.mutation_gate.lock().await;
+        if self.resolve_inode_delta(ino).await?.is_none() {
+            return Err(MetaError::NotFound(ino));
+        }
+        self.open_counts
+            .entry(ino)
+            .and_modify(|count| *count = count.saturating_add(1))
+            .or_insert(1);
+        Ok(())
+    }
+
+    async fn record_close(&self, ino: i64) -> Result<(), MetaError> {
+        let _mutation_guard = self.mutation_gate.lock().await;
+        let remove = if let Some(mut count) = self.open_counts.get_mut(&ino) {
+            *count = count.saturating_sub(1);
+            *count == 0
+        } else {
+            false
+        };
+        if remove {
+            self.open_counts.remove(&ino);
+            if let Some(mut inode) = self.resolve_inode_delta(ino).await?
+                && inode.nlink == 0
+            {
+                inode.state = InodeState::Deleted;
+                inode.ctime_ns = now_ns()?;
+                self.mutate_inode(inode).await?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn lookup(&self, parent: i64, name: &str) -> Result<Option<i64>, MetaError> {
+        validate_name(name)?;
+        Ok(self
+            .resolve_dentry_entry(parent, name.as_bytes())
+            .await?
+            .map(|entry| entry.ino))
+    }
+
+    async fn lookup_path(&self, path: &str) -> Result<Option<(i64, FileType)>, MetaError> {
+        if !path.starts_with('/') {
+            return Err(MetaError::InvalidPath(path.into()));
+        }
+        let mut ino = self.root_ino();
+        if path == "/" {
+            let attr = self.stat(ino).await?.ok_or(MetaError::NotFound(ino))?;
+            return Ok(Some((ino, attr.kind)));
+        }
+        for component in path.split('/').filter(|part| !part.is_empty()) {
+            ino = match self.lookup(ino, component).await? {
+                Some(ino) => ino,
+                None => return Ok(None),
+            };
+        }
+        let attr = self.stat(ino).await?.ok_or(MetaError::NotFound(ino))?;
+        Ok(Some((ino, attr.kind)))
+    }
+
+    async fn readdir(&self, ino: i64) -> Result<Vec<DirEntry>, MetaError> {
+        let attr = self.stat(ino).await?.ok_or(MetaError::NotFound(ino))?;
+        if attr.kind != FileType::Dir {
+            return Err(MetaError::NotDirectory(ino));
+        }
+        let chain = self.chain().await?;
+        let rows = self
+            .store
+            .get_dentry_deltas(DentryQuery {
+                layer_ids: chain.iter().map(|layer| layer.layer_id).collect(),
+                parent_ino: ino,
+                name: None,
+            })
+            .await
+            .map_err(workspace_to_meta)?;
+        resolve_directory(&chain, &rows, ino)
+            .map_err(workspace_to_meta)?
+            .into_iter()
+            .map(|entry| {
+                Ok(DirEntry {
+                    name: String::from_utf8(entry.name).map_err(|_| MetaError::InvalidFilename)?,
+                    ino: entry.ino,
+                    kind: file_type_from_code(entry.entry_type)?,
+                })
+            })
+            .collect()
+    }
+
+    async fn opendir(&self, ino: i64) -> Result<DirHandle, MetaError> {
+        let attr = self.stat(ino).await?.ok_or(MetaError::NotFound(ino))?;
+        if attr.kind != FileType::Dir {
+            return Err(MetaError::NotDirectory(ino));
+        }
+        Ok(DirHandle::new(ino, self.readdir(ino).await?).with_attr(attr))
+    }
+
+    async fn mkdir(&self, parent: i64, name: String) -> Result<i64, MetaError> {
+        self.create_entry(parent, name, FileType::Dir, 0o755, 0, 0, 0, None)
+            .await
+            .map(|result| result.0)
+    }
+
+    async fn rmdir(&self, parent: i64, name: &str) -> Result<(), MetaError> {
+        self.remove_entry(parent, name, true).await
+    }
+
+    async fn create_file(&self, parent: i64, name: String) -> Result<i64, MetaError> {
+        self.create_entry(parent, name, FileType::File, 0o644, 0, 0, 0, None)
+            .await
+            .map(|result| result.0)
+    }
+
+    async fn create_file_with_attr(
+        &self,
+        parent: i64,
+        name: String,
+    ) -> Result<CreateEntryResult, MetaError> {
+        let (ino, attr) = self
+            .create_entry(parent, name, FileType::File, 0o644, 0, 0, 0, None)
+            .await?;
+        Ok(CreateEntryResult {
+            ino,
+            attr: Some(attr),
+        })
+    }
+
+    async fn create_node(
+        &self,
+        parent: i64,
+        name: String,
+        kind: FileType,
+        mode: u32,
+        uid: u32,
+        gid: u32,
+        rdev: u32,
+    ) -> Result<i64, MetaError> {
+        self.create_entry(parent, name, kind, mode, uid, gid, rdev, None)
+            .await
+            .map(|result| result.0)
+    }
+
+    async fn create_node_with_attr(
+        &self,
+        parent: i64,
+        name: String,
+        kind: FileType,
+        mode: u32,
+        uid: u32,
+        gid: u32,
+        rdev: u32,
+    ) -> Result<CreateEntryResult, MetaError> {
+        let (ino, attr) = self
+            .create_entry(parent, name, kind, mode, uid, gid, rdev, None)
+            .await?;
+        Ok(CreateEntryResult {
+            ino,
+            attr: Some(attr),
+        })
+    }
+
+    async fn link(&self, ino: i64, parent: i64, name: &str) -> Result<FileAttr, MetaError> {
+        let _mutation_guard = self.mutation_gate.lock().await;
+        validate_name(name)?;
+        if self.lookup(parent, name).await?.is_some() {
+            return Err(MetaError::AlreadyExists {
+                parent,
+                name: name.into(),
+            });
+        }
+        let mut inode = self
+            .resolve_inode_delta(ino)
+            .await?
+            .ok_or(MetaError::NotFound(ino))?;
+        if file_type_from_code(inode.kind)? == FileType::Dir {
+            return Err(MetaError::NotSupported("hard links to directories".into()));
+        }
+        let mut parent_inode = self
+            .resolve_inode_delta(parent)
+            .await?
+            .ok_or(MetaError::ParentNotFound(parent))?;
+        if file_type_from_code(parent_inode.kind)? != FileType::Dir {
+            return Err(MetaError::NotDirectory(parent));
+        }
+        let guard = self.guard().await;
+        let now = now_ns()?;
+        inode.layer_id = guard.expected_head_layer_id;
+        inode.nlink = inode
+            .nlink
+            .checked_add(1)
+            .ok_or_else(|| MetaError::Internal("inode link count overflow".into()))?;
+        inode.ctime_ns = now;
+        inode.sequence = 0;
+        parent_inode.layer_id = guard.expected_head_layer_id;
+        parent_inode.mtime_ns = now;
+        parent_inode.ctime_ns = now;
+        parent_inode.sequence = 0;
+        self.store
+            .apply_namespace_mutation(NamespaceMutation {
+                guard,
+                dentries: vec![DentryDelta::put(
+                    inode.layer_id,
+                    parent,
+                    name.as_bytes().to_vec(),
+                    ino,
+                    inode.kind,
+                    0,
+                )],
+                inodes: vec![inode.clone(), parent_inode],
+            })
+            .await
+            .map_err(workspace_to_meta)?;
+        file_attr(&inode)
+    }
+
+    async fn symlink(
+        &self,
+        parent: i64,
+        name: &str,
+        target: &str,
+    ) -> Result<(i64, FileAttr), MetaError> {
+        self.create_entry(
+            parent,
+            name.into(),
+            FileType::Symlink,
+            0o777,
+            0,
+            0,
+            0,
+            Some(target.as_bytes().to_vec()),
+        )
+        .await
+    }
+
+    async fn unlink(&self, parent: i64, name: &str) -> Result<(), MetaError> {
+        self.remove_entry(parent, name, false).await
+    }
+
+    async fn rename(
+        &self,
+        old_parent: i64,
+        old_name: &str,
+        new_parent: i64,
+        new_name: String,
+    ) -> Result<(), MetaError> {
+        let _mutation_guard = self.mutation_gate.lock().await;
+        validate_name(old_name)?;
+        validate_name(&new_name)?;
+        if old_parent == new_parent && old_name == new_name {
+            return Ok(());
+        }
+        let source = self
+            .resolve_dentry_entry(old_parent, old_name.as_bytes())
+            .await?
+            .ok_or(MetaError::NotFound(old_parent))?;
+        let mut source_inode = self
+            .resolve_inode_delta(source.ino)
+            .await?
+            .ok_or(MetaError::NotFound(source.ino))?;
+        let source_kind = file_type_from_code(source_inode.kind)?;
+        let destination = self
+            .resolve_dentry_entry(new_parent, new_name.as_bytes())
+            .await?;
+
+        if let Some(destination) = destination.as_ref()
+            && destination.ino == source.ino
+        {
+            // POSIX rename onto another hard link to the same inode removes
+            // only the old name.
+            source_inode.nlink = source_inode
+                .nlink
+                .checked_sub(1)
+                .ok_or_else(|| MetaError::Internal("inode link count underflow".into()))?;
+            source_inode.ctime_ns = now_ns()?;
+            let guard = self.guard().await;
+            source_inode.layer_id = guard.expected_head_layer_id;
+            source_inode.sequence = 0;
+            self.store
+                .apply_namespace_mutation(NamespaceMutation {
+                    guard,
+                    dentries: vec![DentryDelta::whiteout(
+                        source_inode.layer_id,
+                        old_parent,
+                        old_name.as_bytes().to_vec(),
+                        0,
+                    )],
+                    inodes: vec![source_inode],
+                })
+                .await
+                .map_err(workspace_to_meta)?;
+            return Ok(());
+        }
+
+        let mut destination_inode = match destination.as_ref() {
+            Some(entry) => Some(
+                self.resolve_inode_delta(entry.ino)
+                    .await?
+                    .ok_or(MetaError::NotFound(entry.ino))?,
+            ),
+            None => None,
+        };
+        if let Some(inode) = destination_inode.as_ref() {
+            let destination_kind = file_type_from_code(inode.kind)?;
+            match (
+                source_kind == FileType::Dir,
+                destination_kind == FileType::Dir,
+            ) {
+                (true, false) => return Err(MetaError::NotDirectory(inode.ino)),
+                (false, true) => {
+                    return Err(MetaError::Io(std::io::Error::from_raw_os_error(
+                        libc::EISDIR,
+                    )));
+                }
+                (true, true) if !self.readdir(inode.ino).await?.is_empty() => {
+                    return Err(MetaError::DirectoryNotEmpty(inode.ino));
+                }
+                _ => {}
+            }
+        }
+
+        let mut old_parent_inode = self
+            .resolve_inode_delta(old_parent)
+            .await?
+            .ok_or(MetaError::ParentNotFound(old_parent))?;
+        let mut new_parent_inode = if old_parent == new_parent {
+            old_parent_inode.clone()
+        } else {
+            self.resolve_inode_delta(new_parent)
+                .await?
+                .ok_or(MetaError::ParentNotFound(new_parent))?
+        };
+        if file_type_from_code(new_parent_inode.kind)? != FileType::Dir {
+            return Err(MetaError::NotDirectory(new_parent));
+        }
+        let guard = self.guard().await;
+        let now = now_ns()?;
+        let head = guard.expected_head_layer_id;
+        old_parent_inode.layer_id = head;
+        old_parent_inode.mtime_ns = now;
+        old_parent_inode.ctime_ns = now;
+        old_parent_inode.sequence = 0;
+        new_parent_inode.layer_id = head;
+        new_parent_inode.mtime_ns = now;
+        new_parent_inode.ctime_ns = now;
+        new_parent_inode.sequence = 0;
+
+        if source_kind == FileType::Dir && old_parent != new_parent {
+            old_parent_inode.nlink = old_parent_inode
+                .nlink
+                .checked_sub(1)
+                .ok_or_else(|| MetaError::Internal("directory nlink underflow".into()))?;
+            new_parent_inode.nlink = new_parent_inode
+                .nlink
+                .checked_add(1)
+                .ok_or_else(|| MetaError::Internal("directory nlink overflow".into()))?;
+            source_inode.parent_hint = Some(new_parent);
+        }
+        if let Some(inode) = destination_inode.as_mut() {
+            if file_type_from_code(inode.kind)? == FileType::Dir {
+                new_parent_inode.nlink = new_parent_inode
+                    .nlink
+                    .checked_sub(1)
+                    .ok_or_else(|| MetaError::Internal("directory nlink underflow".into()))?;
+                inode.nlink = 0;
+                inode.state = InodeState::Deleted;
+            } else {
+                inode.nlink = inode
+                    .nlink
+                    .checked_sub(1)
+                    .ok_or_else(|| MetaError::Internal("inode nlink underflow".into()))?;
+                if inode.nlink == 0 && !self.open_counts.contains_key(&inode.ino) {
+                    inode.state = InodeState::Deleted;
+                }
+            }
+            inode.layer_id = head;
+            inode.ctime_ns = now;
+            inode.sequence = 0;
+        }
+        source_inode.layer_id = head;
+        source_inode.ctime_ns = now;
+        source_inode.sequence = 0;
+
+        let mut inodes = vec![source_inode];
+        if old_parent == new_parent {
+            inodes.push(new_parent_inode);
+        } else {
+            inodes.push(old_parent_inode);
+            inodes.push(new_parent_inode);
+        }
+        if let Some(inode) = destination_inode {
+            inodes.push(inode);
+        }
+        self.store
+            .apply_namespace_mutation(NamespaceMutation {
+                guard,
+                dentries: vec![
+                    DentryDelta::whiteout(head, old_parent, old_name.as_bytes().to_vec(), 0),
+                    DentryDelta::put(
+                        head,
+                        new_parent,
+                        new_name.into_bytes(),
+                        source.ino,
+                        source.entry_type,
+                        0,
+                    ),
+                ],
+                inodes,
+            })
+            .await
+            .map_err(workspace_to_meta)?;
+        Ok(())
+    }
+
+    async fn rename_exchange(
+        &self,
+        old_parent: i64,
+        old_name: &str,
+        new_parent: i64,
+        new_name: &str,
+    ) -> Result<(), MetaError> {
+        let _mutation_guard = self.mutation_gate.lock().await;
+        validate_name(old_name)?;
+        validate_name(new_name)?;
+        let left = self
+            .resolve_dentry_entry(old_parent, old_name.as_bytes())
+            .await?
+            .ok_or(MetaError::NotFound(old_parent))?;
+        let right = self
+            .resolve_dentry_entry(new_parent, new_name.as_bytes())
+            .await?
+            .ok_or(MetaError::NotFound(new_parent))?;
+        if old_parent == new_parent && old_name == new_name {
+            return Ok(());
+        }
+        let guard = self.guard().await;
+        let head = guard.expected_head_layer_id;
+        let mut inodes = Vec::new();
+        if old_parent != new_parent {
+            let mut left_inode = self
+                .resolve_inode_delta(left.ino)
+                .await?
+                .ok_or(MetaError::NotFound(left.ino))?;
+            let mut right_inode = self
+                .resolve_inode_delta(right.ino)
+                .await?
+                .ok_or(MetaError::NotFound(right.ino))?;
+            if file_type_from_code(left_inode.kind)? == FileType::Dir {
+                left_inode.parent_hint = Some(new_parent);
+            }
+            if file_type_from_code(right_inode.kind)? == FileType::Dir {
+                right_inode.parent_hint = Some(old_parent);
+            }
+            left_inode.layer_id = head;
+            right_inode.layer_id = head;
+            left_inode.sequence = 0;
+            right_inode.sequence = 0;
+            inodes.extend([left_inode, right_inode]);
+        }
+        self.store
+            .apply_namespace_mutation(NamespaceMutation {
+                guard,
+                dentries: vec![
+                    DentryDelta::put(
+                        head,
+                        old_parent,
+                        old_name.as_bytes().to_vec(),
+                        right.ino,
+                        right.entry_type,
+                        0,
+                    ),
+                    DentryDelta::put(
+                        head,
+                        new_parent,
+                        new_name.as_bytes().to_vec(),
+                        left.ino,
+                        left.entry_type,
+                        0,
+                    ),
+                ],
+                inodes,
+            })
+            .await
+            .map_err(workspace_to_meta)?;
+        Ok(())
+    }
+
+    async fn set_file_size(&self, ino: i64, size: u64) -> Result<(), MetaError> {
+        self.truncate(ino, size, self.chunk_size).await
+    }
+
+    async fn extend_file_size(&self, ino: i64, size: u64) -> Result<(), MetaError> {
+        let inode = self
+            .resolve_inode_delta(ino)
+            .await?
+            .ok_or(MetaError::NotFound(ino))?;
+        if size > inode.size {
+            self.set_file_size(ino, size).await?;
+        }
+        Ok(())
+    }
+
+    async fn truncate(&self, ino: i64, size: u64, chunk_size: u64) -> Result<(), MetaError> {
+        let _mutation_guard = self.mutation_gate.lock().await;
+        if chunk_size != self.chunk_size {
+            return Err(MetaError::Internal(format!(
+                "workspace chunk-size mismatch: mounted {}, requested {chunk_size}",
+                self.chunk_size
+            )));
+        }
+        let mut inode = self
+            .resolve_inode_delta(ino)
+            .await?
+            .ok_or(MetaError::NotFound(ino))?;
+        if file_type_from_code(inode.kind)? != FileType::File {
+            return Err(MetaError::NotSupported(
+                "truncate requires a regular file".into(),
+            ));
+        }
+        if inode.size == size {
+            return Ok(());
+        }
+        let extents = if size < inode.size {
+            self.hole_extents(inode.layer_id, ino, size, inode.size)?
+        } else {
+            Vec::new()
+        };
+        inode.size = size;
+        inode.mtime_ns = now_ns()?;
+        inode.ctime_ns = inode.mtime_ns;
+        inode.data_version = inode.data_version.saturating_add(1);
+        self.mutate_data(inode, extents).await?;
+        Ok(())
+    }
+
+    async fn get_names(&self, ino: i64) -> Result<Vec<(Option<i64>, String)>, MetaError> {
+        Ok(self
+            .reverse_entries(ino)
+            .await?
+            .into_iter()
+            .map(|(parent, name, _)| (Some(parent), name))
+            .collect())
+    }
+
+    async fn get_dentries(&self, ino: i64) -> Result<Vec<(i64, String)>, MetaError> {
+        Ok(self
+            .reverse_entries(ino)
+            .await?
+            .into_iter()
+            .map(|(parent, name, _)| (parent, name))
+            .collect())
+    }
+
+    async fn get_dir_parent(&self, dir_ino: i64) -> Result<Option<i64>, MetaError> {
+        Ok(self
+            .resolve_inode_delta(dir_ino)
+            .await?
+            .and_then(|inode| inode.parent_hint))
+    }
+
+    async fn get_paths(&self, ino: i64) -> Result<Vec<String>, MetaError> {
+        Ok(self
+            .reverse_entries(ino)
+            .await?
+            .into_iter()
+            .map(|(_, _, path)| path)
+            .collect())
+    }
+
+    async fn read_symlink(&self, ino: i64) -> Result<String, MetaError> {
+        let inode = self
+            .resolve_inode_delta(ino)
+            .await?
+            .ok_or(MetaError::NotFound(ino))?;
+        if file_type_from_code(inode.kind)? != FileType::Symlink {
+            return Err(MetaError::NotSupported("inode is not a symlink".into()));
+        }
+        String::from_utf8(
+            inode
+                .symlink_target
+                .ok_or_else(|| MetaError::Internal("symlink inode is missing its target".into()))?,
+        )
+        .map_err(|_| MetaError::InvalidPath("symlink target is not UTF-8".into()))
+    }
+
+    async fn set_attr(
+        &self,
+        ino: i64,
+        req: &SetAttrRequest,
+        flags: SetAttrFlags,
+    ) -> Result<FileAttr, MetaError> {
+        let _mutation_guard = self.mutation_gate.lock().await;
+        let mut inode = self
+            .resolve_inode_delta(ino)
+            .await?
+            .ok_or(MetaError::NotFound(ino))?;
+        let old_size = inode.size;
+        if let Some(mode) = req.mode {
+            inode.mode = mode & 0o7777;
+        }
+        if let Some(uid) = req.uid {
+            inode.uid = uid;
+        }
+        if let Some(gid) = req.gid {
+            inode.gid = gid;
+        }
+        if let Some(size) = req.size {
+            inode.size = size;
+            if size != old_size {
+                inode.data_version = inode.data_version.saturating_add(1);
+            }
+        }
+        if let Some(atime) = req.atime {
+            inode.atime_ns = atime;
+        }
+        if let Some(mtime) = req.mtime {
+            inode.mtime_ns = mtime;
+        }
+        if let Some(ctime) = req.ctime {
+            inode.ctime_ns = ctime;
+        } else {
+            inode.ctime_ns = now_ns()?;
+        }
+        if flags.contains(SetAttrFlags::CLEAR_SUID) {
+            inode.mode &= !0o4000;
+        }
+        if flags.contains(SetAttrFlags::CLEAR_SGID) {
+            inode.mode &= !0o2000;
+        }
+        let inode = if inode.size != old_size {
+            let extents = if inode.size < old_size {
+                self.hole_extents(inode.layer_id, ino, inode.size, old_size)?
+            } else {
+                Vec::new()
+            };
+            self.mutate_data(inode, extents).await?
+        } else {
+            self.mutate_inode(inode).await?
+        };
+        file_attr(&inode)
+    }
+
+    async fn open(&self, ino: i64, flags: OpenFlags) -> Result<FileAttr, MetaError> {
+        let _mutation_guard = self.mutation_gate.lock().await;
+        let mut inode = self
+            .resolve_inode_delta(ino)
+            .await?
+            .ok_or(MetaError::NotFound(ino))?;
+        let kind = file_type_from_code(inode.kind)?;
+        if kind == FileType::Symlink {
+            return Err(MetaError::NotSupported(
+                "opening a workspace symlink is not supported".into(),
+            ));
+        }
+        if flags.contains(OpenFlags::TRUNC) {
+            if kind != FileType::File {
+                return Err(MetaError::NotSupported(
+                    "truncate-on-open requires a regular file".into(),
+                ));
+            }
+            let old_size = inode.size;
+            inode.size = 0;
+            inode.data_version = inode.data_version.saturating_add(1);
+            inode.mtime_ns = now_ns()?;
+            inode.atime_ns = now_ns()?;
+            let extents = self.hole_extents(inode.layer_id, ino, 0, old_size)?;
+            let inode = self.mutate_data(inode, extents).await?;
+            return file_attr(&inode);
+        }
+        inode.atime_ns = now_ns()?;
+        let inode = self.mutate_inode(inode).await?;
+        file_attr(&inode)
+    }
+
+    async fn close(&self, ino: i64) -> Result<(), MetaError> {
+        if self.resolve_inode_delta(ino).await?.is_some() {
+            Ok(())
+        } else {
+            Err(MetaError::NotFound(ino))
+        }
+    }
+
+    async fn write(
+        &self,
+        ino: i64,
+        chunk_id: u64,
+        slice: SliceDesc,
+        new_size: u64,
+    ) -> Result<(), MetaError> {
+        let _mutation_guard = self.mutation_gate.lock().await;
+        let (chunk_ino, chunk_index) = crate::vfs::extract_ino_and_chunk_index(chunk_id);
+        if chunk_ino != ino || slice.chunk_id != chunk_id || slice.length == 0 {
+            return Err(MetaError::InvalidPath(
+                "slice does not match the workspace inode/chunk".into(),
+            ));
+        }
+        let end = slice
+            .offset
+            .checked_add(slice.length)
+            .ok_or_else(|| MetaError::InvalidPath("slice range overflows".into()))?;
+        if end > self.chunk_size {
+            return Err(MetaError::InvalidPath(
+                "slice range exceeds workspace chunk size".into(),
+            ));
+        }
+        let mut inode = self
+            .resolve_inode_delta(ino)
+            .await?
+            .ok_or(MetaError::NotFound(ino))?;
+        if file_type_from_code(inode.kind)? != FileType::File {
+            return Err(MetaError::NotSupported(
+                "workspace data writes require a regular file".into(),
+            ));
+        }
+        let chunk_start = chunk_index
+            .checked_mul(self.chunk_size)
+            .ok_or_else(|| MetaError::InvalidPath("file size overflows".into()))?;
+        let slice_start = chunk_start
+            .checked_add(slice.offset)
+            .ok_or_else(|| MetaError::InvalidPath("slice start overflows".into()))?;
+        if new_size <= slice_start {
+            return Err(MetaError::InvalidPath(format!(
+                "new size {new_size} does not cover slice start {slice_start}"
+            )));
+        }
+        // The writer may persist an aligned physical slice that extends past the
+        // logical EOF (for example a 64 KiB cached sub-block produced by a 4 KiB
+        // mmap write).  Only publish the visible prefix.  Keeping the aligned tail
+        // out of the extent graph also guarantees that a later truncate-extend
+        // observes zeroes rather than resurrecting bytes beyond the old EOF.
+        let visible_length = slice.length.min(new_size - slice_start);
+        let now = now_ns()?;
+        inode.size = inode.size.max(new_size);
+        inode.mtime_ns = now;
+        inode.ctime_ns = now;
+        inode.data_version = inode.data_version.saturating_add(1);
+        let extent = DataExtentDelta::data(
+            inode.layer_id,
+            ino,
+            chunk_index,
+            slice.offset,
+            visible_length,
+            slice.slice_id,
+            0,
+            0,
+        );
+        self.mutate_data(inode, vec![extent]).await?;
+        Ok(())
+    }
+
+    async fn get_deleted_files(&self) -> Result<Vec<i64>, MetaError> {
+        Ok(Vec::new())
+    }
+
+    async fn remove_file_metadata(&self, _ino: i64) -> Result<(), MetaError> {
+        Err(MetaError::NotSupported(
+            "workspace inode garbage collection is lifecycle-managed".into(),
+        ))
+    }
+
+    async fn get_slices(&self, _chunk_id: u64) -> Result<Vec<SliceDesc>, MetaError> {
+        Err(MetaError::NotSupported(
+            "workspace extents must be consumed through a neutral read plan".into(),
+        ))
+    }
+
+    async fn append_slice(&self, chunk_id: u64, slice: SliceDesc) -> Result<(), MetaError> {
+        let (ino, chunk_index) = crate::vfs::extract_ino_and_chunk_index(chunk_id);
+        let new_size = chunk_index
+            .checked_mul(self.chunk_size)
+            .and_then(|start| start.checked_add(slice.offset))
+            .and_then(|start| start.checked_add(slice.length))
+            .ok_or_else(|| MetaError::InvalidPath("slice file size overflows".into()))?;
+        self.write(ino, chunk_id, slice, new_size).await
+    }
+
+    async fn next_id(&self, key: &str) -> Result<i64, MetaError> {
+        let allocator = match key {
+            crate::meta::INODE_ID_KEY => "inode",
+            crate::meta::SLICE_ID_KEY => "slice",
+            _ => {
+                return Err(MetaError::NotSupported(format!(
+                    "workspace allocator does not support key {key}"
+                )));
+            }
+        };
+        self.store
+            .allocate_id(allocator)
+            .await
+            .map_err(workspace_to_meta)
+    }
+
+    async fn start_session(&self, _session_info: SessionInfo) -> Result<(), MetaError> {
+        Ok(())
+    }
+
+    async fn shutdown_session(&self) -> Result<(), MetaError> {
+        Ok(())
+    }
+
+    async fn get_plock(
+        &self,
+        inode: i64,
+        query: &FileLockQuery,
+    ) -> Result<FileLockInfo, MetaError> {
+        let locks = self.locks.lock().await;
+        for ((candidate_inode, owner), records) in &locks.plocks {
+            if *candidate_inode == inode && *owner != query.owner {
+                for record in records {
+                    if record.lock_range.overlaps(&query.range)
+                        && (record.lock_type == FileLockType::Write
+                            || query.lock_type == FileLockType::Write)
+                    {
+                        return Ok(FileLockInfo {
+                            lock_type: record.lock_type,
+                            range: record.lock_range,
+                            pid: record.pid,
+                        });
+                    }
+                }
+            }
+        }
+        Ok(FileLockInfo {
+            lock_type: FileLockType::UnLock,
+            range: FileLockRange { start: 0, end: 0 },
+            pid: 0,
+        })
+    }
+
+    async fn set_plock(
+        &self,
+        inode: i64,
+        owner: i64,
+        block: bool,
+        lock_type: FileLockType,
+        range: FileLockRange,
+        pid: u32,
+    ) -> Result<(), MetaError> {
+        if range.start >= range.end {
+            return Err(MetaError::InvalidPath("invalid POSIX lock range".into()));
+        }
+        loop {
+            let mut locks = self.locks.lock().await;
+            let conflict = lock_type != FileLockType::UnLock
+                && locks
+                    .plocks
+                    .iter()
+                    .any(|((candidate_inode, candidate_owner), records)| {
+                        *candidate_inode == inode
+                            && *candidate_owner != owner
+                            && PlockRecord::check_conflict(&lock_type, &range, records)
+                    });
+            if !conflict {
+                let key = (inode, owner);
+                let current = locks.plocks.remove(&key).unwrap_or_default();
+                let updated = PlockRecord::update_locks(
+                    current,
+                    PlockRecord::new(lock_type, pid, range.start, range.end),
+                );
+                if !updated.is_empty() {
+                    locks.plocks.insert(key, updated);
+                }
+                return Ok(());
+            }
+            drop(locks);
+            if !block {
+                return Err(MetaError::LockConflict {
+                    inode,
+                    owner,
+                    range,
+                });
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+        }
+    }
+
+    async fn get_flock(&self, inode: i64, owner: i64) -> Result<FileLockType, MetaError> {
+        Ok(self
+            .locks
+            .lock()
+            .await
+            .flocks
+            .get(&(inode, owner))
+            .copied()
+            .unwrap_or(FileLockType::UnLock))
+    }
+
+    async fn set_flock(
+        &self,
+        inode: i64,
+        owner: i64,
+        block: bool,
+        lock_type: FileLockType,
+    ) -> Result<(), MetaError> {
+        loop {
+            let mut locks = self.locks.lock().await;
+            let conflict = lock_type != FileLockType::UnLock
+                && locks.flocks.iter().any(
+                    |((candidate_inode, candidate_owner), candidate_type)| {
+                        *candidate_inode == inode
+                            && *candidate_owner != owner
+                            && (*candidate_type == FileLockType::Write
+                                || lock_type == FileLockType::Write)
+                    },
+                );
+            if !conflict {
+                if lock_type == FileLockType::UnLock {
+                    locks.flocks.remove(&(inode, owner));
+                } else {
+                    locks.flocks.insert((inode, owner), lock_type);
+                }
+                return Ok(());
+            }
+            drop(locks);
+            if !block {
+                return Err(MetaError::LockConflict {
+                    inode,
+                    owner,
+                    range: FileLockRange {
+                        start: 0,
+                        end: u64::MAX,
+                    },
+                });
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+        }
+    }
+
+    async fn set_xattr(
+        &self,
+        inode: i64,
+        name: &str,
+        value: &[u8],
+        flags: u32,
+    ) -> Result<(), MetaError> {
+        let _mutation_guard = self.mutation_gate.lock().await;
+        validate_xattr_name(name)?;
+        let mut inode_delta = self
+            .resolve_inode_delta(inode)
+            .await?
+            .ok_or(MetaError::NotFound(inode))?;
+        let existing = self.get_xattr(inode, name).await?;
+        let create_only = flags & libc::XATTR_CREATE as u32 != 0;
+        let replace_only = flags & libc::XATTR_REPLACE as u32 != 0;
+        if create_only && replace_only {
+            return Err(MetaError::InvalidPath(
+                "XATTR_CREATE and XATTR_REPLACE are mutually exclusive".into(),
+            ));
+        }
+        if create_only && existing.is_some() {
+            return Err(MetaError::AlreadyExists {
+                parent: inode,
+                name: name.into(),
+            });
+        }
+        if replace_only && existing.is_none() {
+            return Err(MetaError::NotFound(inode));
+        }
+        let guard = self.guard().await;
+        inode_delta.layer_id = guard.expected_head_layer_id;
+        inode_delta.sequence = 0;
+        inode_delta.ctime_ns = now_ns()?;
+        self.store
+            .apply_xattr_mutation(XattrMutation {
+                xattr: XattrDelta {
+                    layer_id: guard.expected_head_layer_id,
+                    ino: inode,
+                    name: name.as_bytes().to_vec(),
+                    op: ValueOp::Put,
+                    value: Some(value.to_vec()),
+                    sequence: 0,
+                },
+                inode: inode_delta,
+                guard,
+            })
+            .await
+            .map_err(workspace_to_meta)
+    }
+
+    async fn get_xattr(&self, inode: i64, name: &str) -> Result<Option<Vec<u8>>, MetaError> {
+        validate_xattr_name(name)?;
+        if self.resolve_inode_delta(inode).await?.is_none() {
+            return Err(MetaError::NotFound(inode));
+        }
+        let chain = self.chain().await?;
+        let rows = self
+            .store
+            .get_xattr_deltas(XattrQuery {
+                layer_ids: chain.iter().map(|layer| layer.layer_id).collect(),
+                ino: inode,
+                name: Some(name.as_bytes().to_vec()),
+            })
+            .await
+            .map_err(workspace_to_meta)?;
+        Ok(resolve_xattr(&chain, &rows, inode, name.as_bytes())
+            .map_err(workspace_to_meta)?
+            .map(|resolved| resolved.value))
+    }
+
+    async fn list_xattr(&self, inode: i64) -> Result<Vec<String>, MetaError> {
+        if self.resolve_inode_delta(inode).await?.is_none() {
+            return Err(MetaError::NotFound(inode));
+        }
+        let chain = self.chain().await?;
+        let rows = self
+            .store
+            .get_xattr_deltas(XattrQuery {
+                layer_ids: chain.iter().map(|layer| layer.layer_id).collect(),
+                ino: inode,
+                name: None,
+            })
+            .await
+            .map_err(workspace_to_meta)?;
+        let mut candidates = BTreeSet::new();
+        for row in &rows {
+            candidates.insert(row.name.clone());
+        }
+        let mut names = Vec::new();
+        for name in candidates {
+            if resolve_xattr(&chain, &rows, inode, &name)
+                .map_err(workspace_to_meta)?
+                .is_some()
+            {
+                names.push(
+                    String::from_utf8(name)
+                        .map_err(|_| MetaError::Internal("non-UTF-8 xattr name".into()))?,
+                );
+            }
+        }
+        Ok(names)
+    }
+
+    async fn remove_xattr(&self, inode: i64, name: &str) -> Result<(), MetaError> {
+        let _mutation_guard = self.mutation_gate.lock().await;
+        validate_xattr_name(name)?;
+        if self.get_xattr(inode, name).await?.is_none() {
+            return Err(MetaError::NotFound(inode));
+        }
+        let mut inode_delta = self
+            .resolve_inode_delta(inode)
+            .await?
+            .ok_or(MetaError::NotFound(inode))?;
+        let guard = self.guard().await;
+        inode_delta.layer_id = guard.expected_head_layer_id;
+        inode_delta.sequence = 0;
+        inode_delta.ctime_ns = now_ns()?;
+        self.store
+            .apply_xattr_mutation(XattrMutation {
+                xattr: XattrDelta {
+                    layer_id: guard.expected_head_layer_id,
+                    ino: inode,
+                    name: name.as_bytes().to_vec(),
+                    op: ValueOp::Whiteout,
+                    value: None,
+                    sequence: 0,
+                },
+                inode: inode_delta,
+                guard,
+            })
+            .await
+            .map_err(workspace_to_meta)
+    }
+
+    async fn set_acl(&self, inode: i64, rule: AclRule) -> Result<(), MetaError> {
+        let _mutation_guard = self.mutation_gate.lock().await;
+        if self.resolve_inode_delta(inode).await?.is_none() {
+            return Err(MetaError::NotFound(inode));
+        }
+        let guard = self.guard().await;
+        self.store
+            .apply_acl_mutation(AclMutation {
+                acl: AclDelta {
+                    layer_id: guard.expected_head_layer_id,
+                    ino: inode,
+                    acl_type: rule.acl_type,
+                    acl_id: i64::from(rule.qualifier),
+                    op: ValueOp::Put,
+                    value: Some(rule.permissions.to_be_bytes().to_vec()),
+                    sequence: 0,
+                },
+                guard,
+            })
+            .await
+            .map_err(workspace_to_meta)
+    }
+
+    async fn get_acl(
+        &self,
+        inode: i64,
+        acl_type: u8,
+        acl_id: u32,
+    ) -> Result<Option<AclRule>, MetaError> {
+        if self.resolve_inode_delta(inode).await?.is_none() {
+            return Err(MetaError::NotFound(inode));
+        }
+        let chain = self.chain().await?;
+        let rows = self
+            .store
+            .get_acl_deltas(AclQuery {
+                layer_ids: chain.iter().map(|layer| layer.layer_id).collect(),
+                ino: inode,
+                acl_type: Some(acl_type),
+                acl_id: Some(i64::from(acl_id)),
+            })
+            .await
+            .map_err(workspace_to_meta)?;
+        let Some(resolved) = resolve_acl(&chain, &rows, inode, acl_type, i64::from(acl_id))
+            .map_err(workspace_to_meta)?
+        else {
+            return Ok(None);
+        };
+        let bytes: [u8; 4] = resolved.value.try_into().map_err(|_| {
+            MetaError::Internal("workspace ACL permissions have an invalid encoding".into())
+        })?;
+        Ok(Some(AclRule {
+            acl_type,
+            qualifier: acl_id,
+            permissions: u32::from_be_bytes(bytes),
+        }))
+    }
+}
+
+#[async_trait]
+impl<W: WorkspaceStore + 'static> WorkspaceReadPlanProvider for WorkspaceMetaLayer<W> {
+    async fn read_plan(
+        &self,
+        ino: i64,
+        chunk_index: u64,
+        offset: u64,
+        len: u64,
+    ) -> Result<ResolvedReadPlan, MetaError> {
+        let inode = self
+            .resolve_inode_delta(ino)
+            .await?
+            .ok_or(MetaError::NotFound(ino))?;
+        let end = offset
+            .checked_add(len)
+            .ok_or_else(|| MetaError::Internal("workspace read range overflows".into()))?;
+        if end > self.chunk_size {
+            return Err(MetaError::Internal(format!(
+                "workspace read range ends at {end}, beyond chunk size {}",
+                self.chunk_size
+            )));
+        }
+        if len == 0 {
+            return Ok(ResolvedReadPlan::default());
+        }
+        let view = self.view_context().await;
+        let cache_key = ReadPlanCacheKey {
+            workspace_id: view.workspace_id,
+            head_epoch: view.head_epoch,
+            ino,
+            chunk_index,
+            inode_data_version: inode.data_version,
+            range_start: offset,
+            range_end: end,
+        };
+        if let Some(plan) = self.resolver_cache.get_read_plan(&cache_key) {
+            return Ok(plan);
+        }
+        let chain = self.chain().await?;
+        let rows = self
+            .store
+            .get_extent_deltas(ExtentQuery {
+                layer_ids: chain.iter().map(|layer| layer.layer_id).collect(),
+                ino,
+                chunk_index,
+                range_start: offset,
+                range_end: end,
+            })
+            .await
+            .map_err(workspace_to_meta)?;
+        let extents = resolve_extents(&chain, &rows, ino, chunk_index, offset..end)
+            .map_err(workspace_to_meta)?;
+        let segments = extents
+            .into_iter()
+            .map(|extent| match extent.kind {
+                super::model::ExtentKind::Data {
+                    slice_id,
+                    slice_offset,
+                } => ReadPlanSegment::Data {
+                    logical_offset: extent.logical_offset,
+                    length: extent.length,
+                    slice_id,
+                    slice_offset,
+                },
+                super::model::ExtentKind::Hole => ReadPlanSegment::Zero {
+                    logical_offset: extent.logical_offset,
+                    length: extent.length,
+                },
+            })
+            .collect();
+        let plan = ResolvedReadPlan { segments };
+        self.metrics
+            .add_extent_plan_segments(plan.segments.len() as u64);
+        self.resolver_cache
+            .insert_read_plan(cache_key, plan.clone());
+        Ok(plan)
+    }
+
+    async fn range_has_data(&self, ino: i64, offset: u64, len: u64) -> Result<bool, MetaError> {
+        let end = offset
+            .checked_add(len)
+            .ok_or_else(|| MetaError::Internal("workspace file range overflows".into()))?;
+        let mut cursor = offset;
+        while cursor < end {
+            let chunk_index = cursor / self.chunk_size;
+            let chunk_offset = cursor % self.chunk_size;
+            let take = (end - cursor).min(self.chunk_size - chunk_offset);
+            let plan = self.read_plan(ino, chunk_index, chunk_offset, take).await?;
+            if plan
+                .segments
+                .iter()
+                .any(|segment| matches!(segment, ReadPlanSegment::Data { .. }))
+            {
+                return Ok(true);
+            }
+            cursor = cursor
+                .checked_add(take)
+                .ok_or_else(|| MetaError::Internal("workspace range cursor overflows".into()))?;
+        }
+        Ok(false)
+    }
+
+    async fn record_orphan_slice(&self, slice_id: u64, slice_end: u64) -> Result<(), MetaError> {
+        self.store
+            .record_orphan_slice(RecordOrphanSlice {
+                orphan_layer_id: super::ids::LayerId::new(),
+                slice_id,
+                slice_end,
+            })
+            .await
+            .map_err(workspace_to_meta)
+    }
+
+    async fn apply_hole_range(
+        &self,
+        ino: i64,
+        offset: u64,
+        len: u64,
+        keep_size: bool,
+    ) -> Result<u64, MetaError> {
+        let _mutation_guard = self.mutation_gate.lock().await;
+        let requested_end = offset
+            .checked_add(len)
+            .ok_or_else(|| MetaError::InvalidPath("hole range overflows".into()))?;
+        let mut inode = self
+            .resolve_inode_delta(ino)
+            .await?
+            .ok_or(MetaError::NotFound(ino))?;
+        if file_type_from_code(inode.kind)? != FileType::File {
+            return Err(MetaError::NotSupported(
+                "hole mutation requires a regular file".into(),
+            ));
+        }
+        let range_end = if keep_size {
+            requested_end.min(inode.size)
+        } else {
+            requested_end
+        };
+        if len == 0 || offset >= range_end {
+            return Ok(inode.size);
+        }
+        let extents = self.hole_extents(inode.layer_id, ino, offset, range_end)?;
+        if !keep_size {
+            inode.size = inode.size.max(requested_end);
+        }
+        let now = now_ns()?;
+        inode.mtime_ns = now;
+        inode.ctime_ns = now;
+        inode.data_version = inode.data_version.saturating_add(1);
+        let inode = self.mutate_data(inode, extents).await?;
+        Ok(inode.size)
+    }
+}
+
+fn workspace_to_meta(error: WorkspaceError) -> MetaError {
+    match error {
+        WorkspaceError::Io(error) => MetaError::Io(error),
+        WorkspaceError::Fenced => MetaError::Io(std::io::Error::from_raw_os_error(libc::ESTALE)),
+        WorkspaceError::Busy => MetaError::Io(std::io::Error::from_raw_os_error(libc::EBUSY)),
+        WorkspaceError::UnsupportedCapability(capability) => {
+            MetaError::NotSupported(format!("workspace capability {capability}"))
+        }
+        WorkspaceError::FeatureNotCompiled(feature) => {
+            MetaError::NotSupported(format!("feature {feature} is not compiled"))
+        }
+        WorkspaceError::WorkspaceNotFound(_) | WorkspaceError::LayerNotFound(_) => {
+            MetaError::NotFound(1)
+        }
+        WorkspaceError::LeaseNotFound(_) => {
+            MetaError::Io(std::io::Error::from_raw_os_error(libc::ESTALE))
+        }
+        WorkspaceError::CorruptMetadata(message)
+        | WorkspaceError::InvalidReadPlan(message)
+        | WorkspaceError::Backend(message)
+        | WorkspaceError::UnsupportedVolumeFormat(message) => MetaError::Internal(message),
+        WorkspaceError::UnsupportedSchemaVersion(version) => {
+            MetaError::Internal(format!("unsupported workspace schema version {version}"))
+        }
+        WorkspaceError::Conflict(detail) => MetaError::Internal(format!(
+            "workspace conflict at {:?}: {}",
+            detail.path, detail.reason
+        )),
+        WorkspaceError::LayerDepthLimit { depth, hard_limit } => MetaError::Internal(format!(
+            "workspace layer depth {depth} exceeds {hard_limit}"
+        )),
+        WorkspaceError::InvalidStateTransition { from, to } => {
+            MetaError::Internal(format!("invalid workspace transition {from} -> {to}"))
+        }
+    }
+}
+
+fn now_ns() -> Result<i64, MetaError> {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|error| MetaError::Internal(format!("system clock is before epoch: {error}")))?
+        .as_nanos();
+    i64::try_from(nanos).map_err(|_| MetaError::Internal("timestamp exceeds i64".into()))
+}
+
+fn file_type_code(kind: FileType) -> u8 {
+    match kind {
+        FileType::File => 0,
+        FileType::Dir => 1,
+        FileType::Symlink => 2,
+        FileType::Fifo => 3,
+        FileType::Socket => 4,
+        FileType::CharDevice => 5,
+        FileType::BlockDevice => 6,
+    }
+}
+
+fn file_type_from_code(code: u8) -> Result<FileType, MetaError> {
+    match code {
+        0 => Ok(FileType::File),
+        1 => Ok(FileType::Dir),
+        2 => Ok(FileType::Symlink),
+        3 => Ok(FileType::Fifo),
+        4 => Ok(FileType::Socket),
+        5 => Ok(FileType::CharDevice),
+        6 => Ok(FileType::BlockDevice),
+        _ => Err(MetaError::Internal(format!(
+            "invalid workspace inode kind {code}"
+        ))),
+    }
+}
+
+fn file_attr(inode: &InodeDelta) -> Result<FileAttr, MetaError> {
+    if inode.state != InodeState::Present {
+        return Err(MetaError::NotFound(inode.ino));
+    }
+    Ok(FileAttr {
+        ino: inode.ino,
+        size: inode.size,
+        blocks: inode.size.div_ceil(512),
+        kind: file_type_from_code(inode.kind)?,
+        mode: inode.mode,
+        rdev: inode.rdev,
+        uid: inode.uid,
+        gid: inode.gid,
+        atime: inode.atime_ns,
+        mtime: inode.mtime_ns,
+        ctime: inode.ctime_ns,
+        nlink: inode.nlink,
+    })
+}
+
+fn validate_name(name: &str) -> Result<(), MetaError> {
+    if name.is_empty() || matches!(name, "." | "..") || name.as_bytes().contains(&0) {
+        return Err(MetaError::InvalidFilename);
+    }
+    if name.as_bytes().contains(&b'/') {
+        return Err(MetaError::InvalidFilename);
+    }
+    if name.len() > 255 {
+        return Err(MetaError::FilenameTooLong);
+    }
+    Ok(())
+}
+
+fn validate_xattr_name(name: &str) -> Result<(), MetaError> {
+    if name.is_empty() || name.as_bytes().contains(&0) {
+        return Err(MetaError::InvalidPath("invalid xattr name".into()));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/workspace_overlay/meta_layer/tests.rs
+++ b/src/workspace_overlay/meta_layer/tests.rs
@@ -1,0 +1,725 @@
+use std::sync::Arc;
+
+use uuid::Uuid;
+
+use crate::chunk::SliceDesc;
+use crate::chunk::read_plan::{ReadPlanSegment, WorkspaceReadPlanProvider};
+use crate::meta::MetaLayer;
+use crate::meta::file_lock::{FileLockQuery, FileLockRange, FileLockType};
+use crate::meta::store::{FileType, SetAttrFlags, SetAttrRequest};
+use crate::workspace_overlay::catalog::{AcquireLease, CreateVolumeRoot, WorkspaceStore};
+use crate::workspace_overlay::ids::{LayerId, LeaseId, WorkspaceId};
+use crate::workspace_overlay::lifecycle::{NoopDurableRemoteBarrier, WorkspaceLifecycle};
+use crate::workspace_overlay::model::ViewContext;
+use crate::workspace_overlay::stores::database::SqliteWorkspaceStore;
+
+use super::WorkspaceMetaLayer;
+
+async fn test_meta() -> WorkspaceMetaLayer<SqliteWorkspaceStore> {
+    let store = Arc::new(
+        SqliteWorkspaceStore::connect("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
+    store.initialize_workspace_schema().await.unwrap();
+    let workspace_id = WorkspaceId::from_uuid(Uuid::from_u128(100));
+    let workspace = store
+        .create_volume_root(CreateVolumeRoot {
+            volume_id: Uuid::from_u128(101),
+            workspace_id,
+            root_layer_id: LayerId::from_uuid(Uuid::from_u128(102)),
+            writable_layer_id: LayerId::from_uuid(Uuid::from_u128(103)),
+            owner_id: Some("meta-test".into()),
+        })
+        .await
+        .unwrap();
+    let lease = store
+        .acquire_lease(AcquireLease {
+            workspace_id,
+            lease_id: LeaseId::from_uuid(Uuid::from_u128(104)),
+            holder_generation: 1,
+            ttl_ns: 60_000_000_000,
+        })
+        .await
+        .unwrap();
+    WorkspaceMetaLayer::new(
+        store,
+        ViewContext {
+            workspace_id,
+            head_layer_id: workspace.head_layer_id,
+            head_epoch: workspace.head_epoch,
+            lease_id: lease.lease_id,
+            holder_generation: lease.holder_generation,
+        },
+    )
+}
+
+#[tokio::test]
+async fn create_unlink_recreate_and_rmdir_follow_effective_view() {
+    let meta = test_meta().await;
+    let root = meta.root_ino();
+    let before = meta.stat(root).await.unwrap().unwrap();
+    assert_eq!(before.kind, FileType::Dir);
+    assert_eq!(before.nlink, 2);
+
+    let work = meta.mkdir(root, "work".into()).await.unwrap();
+    assert_eq!(meta.stat(root).await.unwrap().unwrap().nlink, 3);
+    let first = meta.create_file(work, "result".into()).await.unwrap();
+    assert_eq!(meta.lookup(work, "result").await.unwrap(), Some(first));
+    let entries = meta.readdir(work).await.unwrap();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].name, "result");
+
+    let not_empty = meta.rmdir(root, "work").await.unwrap_err();
+    assert!(matches!(
+        not_empty,
+        crate::meta::store::MetaError::DirectoryNotEmpty(ino) if ino == work
+    ));
+    meta.unlink(work, "result").await.unwrap();
+    assert_eq!(meta.lookup(work, "result").await.unwrap(), None);
+    let second = meta.create_file(work, "result".into()).await.unwrap();
+    assert_ne!(first, second);
+    meta.unlink(work, "result").await.unwrap();
+    meta.rmdir(root, "work").await.unwrap();
+    assert_eq!(meta.lookup(root, "work").await.unwrap(), None);
+    assert_eq!(meta.stat(root).await.unwrap().unwrap().nlink, 2);
+}
+
+#[tokio::test]
+async fn rename_exchange_and_hardlink_update_dentries_and_nlink_atomically() {
+    let meta = test_meta().await;
+    let root = meta.root_ino();
+    let left = meta.mkdir(root, "left".into()).await.unwrap();
+    let right = meta.mkdir(root, "right".into()).await.unwrap();
+    let source = meta.create_file(left, "source".into()).await.unwrap();
+    let other = meta.create_file(right, "other".into()).await.unwrap();
+
+    let linked = meta.link(source, right, "linked").await.unwrap();
+    assert_eq!(linked.nlink, 2);
+    meta.rename(left, "source", right, "moved".into())
+        .await
+        .unwrap();
+    assert_eq!(meta.lookup(left, "source").await.unwrap(), None);
+    assert_eq!(meta.lookup(right, "linked").await.unwrap(), Some(source));
+    assert_eq!(meta.lookup(right, "moved").await.unwrap(), Some(source));
+
+    meta.rename_exchange(right, "moved", right, "other")
+        .await
+        .unwrap();
+    assert_eq!(meta.lookup(right, "moved").await.unwrap(), Some(other));
+    assert_eq!(meta.lookup(right, "other").await.unwrap(), Some(source));
+    meta.unlink(right, "linked").await.unwrap();
+    assert_eq!(meta.stat(source).await.unwrap().unwrap().nlink, 1);
+}
+
+#[tokio::test]
+async fn symlink_setattr_and_xattr_mutations_round_trip() {
+    let meta = test_meta().await;
+    let root = meta.root_ino();
+    let file = meta.create_file(root, "file".into()).await.unwrap();
+    let (link, attr) = meta.symlink(root, "link", "file").await.unwrap();
+    assert_eq!(attr.kind, FileType::Symlink);
+    assert_eq!(meta.read_symlink(link).await.unwrap(), "file");
+
+    let updated = meta
+        .set_attr(
+            file,
+            &SetAttrRequest {
+                mode: Some(0o640),
+                uid: Some(2000),
+                gid: Some(3000),
+                size: None,
+                atime: None,
+                mtime: None,
+                ctime: None,
+                flags: None,
+            },
+            SetAttrFlags::empty(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        (updated.mode, updated.uid, updated.gid),
+        (0o640, 2000, 3000)
+    );
+
+    meta.set_xattr(file, "user.agent", b"private", 0)
+        .await
+        .unwrap();
+    assert_eq!(
+        meta.get_xattr(file, "user.agent").await.unwrap(),
+        Some(b"private".to_vec())
+    );
+    assert_eq!(meta.list_xattr(file).await.unwrap(), vec!["user.agent"]);
+    meta.remove_xattr(file, "user.agent").await.unwrap();
+    assert_eq!(meta.get_xattr(file, "user.agent").await.unwrap(), None);
+}
+
+#[tokio::test]
+async fn setattr_timestamps_round_trip_as_nanoseconds() {
+    let meta = test_meta().await;
+    let file = meta
+        .create_file(meta.root_ino(), "timestamps".into())
+        .await
+        .unwrap();
+    let atime = 1_725_000_000_123_456_789;
+    let mtime = 1_725_000_001_234_567_890;
+    let ctime = 1_725_000_002_345_678_901;
+
+    let updated = meta
+        .set_attr(
+            file,
+            &SetAttrRequest {
+                atime: Some(atime),
+                mtime: Some(mtime),
+                ctime: Some(ctime),
+                ..SetAttrRequest::default()
+            },
+            SetAttrFlags::empty(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(updated.atime, atime);
+    assert_eq!(updated.mtime, mtime);
+    assert_eq!(updated.ctime, ctime);
+    let stat = meta.stat(file).await.unwrap().unwrap();
+    assert_eq!(stat.atime, atime);
+    assert_eq!(stat.mtime, mtime);
+    assert_eq!(stat.ctime, ctime);
+}
+
+#[tokio::test]
+async fn writes_build_read_plans_and_truncate_holes_prevent_data_revival() {
+    let meta = test_meta().await;
+    let file = meta
+        .create_file(meta.root_ino(), "data".into())
+        .await
+        .unwrap();
+    let chunk_id = crate::vfs::chunk_id_for(file, 0).unwrap();
+    meta.write(
+        file,
+        chunk_id,
+        SliceDesc {
+            slice_id: 10,
+            chunk_id,
+            offset: 0,
+            length: 8,
+        },
+        8,
+    )
+    .await
+    .unwrap();
+    meta.write(
+        file,
+        chunk_id,
+        SliceDesc {
+            slice_id: 11,
+            chunk_id,
+            offset: 2,
+            length: 2,
+        },
+        8,
+    )
+    .await
+    .unwrap();
+
+    let plan = meta.read_plan(file, 0, 0, 8).await.unwrap();
+    assert_eq!(
+        plan.segments,
+        vec![
+            ReadPlanSegment::Data {
+                logical_offset: 0,
+                length: 2,
+                slice_id: 10,
+                slice_offset: 0,
+            },
+            ReadPlanSegment::Data {
+                logical_offset: 2,
+                length: 2,
+                slice_id: 11,
+                slice_offset: 0,
+            },
+            ReadPlanSegment::Data {
+                logical_offset: 4,
+                length: 4,
+                slice_id: 10,
+                slice_offset: 4,
+            },
+        ]
+    );
+
+    meta.truncate(file, 3, crate::chunk::DEFAULT_CHUNK_SIZE)
+        .await
+        .unwrap();
+    meta.extend_file_size(file, 8).await.unwrap();
+    let plan = meta.read_plan(file, 0, 0, 8).await.unwrap();
+    assert_eq!(
+        plan.segments,
+        vec![
+            ReadPlanSegment::Data {
+                logical_offset: 0,
+                length: 2,
+                slice_id: 10,
+                slice_offset: 0,
+            },
+            ReadPlanSegment::Data {
+                logical_offset: 2,
+                length: 1,
+                slice_id: 11,
+                slice_offset: 0,
+            },
+            ReadPlanSegment::Zero {
+                logical_offset: 3,
+                length: 5,
+            },
+        ]
+    );
+    assert!(meta.range_has_data(file, 0, 3).await.unwrap());
+    assert!(!meta.range_has_data(file, 3, 5).await.unwrap());
+}
+
+#[tokio::test]
+async fn aligned_physical_slice_is_clipped_to_logical_eof() {
+    let meta = test_meta().await;
+    let file = meta
+        .create_file(meta.root_ino(), "aligned-tail".into())
+        .await
+        .unwrap();
+    let chunk_id = crate::vfs::chunk_id_for(file, 0).unwrap();
+
+    meta.write(
+        file,
+        chunk_id,
+        SliceDesc {
+            slice_id: 20,
+            chunk_id,
+            offset: 0,
+            length: 64 * 1024,
+        },
+        4 * 1024,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(meta.stat(file).await.unwrap().unwrap().size, 4 * 1024);
+    assert_eq!(
+        meta.read_plan(file, 0, 0, 4 * 1024).await.unwrap().segments,
+        vec![ReadPlanSegment::Data {
+            logical_offset: 0,
+            length: 4 * 1024,
+            slice_id: 20,
+            slice_offset: 0,
+        }]
+    );
+
+    meta.extend_file_size(file, 8 * 1024).await.unwrap();
+    assert_eq!(
+        meta.read_plan(file, 0, 0, 8 * 1024).await.unwrap().segments,
+        vec![
+            ReadPlanSegment::Data {
+                logical_offset: 0,
+                length: 4 * 1024,
+                slice_id: 20,
+                slice_offset: 0,
+            },
+            ReadPlanSegment::Zero {
+                logical_offset: 4 * 1024,
+                length: 4 * 1024,
+            },
+        ]
+    );
+}
+
+#[tokio::test]
+async fn punch_hole_and_zero_range_replace_data_without_lower_byte_revival() {
+    let meta = test_meta().await;
+    let file = meta
+        .create_file(meta.root_ino(), "hole-data".into())
+        .await
+        .unwrap();
+    let chunk_id = crate::vfs::chunk_id_for(file, 0).unwrap();
+    meta.write(
+        file,
+        chunk_id,
+        SliceDesc {
+            slice_id: 12,
+            chunk_id,
+            offset: 0,
+            length: 8,
+        },
+        8,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(meta.apply_hole_range(file, 2, 3, true).await.unwrap(), 8);
+    assert_eq!(
+        meta.read_plan(file, 0, 0, 8).await.unwrap().segments,
+        vec![
+            ReadPlanSegment::Data {
+                logical_offset: 0,
+                length: 2,
+                slice_id: 12,
+                slice_offset: 0,
+            },
+            ReadPlanSegment::Zero {
+                logical_offset: 2,
+                length: 3,
+            },
+            ReadPlanSegment::Data {
+                logical_offset: 5,
+                length: 3,
+                slice_id: 12,
+                slice_offset: 5,
+            },
+        ]
+    );
+    assert_eq!(meta.apply_hole_range(file, 7, 4, false).await.unwrap(), 11);
+    assert_eq!(meta.stat(file).await.unwrap().unwrap().size, 11);
+    assert_eq!(
+        meta.read_plan(file, 0, 7, 4).await.unwrap().segments,
+        vec![ReadPlanSegment::Zero {
+            logical_offset: 7,
+            length: 4,
+        }]
+    );
+}
+
+#[tokio::test]
+async fn locks_conflict_within_a_workspace_but_not_across_workspace_instances() {
+    let meta = test_meta().await;
+    let other_workspace = test_meta().await;
+    let file = meta
+        .create_file(meta.root_ino(), "locked".into())
+        .await
+        .unwrap();
+    let range = FileLockRange { start: 0, end: 10 };
+
+    meta.set_plock(file, 1, false, FileLockType::Write, range, 100)
+        .await
+        .unwrap();
+    let conflict = meta
+        .get_plock(
+            file,
+            &FileLockQuery {
+                owner: 2,
+                lock_type: FileLockType::Read,
+                range,
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(conflict.lock_type, FileLockType::Write);
+    assert!(
+        meta.set_plock(file, 2, false, FileLockType::Read, range, 200)
+            .await
+            .is_err()
+    );
+    other_workspace
+        .set_plock(file, 2, false, FileLockType::Write, range, 200)
+        .await
+        .unwrap();
+
+    meta.set_flock(file, 1, false, FileLockType::Write)
+        .await
+        .unwrap();
+    assert!(
+        meta.set_flock(file, 2, false, FileLockType::Read)
+            .await
+            .is_err()
+    );
+    other_workspace
+        .set_flock(file, 2, false, FileLockType::Write)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn open_unlink_keeps_inode_alive_until_last_close() {
+    let meta = test_meta().await;
+    let root = meta.root_ino();
+    let file = meta.create_file(root, "open".into()).await.unwrap();
+    let attr = meta.stat(file).await.unwrap().unwrap();
+    meta.record_open(file, attr, true, true, false)
+        .await
+        .unwrap();
+    meta.unlink(root, "open").await.unwrap();
+    assert_eq!(meta.lookup(root, "open").await.unwrap(), None);
+    assert_eq!(meta.stat(file).await.unwrap().unwrap().nlink, 0);
+    meta.record_close(file).await.unwrap();
+    assert!(meta.stat(file).await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn concurrent_open_before_final_close_keeps_unlinked_inode_alive() {
+    let meta = Arc::new(test_meta().await);
+    let root = meta.root_ino();
+    let file = meta.create_file(root, "open-race".into()).await.unwrap();
+    let attr = meta.stat(file).await.unwrap().unwrap();
+    meta.record_open(file, attr.clone(), true, false, false)
+        .await
+        .unwrap();
+    meta.unlink(root, "open-race").await.unwrap();
+
+    let gate = meta.mutation_gate.lock().await;
+    let opening_meta = meta.clone();
+    let mut opening = tokio::spawn(async move {
+        opening_meta
+            .record_open(file, attr, true, false, false)
+            .await
+    });
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(50), &mut opening)
+            .await
+            .is_err(),
+        "the open must be queued behind the held mutation gate"
+    );
+
+    let closing_meta = meta.clone();
+    let mut closing = tokio::spawn(async move { closing_meta.record_close(file).await });
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(50), &mut closing)
+            .await
+            .is_err(),
+        "the close must be queued behind the open"
+    );
+
+    drop(gate);
+    opening.await.unwrap().unwrap();
+    closing.await.unwrap().unwrap();
+    assert!(meta.stat(file).await.unwrap().is_some());
+    meta.record_close(file).await.unwrap();
+    assert!(meta.stat(file).await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn final_close_before_concurrent_open_rejects_stale_inode() {
+    let meta = Arc::new(test_meta().await);
+    let root = meta.root_ino();
+    let file = meta
+        .create_file(root, "close-wins-race".into())
+        .await
+        .unwrap();
+    let attr = meta.stat(file).await.unwrap().unwrap();
+    meta.record_open(file, attr.clone(), true, false, false)
+        .await
+        .unwrap();
+    meta.unlink(root, "close-wins-race").await.unwrap();
+
+    let gate = meta.mutation_gate.lock().await;
+    let closing_meta = meta.clone();
+    let mut closing = tokio::spawn(async move { closing_meta.record_close(file).await });
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(50), &mut closing)
+            .await
+            .is_err(),
+        "the close must be queued first"
+    );
+
+    let opening_meta = meta.clone();
+    let mut opening = tokio::spawn(async move {
+        opening_meta
+            .record_open(file, attr, true, false, false)
+            .await
+    });
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(50), &mut opening)
+            .await
+            .is_err(),
+        "the open must be queued behind the close"
+    );
+
+    drop(gate);
+    closing.await.unwrap().unwrap();
+    assert!(matches!(
+        opening.await.unwrap(),
+        Err(crate::meta::store::MetaError::NotFound(ino)) if ino == file
+    ));
+    assert!(!meta.open_counts.contains_key(&file));
+    assert!(meta.stat(file).await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn stale_open_paths_do_not_allocate_a_handle_or_increment_open_count() {
+    let meta = Arc::new(test_meta().await);
+    let root = meta.root_ino();
+    let file = meta
+        .create_file(root, "stale-vfs-open".into())
+        .await
+        .unwrap();
+    let stale_attr = meta.stat(file).await.unwrap().unwrap();
+    meta.unlink(root, "stale-vfs-open").await.unwrap();
+
+    let layout = crate::chunk::layout::ChunkLayout::default();
+    let fs = crate::vfs::fs::VFS::from_workspace_components(
+        crate::vfs::config::VFSConfig::new(layout),
+        Arc::new(crate::chunk::store::InMemoryBlockStore::new()),
+        meta.clone(),
+    )
+    .unwrap();
+    assert!(matches!(
+        fs.open_with_cached_attr(file, stale_attr.clone(), true, false, false)
+            .await,
+        Err(crate::vfs::error::VfsError::NotFound { .. })
+    ));
+    assert!(matches!(
+        fs.open(file, stale_attr.clone(), true, false, false).await,
+        Err(crate::vfs::error::VfsError::NotFound { .. })
+    ));
+    assert!(matches!(
+        fs.open_guard(file, stale_attr, true, false).await,
+        Err(crate::vfs::error::VfsError::NotFound { .. })
+    ));
+    assert!(
+        !meta.open_counts.contains_key(&file),
+        "rejected opens must not increment the metadata open count"
+    );
+    assert!(
+        fs.handles_for(file).is_empty(),
+        "rejected opens must not leak an allocated VFS handle"
+    );
+}
+
+#[tokio::test]
+async fn statfs_rejects_unbounded_layer_scans_until_usage_counters_exist() {
+    let meta = test_meta().await;
+    assert!(matches!(
+        meta.stat_fs().await,
+        Err(crate::meta::store::MetaError::NotSupported(message))
+            if message == "workspace statfs requires persistent usage counters"
+    ));
+}
+
+#[tokio::test]
+async fn concurrent_directory_creates_do_not_lose_parent_updates() {
+    let meta = Arc::new(test_meta().await);
+    let root = meta.root_ino();
+    let mut tasks = Vec::new();
+    for index in 0..32 {
+        let meta = meta.clone();
+        tasks.push(tokio::spawn(async move {
+            meta.mkdir(root, format!("dir-{index}")).await.unwrap();
+        }));
+    }
+    for task in tasks {
+        task.await.unwrap();
+    }
+    assert_eq!(meta.readdir(root).await.unwrap().len(), 32);
+    assert_eq!(meta.stat(root).await.unwrap().unwrap().nlink, 34);
+}
+
+#[tokio::test]
+async fn sibling_workspaces_share_the_base_but_isolate_namespace_and_data_changes() {
+    let base = test_meta().await;
+    let store = base.store().clone();
+    let base_view = base.view_context().await;
+    let root = base.root_ino();
+    let file = base.create_file(root, "shared".into()).await.unwrap();
+    let chunk_id = crate::vfs::chunk_id_for(file, 0).unwrap();
+    base.write(
+        file,
+        chunk_id,
+        SliceDesc {
+            chunk_id,
+            slice_id: 501,
+            offset: 0,
+            length: 8,
+        },
+        8,
+    )
+    .await
+    .unwrap();
+    let revision = WorkspaceLifecycle::new(store.clone())
+        .seal(&base_view, &NoopDurableRemoteBarrier)
+        .await
+        .unwrap()
+        .revision;
+    let children = WorkspaceLifecycle::new(store.clone())
+        .fork_revision(revision, 2, Some("agent".into()))
+        .await
+        .unwrap();
+
+    let mut views = Vec::new();
+    for (index, child) in children.iter().enumerate() {
+        let lease = store
+            .acquire_lease(AcquireLease {
+                workspace_id: child.workspace_id,
+                lease_id: LeaseId::new(),
+                holder_generation: index as u64 + 10,
+                ttl_ns: 60_000_000_000,
+            })
+            .await
+            .unwrap();
+        views.push(ViewContext {
+            workspace_id: child.workspace_id,
+            head_layer_id: child.head_layer_id,
+            head_epoch: child.head_epoch,
+            lease_id: lease.lease_id,
+            holder_generation: lease.holder_generation,
+        });
+    }
+    let left = WorkspaceMetaLayer::new(store.clone(), views[0].clone());
+    let right = WorkspaceMetaLayer::new(store, views[1].clone());
+    assert_eq!(left.lookup(root, "shared").await.unwrap(), Some(file));
+    assert_eq!(right.lookup(root, "shared").await.unwrap(), Some(file));
+
+    left.create_file(root, "left-only".into()).await.unwrap();
+    right.create_file(root, "right-only".into()).await.unwrap();
+    left.write(
+        file,
+        chunk_id,
+        SliceDesc {
+            chunk_id,
+            slice_id: 502,
+            offset: 2,
+            length: 2,
+        },
+        8,
+    )
+    .await
+    .unwrap();
+    right
+        .write(
+            file,
+            chunk_id,
+            SliceDesc {
+                chunk_id,
+                slice_id: 503,
+                offset: 4,
+                length: 2,
+            },
+            8,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(left.lookup(root, "right-only").await.unwrap(), None);
+    assert_eq!(right.lookup(root, "left-only").await.unwrap(), None);
+    assert!(
+        left.read_plan(file, 0, 0, 8)
+            .await
+            .unwrap()
+            .segments
+            .iter()
+            .any(|segment| matches!(segment, ReadPlanSegment::Data { slice_id: 502, .. }))
+    );
+    assert!(
+        !left
+            .read_plan(file, 0, 0, 8)
+            .await
+            .unwrap()
+            .segments
+            .iter()
+            .any(|segment| matches!(segment, ReadPlanSegment::Data { slice_id: 503, .. }))
+    );
+    assert!(
+        right
+            .read_plan(file, 0, 0, 8)
+            .await
+            .unwrap()
+            .segments
+            .iter()
+            .any(|segment| matches!(segment, ReadPlanSegment::Data { slice_id: 503, .. }))
+    );
+}

--- a/src/workspace_overlay/metrics.rs
+++ b/src/workspace_overlay/metrics.rs
@@ -1,0 +1,280 @@
+//! Feature-local workspace metrics. Flat `.stats` remains unchanged.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, OnceLock};
+
+#[derive(Default)]
+pub struct WorkspaceMetrics {
+    mount_ok: AtomicU64,
+    mount_err: AtomicU64,
+    fork_ok: AtomicU64,
+    fork_err: AtomicU64,
+    seal_ok: AtomicU64,
+    seal_err: AtomicU64,
+    publish_ok: AtomicU64,
+    publish_err: AtomicU64,
+    fork_control_latency_ns: AtomicU64,
+    fork_drain_latency_ns: AtomicU64,
+    quiesce_latency_ns: AtomicU64,
+    seal_pending_bytes: AtomicU64,
+    publish_changed_paths: AtomicU64,
+    layer_depth: AtomicU64,
+    resolver_steps: AtomicU64,
+    extent_plan_segments: AtomicU64,
+    private_bytes_written: AtomicU64,
+    parent_bytes_read: AtomicU64,
+    shared_cache_hits: AtomicU64,
+    fenced_writes: AtomicU64,
+    active_leases: AtomicU64,
+    gc_reachable_layers: AtomicU64,
+    gc_orphan_bytes: AtomicU64,
+    compaction_bytes: AtomicU64,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct WorkspaceMetricsSnapshot {
+    pub mount_ok: u64,
+    pub mount_err: u64,
+    pub fork_ok: u64,
+    pub fork_err: u64,
+    pub seal_ok: u64,
+    pub seal_err: u64,
+    pub publish_ok: u64,
+    pub publish_err: u64,
+    pub fork_control_latency_ns: u64,
+    pub fork_drain_latency_ns: u64,
+    pub quiesce_latency_ns: u64,
+    pub seal_pending_bytes: u64,
+    pub publish_changed_paths: u64,
+    pub layer_depth: u64,
+    pub resolver_steps: u64,
+    pub extent_plan_segments: u64,
+    pub private_bytes_written: u64,
+    pub parent_bytes_read: u64,
+    pub shared_cache_hits: u64,
+    pub fenced_writes: u64,
+    pub active_leases: u64,
+    pub gc_reachable_layers: u64,
+    pub gc_orphan_bytes: u64,
+    pub compaction_bytes: u64,
+}
+
+impl WorkspaceMetrics {
+    pub fn record_mount(&self, ok: bool) {
+        counter(ok, &self.mount_ok, &self.mount_err);
+    }
+    pub fn record_fork(&self, ok: bool) {
+        counter(ok, &self.fork_ok, &self.fork_err);
+    }
+    pub fn record_seal(&self, ok: bool) {
+        counter(ok, &self.seal_ok, &self.seal_err);
+    }
+    pub fn record_publish(&self, ok: bool) {
+        counter(ok, &self.publish_ok, &self.publish_err);
+    }
+    pub fn add_fork_control_latency_ns(&self, value: u64) {
+        self.fork_control_latency_ns
+            .fetch_add(value, Ordering::Relaxed);
+    }
+    pub fn add_fork_drain_latency_ns(&self, value: u64) {
+        self.fork_drain_latency_ns
+            .fetch_add(value, Ordering::Relaxed);
+    }
+    pub fn add_quiesce_latency_ns(&self, value: u64) {
+        self.quiesce_latency_ns.fetch_add(value, Ordering::Relaxed);
+    }
+    pub fn set_seal_pending_bytes(&self, value: u64) {
+        self.seal_pending_bytes.store(value, Ordering::Relaxed);
+    }
+    pub fn add_publish_changed_paths(&self, value: u64) {
+        self.publish_changed_paths
+            .fetch_add(value, Ordering::Relaxed);
+    }
+    pub fn set_layer_depth(&self, value: u64) {
+        self.layer_depth.store(value, Ordering::Relaxed);
+    }
+    pub fn add_resolver_steps(&self, value: u64) {
+        self.resolver_steps.fetch_add(value, Ordering::Relaxed);
+    }
+    pub fn add_extent_plan_segments(&self, value: u64) {
+        self.extent_plan_segments
+            .fetch_add(value, Ordering::Relaxed);
+    }
+    pub fn add_private_bytes_written(&self, value: u64) {
+        self.private_bytes_written
+            .fetch_add(value, Ordering::Relaxed);
+    }
+    pub fn add_parent_bytes_read(&self, value: u64) {
+        self.parent_bytes_read.fetch_add(value, Ordering::Relaxed);
+    }
+    pub fn record_shared_cache_hit(&self) {
+        self.shared_cache_hits.fetch_add(1, Ordering::Relaxed);
+    }
+    pub fn record_fenced_write(&self) {
+        self.fenced_writes.fetch_add(1, Ordering::Relaxed);
+    }
+    pub fn add_active_lease(&self) {
+        self.active_leases.fetch_add(1, Ordering::Relaxed);
+    }
+    pub fn remove_active_lease(&self) {
+        let _ = self
+            .active_leases
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |value| {
+                Some(value.saturating_sub(1))
+            });
+    }
+    pub fn set_active_leases(&self, value: u64) {
+        self.active_leases.store(value, Ordering::Relaxed);
+    }
+    pub fn set_gc(&self, reachable_layers: u64, orphan_bytes: u64) {
+        self.gc_reachable_layers
+            .store(reachable_layers, Ordering::Relaxed);
+        self.gc_orphan_bytes.store(orphan_bytes, Ordering::Relaxed);
+    }
+    pub fn add_compaction_bytes(&self, value: u64) {
+        self.compaction_bytes.fetch_add(value, Ordering::Relaxed);
+    }
+
+    pub fn snapshot(&self) -> WorkspaceMetricsSnapshot {
+        macro_rules! load {
+            ($field:ident) => {
+                self.$field.load(Ordering::Relaxed)
+            };
+        }
+        WorkspaceMetricsSnapshot {
+            mount_ok: load!(mount_ok),
+            mount_err: load!(mount_err),
+            fork_ok: load!(fork_ok),
+            fork_err: load!(fork_err),
+            seal_ok: load!(seal_ok),
+            seal_err: load!(seal_err),
+            publish_ok: load!(publish_ok),
+            publish_err: load!(publish_err),
+            fork_control_latency_ns: load!(fork_control_latency_ns),
+            fork_drain_latency_ns: load!(fork_drain_latency_ns),
+            quiesce_latency_ns: load!(quiesce_latency_ns),
+            seal_pending_bytes: load!(seal_pending_bytes),
+            publish_changed_paths: load!(publish_changed_paths),
+            layer_depth: load!(layer_depth),
+            resolver_steps: load!(resolver_steps),
+            extent_plan_segments: load!(extent_plan_segments),
+            private_bytes_written: load!(private_bytes_written),
+            parent_bytes_read: load!(parent_bytes_read),
+            shared_cache_hits: load!(shared_cache_hits),
+            fenced_writes: load!(fenced_writes),
+            active_leases: load!(active_leases),
+            gc_reachable_layers: load!(gc_reachable_layers),
+            gc_orphan_bytes: load!(gc_orphan_bytes),
+            compaction_bytes: load!(compaction_bytes),
+        }
+    }
+
+    pub fn render_prometheus(&self) -> String {
+        let value = self.snapshot();
+        let mut lines = vec![
+            metric_label("brewfs_workspace_mount_total", "ok", value.mount_ok),
+            metric_label("brewfs_workspace_mount_total", "error", value.mount_err),
+            metric_label("brewfs_workspace_fork_total", "ok", value.fork_ok),
+            metric_label("brewfs_workspace_fork_total", "error", value.fork_err),
+            metric_label("brewfs_workspace_seal_total", "ok", value.seal_ok),
+            metric_label("brewfs_workspace_seal_total", "error", value.seal_err),
+            metric_label("brewfs_workspace_publish_total", "ok", value.publish_ok),
+            metric_label("brewfs_workspace_publish_total", "error", value.publish_err),
+            metric_seconds(
+                "brewfs_workspace_fork_control_latency_seconds",
+                value.fork_control_latency_ns,
+            ),
+            metric_seconds(
+                "brewfs_workspace_fork_drain_latency_seconds",
+                value.fork_drain_latency_ns,
+            ),
+            metric_seconds(
+                "brewfs_workspace_quiesce_latency_seconds",
+                value.quiesce_latency_ns,
+            ),
+            metric(
+                "brewfs_workspace_seal_pending_bytes",
+                value.seal_pending_bytes,
+            ),
+            metric(
+                "brewfs_workspace_publish_changed_paths",
+                value.publish_changed_paths,
+            ),
+            metric("brewfs_workspace_layer_depth", value.layer_depth),
+            metric("brewfs_workspace_resolver_steps", value.resolver_steps),
+            metric(
+                "brewfs_workspace_extent_plan_segments",
+                value.extent_plan_segments,
+            ),
+            metric(
+                "brewfs_workspace_private_bytes_written",
+                value.private_bytes_written,
+            ),
+            metric(
+                "brewfs_workspace_parent_bytes_read",
+                value.parent_bytes_read,
+            ),
+            metric(
+                "brewfs_workspace_shared_cache_hits",
+                value.shared_cache_hits,
+            ),
+            metric("brewfs_workspace_active_leases", value.active_leases),
+            metric("brewfs_workspace_fenced_writes_total", value.fenced_writes),
+            metric(
+                "brewfs_workspace_gc_reachable_layers",
+                value.gc_reachable_layers,
+            ),
+            metric("brewfs_workspace_gc_orphan_bytes", value.gc_orphan_bytes),
+            metric("brewfs_workspace_compaction_bytes", value.compaction_bytes),
+        ];
+        lines.push(String::new());
+        lines.join("\n")
+    }
+}
+
+pub fn global_workspace_metrics() -> Arc<WorkspaceMetrics> {
+    static METRICS: OnceLock<Arc<WorkspaceMetrics>> = OnceLock::new();
+    METRICS
+        .get_or_init(|| Arc::new(WorkspaceMetrics::default()))
+        .clone()
+}
+
+fn counter(ok: bool, success: &AtomicU64, error: &AtomicU64) {
+    if ok { success } else { error }.fetch_add(1, Ordering::Relaxed);
+}
+
+fn metric(name: &str, value: u64) -> String {
+    format!("{name} {value}")
+}
+
+fn metric_label(name: &str, result: &str, value: u64) -> String {
+    format!(r#"{name}{{result="{result}"}} {value}"#)
+}
+
+fn metric_seconds(name: &str, nanoseconds: u64) -> String {
+    format!("{name} {}", nanoseconds as f64 / 1_000_000_000.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metrics_are_feature_local_and_render_all_stable_names() {
+        let metrics = WorkspaceMetrics::default();
+        metrics.record_mount(true);
+        metrics.record_fenced_write();
+        let rendered = metrics.render_prometheus();
+        assert!(rendered.contains("brewfs_workspace_mount_total{result=\"ok\"} 1"));
+        assert!(rendered.contains("brewfs_workspace_fenced_writes_total 1"));
+        for name in [
+            "brewfs_workspace_fork_control_latency_seconds",
+            "brewfs_workspace_fork_drain_latency_seconds",
+            "brewfs_workspace_quiesce_latency_seconds",
+            "brewfs_workspace_publish_changed_paths",
+            "brewfs_workspace_shared_cache_hits",
+        ] {
+            assert!(rendered.contains(name), "missing {name}");
+        }
+    }
+}

--- a/src/workspace_overlay/mod.rs
+++ b/src/workspace_overlay/mod.rs
@@ -1,0 +1,21 @@
+//! Workspace-isolated copy-on-write views.
+//!
+//! This module is compiled only when the `workspace-overlay` feature is
+//! explicitly enabled. The default flat-volume path must not depend on it.
+
+pub mod cache;
+pub mod cache_scope;
+pub mod catalog;
+pub mod compaction;
+pub mod control;
+pub mod digest;
+pub mod error;
+pub mod gc;
+pub mod ids;
+pub mod lifecycle;
+pub mod meta_layer;
+pub mod metrics;
+pub mod model;
+pub mod publish;
+pub mod resolver;
+pub mod stores;

--- a/src/workspace_overlay/model.rs
+++ b/src/workspace_overlay/model.rs
@@ -1,0 +1,473 @@
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+
+use super::error::WorkspaceError;
+use super::ids::{JournalId, LayerId, LeaseId, SnapshotId, WorkspaceId};
+use uuid::Uuid;
+
+pub const WORKSPACE_SCHEMA_VERSION: u32 = 1;
+pub const LAYER_CHAIN_HARD_LIMIT: u32 = 32;
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct VolumeHeader {
+    pub volume_format: String,
+    pub schema_version: u32,
+    pub volume_id: Uuid,
+    pub created_at_ns: i64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct BaseRevision {
+    pub layer_id: LayerId,
+    pub sealed_version: u64,
+    pub root_hash: [u8; 32],
+}
+
+impl fmt::Display for BaseRevision {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "{}:{}:{}",
+            self.layer_id,
+            self.sealed_version,
+            hex::encode(self.root_hash)
+        )
+    }
+}
+
+impl FromStr for BaseRevision {
+    type Err = WorkspaceError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let mut fields = value.split(':');
+        let layer_id = fields
+            .next()
+            .ok_or_else(|| WorkspaceError::CorruptMetadata("revision layer id is missing".into()))?
+            .parse()
+            .map_err(|error| {
+                WorkspaceError::CorruptMetadata(format!("invalid revision layer id: {error}"))
+            })?;
+        let sealed_version = fields
+            .next()
+            .ok_or_else(|| {
+                WorkspaceError::CorruptMetadata("revision sealed version is missing".into())
+            })?
+            .parse()
+            .map_err(|error| {
+                WorkspaceError::CorruptMetadata(format!("invalid sealed version: {error}"))
+            })?;
+        let hash = fields.next().ok_or_else(|| {
+            WorkspaceError::CorruptMetadata("revision root hash is missing".into())
+        })?;
+        if fields.next().is_some() {
+            return Err(WorkspaceError::CorruptMetadata(
+                "revision has extra fields".into(),
+            ));
+        }
+        let decoded = hex::decode(hash).map_err(|error| {
+            WorkspaceError::CorruptMetadata(format!("invalid revision root hash: {error}"))
+        })?;
+        let root_hash: [u8; 32] = decoded.try_into().map_err(|_| {
+            WorkspaceError::CorruptMetadata("revision root hash must contain 32 bytes".into())
+        })?;
+        Ok(Self {
+            layer_id,
+            sealed_version,
+            root_hash,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ViewContext {
+    pub workspace_id: WorkspaceId,
+    pub head_layer_id: LayerId,
+    pub head_epoch: u64,
+    pub lease_id: LeaseId,
+    pub holder_generation: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct WorkspaceRecord {
+    pub workspace_id: WorkspaceId,
+    pub head_layer_id: LayerId,
+    pub head_epoch: u64,
+    pub fork_base: Option<BaseRevision>,
+    pub owner_id: Option<String>,
+    pub state: WorkspaceState,
+    pub created_at_ns: i64,
+    pub updated_at_ns: i64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SnapshotLease {
+    pub lease_id: LeaseId,
+    pub workspace_id: WorkspaceId,
+    pub base_revision: BaseRevision,
+    pub holder_generation: u64,
+    pub writable: bool,
+    pub state: LeaseState,
+    pub expires_at_ns: i64,
+    pub created_at_ns: i64,
+    pub updated_at_ns: i64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SnapshotRecord {
+    pub snapshot_id: SnapshotId,
+    pub name: Option<String>,
+    pub revision: BaseRevision,
+    pub owner_id: Option<String>,
+    pub created_at_ns: i64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SealJournal {
+    pub journal_id: JournalId,
+    pub workspace_id: WorkspaceId,
+    pub old_head_layer_id: LayerId,
+    pub expected_head_epoch: u64,
+    pub phase: SealPhase,
+    pub pending_bytes: u64,
+    pub delta_digest: Option<[u8; 32]>,
+    pub root_hash: Option<[u8; 32]>,
+    pub new_head_layer_id: Option<LayerId>,
+    pub last_error: Option<String>,
+    pub created_at_ns: i64,
+    pub updated_at_ns: i64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SealResult {
+    pub revision: BaseRevision,
+    pub new_head_layer_id: LayerId,
+    pub head_epoch: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct CommitResult {
+    pub revision: BaseRevision,
+    pub target_head_layer_id: LayerId,
+    pub target_head_epoch: u64,
+}
+
+#[cfg(test)]
+mod revision_tests {
+    use super::*;
+
+    #[test]
+    fn external_revision_encoding_round_trips_exact_precondition() {
+        let revision = BaseRevision {
+            layer_id: LayerId::from_uuid(Uuid::from_u128(91)),
+            sealed_version: 12,
+            root_hash: [0xab; 32],
+        };
+
+        assert_eq!(
+            revision.to_string().parse::<BaseRevision>().unwrap(),
+            revision
+        );
+    }
+
+    #[test]
+    fn external_revision_rejects_layer_id_only() {
+        let error = Uuid::from_u128(91)
+            .to_string()
+            .parse::<BaseRevision>()
+            .unwrap_err();
+
+        assert!(matches!(error, WorkspaceError::CorruptMetadata(_)));
+    }
+}
+
+macro_rules! persisted_enum {
+    ($name:ident { $($variant:ident = $value:expr),+ $(,)? }) => {
+        #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+        #[repr(u8)]
+        pub enum $name {
+            $($variant = $value),+
+        }
+
+        impl $name {
+            pub const fn discriminant(self) -> u8 {
+                self as u8
+            }
+        }
+
+        impl TryFrom<u8> for $name {
+            type Error = WorkspaceError;
+
+            fn try_from(value: u8) -> Result<Self, WorkspaceError> {
+                match value {
+                    $($value => Ok(Self::$variant),)+
+                    unknown => Err(WorkspaceError::CorruptMetadata(format!(
+                        "unknown {} discriminant {unknown}",
+                        stringify!($name)
+                    ))),
+                }
+            }
+        }
+    };
+}
+
+persisted_enum!(WorkspaceState {
+    Active = 0,
+    Quiescing = 1,
+    Sealing = 2,
+    Deleting = 3,
+    Error = 4,
+});
+persisted_enum!(LayerState {
+    Writable = 0,
+    Sealing = 1,
+    Sealed = 2,
+    Deleting = 3,
+});
+persisted_enum!(LeaseState {
+    Active = 0,
+    Releasing = 1,
+    Released = 2,
+    Expired = 3,
+});
+persisted_enum!(DentryOp { Put = 0, Whiteout = 1 });
+persisted_enum!(InodeState { Present = 0, Deleted = 1 });
+persisted_enum!(ValueOp { Put = 0, Whiteout = 1 });
+persisted_enum!(SealPhase {
+    Prepare = 0,
+    Quiesced = 1,
+    DataDrained = 2,
+    Hashed = 3,
+    HeadSwitched = 4,
+    Completed = 5,
+    Aborted = 6,
+});
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct LayerRecord {
+    pub layer_id: LayerId,
+    pub parent_layer_id: Option<LayerId>,
+    pub state: LayerState,
+    pub schema_version: u32,
+    pub sealed_version: Option<u64>,
+    pub delta_digest: Option<[u8; 32]>,
+    pub root_hash: Option<[u8; 32]>,
+    pub depth: u32,
+    pub owner_workspace_id: Option<WorkspaceId>,
+    pub next_sequence: u64,
+    pub owned_slice_count: u64,
+    pub owned_bytes: u64,
+    pub created_at_ns: i64,
+    pub sealed_at_ns: Option<i64>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct DentryDelta {
+    pub layer_id: LayerId,
+    pub parent_ino: i64,
+    pub name: Vec<u8>,
+    pub op: DentryOp,
+    pub ino: Option<i64>,
+    pub entry_type: Option<u8>,
+    pub sequence: u64,
+}
+
+impl DentryDelta {
+    pub fn put(
+        layer_id: LayerId,
+        parent_ino: i64,
+        name: Vec<u8>,
+        ino: i64,
+        entry_type: u8,
+        sequence: u64,
+    ) -> Self {
+        Self {
+            layer_id,
+            parent_ino,
+            name,
+            op: DentryOp::Put,
+            ino: Some(ino),
+            entry_type: Some(entry_type),
+            sequence,
+        }
+    }
+
+    pub fn whiteout(layer_id: LayerId, parent_ino: i64, name: Vec<u8>, sequence: u64) -> Self {
+        Self {
+            layer_id,
+            parent_ino,
+            name,
+            op: DentryOp::Whiteout,
+            ino: None,
+            entry_type: None,
+            sequence,
+        }
+    }
+
+    pub fn validate(&self) -> Result<(), WorkspaceError> {
+        if self.name.is_empty() {
+            return Err(WorkspaceError::CorruptMetadata(
+                "dentry name must not be empty".into(),
+            ));
+        }
+        match self.op {
+            DentryOp::Put if self.ino.is_some() && self.entry_type.is_some() => Ok(()),
+            DentryOp::Whiteout if self.ino.is_none() && self.entry_type.is_none() => Ok(()),
+            _ => Err(WorkspaceError::CorruptMetadata(
+                "dentry op/payload mismatch".into(),
+            )),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct InodeDelta {
+    pub layer_id: LayerId,
+    pub ino: i64,
+    pub state: InodeState,
+    pub kind: u8,
+    pub size: u64,
+    pub mode: u32,
+    pub uid: u32,
+    pub gid: u32,
+    pub rdev: u32,
+    pub nlink: u32,
+    pub atime_ns: i64,
+    pub mtime_ns: i64,
+    pub ctime_ns: i64,
+    pub symlink_target: Option<Vec<u8>>,
+    pub parent_hint: Option<i64>,
+    pub data_version: u64,
+    pub sequence: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct XattrDelta {
+    pub layer_id: LayerId,
+    pub ino: i64,
+    pub name: Vec<u8>,
+    pub op: ValueOp,
+    pub value: Option<Vec<u8>>,
+    pub sequence: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct AclDelta {
+    pub layer_id: LayerId,
+    pub ino: i64,
+    pub acl_type: u8,
+    pub acl_id: i64,
+    pub op: ValueOp,
+    pub value: Option<Vec<u8>>,
+    pub sequence: u64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum ExtentKind {
+    Data { slice_id: u64, slice_offset: u64 },
+    Hole,
+}
+
+impl ExtentKind {
+    pub const fn discriminant(self) -> u8 {
+        match self {
+            Self::Data { .. } => 0,
+            Self::Hole => 1,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct LayerExtent {
+    pub layer_id: LayerId,
+    pub logical_offset: u64,
+    pub length: u64,
+    pub sequence: u64,
+    pub kind: ExtentKind,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct DataExtentDelta {
+    pub layer_id: LayerId,
+    pub ino: i64,
+    pub chunk_index: u64,
+    pub logical_offset: u64,
+    pub length: u64,
+    pub kind: ExtentKind,
+    pub sequence: u64,
+}
+
+impl DataExtentDelta {
+    #[allow(clippy::too_many_arguments)]
+    pub fn data(
+        layer_id: LayerId,
+        ino: i64,
+        chunk_index: u64,
+        logical_offset: u64,
+        length: u64,
+        slice_id: u64,
+        slice_offset: u64,
+        sequence: u64,
+    ) -> Self {
+        Self {
+            layer_id,
+            ino,
+            chunk_index,
+            logical_offset,
+            length,
+            kind: ExtentKind::Data {
+                slice_id,
+                slice_offset,
+            },
+            sequence,
+        }
+    }
+
+    pub fn hole(
+        layer_id: LayerId,
+        ino: i64,
+        chunk_index: u64,
+        logical_offset: u64,
+        length: u64,
+        sequence: u64,
+    ) -> Self {
+        Self {
+            layer_id,
+            ino,
+            chunk_index,
+            logical_offset,
+            length,
+            kind: ExtentKind::Hole,
+            sequence,
+        }
+    }
+
+    pub fn as_layer_extent(&self) -> LayerExtent {
+        LayerExtent {
+            layer_id: self.layer_id,
+            logical_offset: self.logical_offset,
+            length: self.length,
+            sequence: self.sequence,
+            kind: self.kind,
+        }
+    }
+
+    pub fn validate(&self) -> Result<(), WorkspaceError> {
+        if self.length == 0 {
+            return Err(WorkspaceError::CorruptMetadata(
+                "zero-length data extent".into(),
+            ));
+        }
+        self.logical_offset
+            .checked_add(self.length)
+            .ok_or_else(|| {
+                WorkspaceError::CorruptMetadata("data extent logical range overflows".into())
+            })?;
+        if let ExtentKind::Data { slice_offset, .. } = self.kind {
+            slice_offset.checked_add(self.length).ok_or_else(|| {
+                WorkspaceError::CorruptMetadata("data extent slice range overflows".into())
+            })?;
+        }
+        Ok(())
+    }
+}

--- a/src/workspace_overlay/publish/diff.rs
+++ b/src/workspace_overlay/publish/diff.rs
@@ -1,0 +1,390 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::ops::Range;
+use std::sync::Arc;
+
+use serde::Serialize;
+
+use super::super::catalog::WorkspaceStore;
+use super::super::error::WorkspaceError;
+use super::super::ids::LayerId;
+use super::super::metrics::{WorkspaceMetrics, global_workspace_metrics};
+use super::super::model::{BaseRevision, LayerRecord};
+use super::super::resolver::{resolve_dentry, resolve_inode};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+pub enum PathChangeKind {
+    Added,
+    Modified,
+    Deleted,
+    Renamed,
+    MetadataOnly,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct PathChange {
+    pub path: Vec<u8>,
+    pub kind: PathChangeKind,
+    pub old_path: Option<Vec<u8>>,
+    pub ino: Option<i64>,
+    pub changed_ranges: Vec<Range<u64>>,
+}
+
+pub struct WorkspaceDiff<W> {
+    store: Arc<W>,
+    chunk_size: u64,
+    metrics: Arc<WorkspaceMetrics>,
+}
+
+impl<W: WorkspaceStore + 'static> WorkspaceDiff<W> {
+    pub fn new(store: Arc<W>, chunk_size: u64) -> Self {
+        Self {
+            store,
+            chunk_size,
+            metrics: global_workspace_metrics(),
+        }
+    }
+
+    pub async fn diff(
+        &self,
+        base: &BaseRevision,
+        current_head: LayerId,
+    ) -> Result<Vec<PathChange>, WorkspaceError> {
+        let base_layer = self.store.load_layer(base.layer_id).await?;
+        if base_layer.sealed_version != Some(base.sealed_version)
+            || base_layer.root_hash != Some(base.root_hash)
+        {
+            return Err(WorkspaceError::Conflict(
+                super::super::error::ConflictDetail {
+                    path: Vec::new(),
+                    reason: "diff base revision changed".into(),
+                },
+            ));
+        }
+        let current_chain = self.store.load_layer_chain(current_head).await?;
+        let base_index = current_chain
+            .iter()
+            .position(|layer| layer.layer_id == base.layer_id)
+            .ok_or_else(|| {
+                WorkspaceError::Conflict(super::super::error::ConflictDetail {
+                    path: Vec::new(),
+                    reason: "base revision is not an ancestor of current head".into(),
+                })
+            })?;
+        let base_chain = self.store.load_layer_chain(base.layer_id).await?;
+        let current_deltas = self.load_deltas(&current_chain).await?;
+        let base_deltas = self.load_deltas(&base_chain).await?;
+        let old_paths = materialize_paths(&base_chain, &base_deltas)?;
+        let new_paths = materialize_paths(&current_chain, &current_deltas)?;
+
+        let changed_layers: BTreeSet<_> = current_chain[..base_index]
+            .iter()
+            .map(|layer| layer.layer_id)
+            .collect();
+        let mut changed_inodes = BTreeSet::new();
+        let mut data_changed = BTreeSet::new();
+        let mut changed_ranges: BTreeMap<i64, Vec<Range<u64>>> = BTreeMap::new();
+        for delta in current_deltas.values() {
+            for inode in &delta.inodes {
+                if changed_layers.contains(&inode.layer_id) {
+                    changed_inodes.insert(inode.ino);
+                }
+            }
+            for xattr in &delta.xattrs {
+                if changed_layers.contains(&xattr.layer_id) {
+                    changed_inodes.insert(xattr.ino);
+                }
+            }
+            for acl in &delta.acls {
+                if changed_layers.contains(&acl.layer_id) {
+                    changed_inodes.insert(acl.ino);
+                }
+            }
+            for extent in &delta.extents {
+                if changed_layers.contains(&extent.layer_id) {
+                    changed_inodes.insert(extent.ino);
+                    data_changed.insert(extent.ino);
+                    let start = extent
+                        .chunk_index
+                        .checked_mul(self.chunk_size)
+                        .and_then(|value| value.checked_add(extent.logical_offset))
+                        .ok_or_else(|| {
+                            WorkspaceError::CorruptMetadata("diff range overflows".into())
+                        })?;
+                    let end = start.checked_add(extent.length).ok_or_else(|| {
+                        WorkspaceError::CorruptMetadata("diff range overflows".into())
+                    })?;
+                    changed_ranges
+                        .entry(extent.ino)
+                        .or_default()
+                        .push(start..end);
+                }
+            }
+            for dentry in &delta.dentries {
+                if changed_layers.contains(&dentry.layer_id)
+                    && let Some(ino) = dentry.ino
+                {
+                    changed_inodes.insert(ino);
+                }
+            }
+        }
+        for ranges in changed_ranges.values_mut() {
+            *ranges = merge_ranges(std::mem::take(ranges));
+        }
+
+        let mut changes = BTreeMap::<Vec<u8>, PathChange>::new();
+        for ino in changed_inodes {
+            let old = old_paths.get(&ino).cloned().unwrap_or_default();
+            let new = new_paths.get(&ino).cloned().unwrap_or_default();
+            let removed = old.difference(&new).cloned().collect::<Vec<_>>();
+            let added = new.difference(&old).cloned().collect::<Vec<_>>();
+            let ranges = changed_ranges.get(&ino).cloned().unwrap_or_default();
+            if removed.len() == 1 && added.len() == 1 {
+                changes.insert(
+                    added[0].clone(),
+                    PathChange {
+                        path: added[0].clone(),
+                        kind: PathChangeKind::Renamed,
+                        old_path: Some(removed[0].clone()),
+                        ino: Some(ino),
+                        changed_ranges: ranges.clone(),
+                    },
+                );
+            } else {
+                for path in removed {
+                    changes.insert(
+                        path.clone(),
+                        PathChange {
+                            path,
+                            kind: PathChangeKind::Deleted,
+                            old_path: None,
+                            ino: Some(ino),
+                            changed_ranges: Vec::new(),
+                        },
+                    );
+                }
+                for path in added {
+                    changes.insert(
+                        path.clone(),
+                        PathChange {
+                            path,
+                            kind: PathChangeKind::Added,
+                            old_path: None,
+                            ino: Some(ino),
+                            changed_ranges: ranges.clone(),
+                        },
+                    );
+                }
+            }
+            for path in old.intersection(&new) {
+                changes.entry(path.clone()).or_insert_with(|| PathChange {
+                    path: path.clone(),
+                    kind: if data_changed.contains(&ino) {
+                        PathChangeKind::Modified
+                    } else {
+                        PathChangeKind::MetadataOnly
+                    },
+                    old_path: None,
+                    ino: Some(ino),
+                    changed_ranges: ranges.clone(),
+                });
+            }
+        }
+        let changes = changes.into_values().collect::<Vec<_>>();
+        self.metrics.add_publish_changed_paths(changes.len() as u64);
+        Ok(changes)
+    }
+
+    async fn load_deltas(
+        &self,
+        chain: &[LayerRecord],
+    ) -> Result<BTreeMap<LayerId, super::super::digest::CanonicalLayerDelta>, WorkspaceError> {
+        let mut deltas = BTreeMap::new();
+        for layer in chain {
+            deltas.insert(
+                layer.layer_id,
+                self.store.load_layer_delta(layer.layer_id).await?,
+            );
+        }
+        Ok(deltas)
+    }
+}
+
+fn materialize_paths(
+    chain: &[LayerRecord],
+    deltas: &BTreeMap<LayerId, super::super::digest::CanonicalLayerDelta>,
+) -> Result<BTreeMap<i64, BTreeSet<Vec<u8>>>, WorkspaceError> {
+    let all_dentries = deltas
+        .values()
+        .flat_map(|delta| delta.dentries.iter().cloned())
+        .collect::<Vec<_>>();
+    let all_inodes = deltas
+        .values()
+        .flat_map(|delta| delta.inodes.iter().cloned())
+        .collect::<Vec<_>>();
+    let candidates = all_dentries
+        .iter()
+        .map(|dentry| (dentry.parent_ino, dentry.name.clone()))
+        .collect::<BTreeSet<_>>();
+    let mut edges = Vec::new();
+    for (parent, name) in candidates {
+        if let Some(entry) = resolve_dentry(chain, &all_dentries, parent, &name)? {
+            edges.push(entry);
+        }
+    }
+    let mut paths: BTreeMap<i64, BTreeSet<Vec<u8>>> = BTreeMap::new();
+    paths.entry(1).or_default().insert(b"/".to_vec());
+    let mut unresolved = edges;
+    for _ in 0..=unresolved.len() {
+        let mut progress = false;
+        let mut next = Vec::new();
+        for edge in unresolved {
+            let Some(parent_paths) = paths.get(&edge.parent_ino).cloned() else {
+                next.push(edge);
+                continue;
+            };
+            if resolve_inode(chain, &all_inodes, edge.ino)?.is_none() {
+                continue;
+            }
+            for parent_path in parent_paths {
+                let mut path = parent_path;
+                if path.as_slice() != b"/" {
+                    path.push(b'/');
+                }
+                path.extend_from_slice(&edge.name);
+                progress |= paths.entry(edge.ino).or_default().insert(path);
+            }
+        }
+        unresolved = next;
+        if !progress {
+            break;
+        }
+    }
+    Ok(paths)
+}
+
+fn merge_ranges(mut ranges: Vec<Range<u64>>) -> Vec<Range<u64>> {
+    ranges.sort_by_key(|range| range.start);
+    let mut merged: Vec<Range<u64>> = Vec::new();
+    for range in ranges {
+        if let Some(last) = merged.last_mut()
+            && range.start <= last.end
+        {
+            last.end = last.end.max(range.end);
+            continue;
+        }
+        merged.push(range);
+    }
+    merged
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::chunk::SliceDesc;
+    use crate::meta::MetaLayer;
+    use crate::workspace_overlay::catalog::{CreateVolumeRoot, WorkspaceStore};
+    use crate::workspace_overlay::ids::{LayerId, WorkspaceId};
+    use crate::workspace_overlay::lifecycle::{
+        DEFAULT_HEARTBEAT_INTERVAL, DEFAULT_LEASE_TTL, NoopDurableRemoteBarrier,
+        WorkspaceLifecycle, WorkspaceMountSession,
+    };
+    use crate::workspace_overlay::meta_layer::WorkspaceMetaLayer;
+    use crate::workspace_overlay::model::ViewContext;
+    use crate::workspace_overlay::stores::database::SqliteWorkspaceStore;
+
+    #[tokio::test]
+    async fn diff_detects_rename_metadata_and_changed_data_ranges() {
+        let store = Arc::new(
+            SqliteWorkspaceStore::connect("sqlite::memory:")
+                .await
+                .unwrap(),
+        );
+        store.initialize_workspace_schema().await.unwrap();
+        let workspace_id = WorkspaceId::from_uuid(Uuid::from_u128(701));
+        store
+            .create_volume_root(CreateVolumeRoot {
+                volume_id: Uuid::from_u128(702),
+                workspace_id,
+                root_layer_id: LayerId::from_uuid(Uuid::from_u128(703)),
+                writable_layer_id: LayerId::from_uuid(Uuid::from_u128(704)),
+                owner_id: None,
+            })
+            .await
+            .unwrap();
+        let session = WorkspaceMountSession::acquire(
+            store.clone(),
+            workspace_id,
+            1,
+            DEFAULT_LEASE_TTL,
+            DEFAULT_HEARTBEAT_INTERVAL,
+        )
+        .await
+        .unwrap();
+        let meta = WorkspaceMetaLayer::new(store.clone(), session.view.clone());
+        let ino = meta
+            .create_file(meta.root_ino(), "old".into())
+            .await
+            .unwrap();
+        let chunk_id = crate::vfs::chunk_id_for(ino, 0).unwrap();
+        meta.write(
+            ino,
+            chunk_id,
+            SliceDesc {
+                slice_id: 1,
+                chunk_id,
+                offset: 0,
+                length: 8,
+            },
+            8,
+        )
+        .await
+        .unwrap();
+        let lifecycle = WorkspaceLifecycle::new(store.clone());
+        let sealed = lifecycle
+            .seal(&session.view, &NoopDurableRemoteBarrier)
+            .await
+            .unwrap();
+        meta.replace_view_context(ViewContext {
+            head_layer_id: sealed.new_head_layer_id,
+            head_epoch: sealed.head_epoch,
+            ..session.view.clone()
+        })
+        .await;
+        meta.rename(meta.root_ino(), "old", meta.root_ino(), "new".into())
+            .await
+            .unwrap();
+        meta.set_xattr(ino, "user.agent", b"changed", 0)
+            .await
+            .unwrap();
+        meta.write(
+            ino,
+            chunk_id,
+            SliceDesc {
+                slice_id: 2,
+                chunk_id,
+                offset: 4,
+                length: 2,
+            },
+            8,
+        )
+        .await
+        .unwrap();
+
+        let changes = WorkspaceDiff::new(store.clone(), crate::chunk::DEFAULT_CHUNK_SIZE)
+            .diff(&sealed.revision, sealed.new_head_layer_id)
+            .await
+            .unwrap();
+        let renamed = changes
+            .iter()
+            .find(|change| change.kind == PathChangeKind::Renamed)
+            .unwrap();
+        assert_eq!(renamed.path, b"/new");
+        assert_eq!(renamed.old_path.as_deref(), Some(b"/old".as_slice()));
+        assert_eq!(renamed.changed_ranges, vec![4..6]);
+        session.release().await.unwrap();
+    }
+}

--- a/src/workspace_overlay/publish/mod.rs
+++ b/src/workspace_overlay/publish/mod.rs
@@ -1,0 +1,3 @@
+pub mod diff;
+
+pub use diff::{PathChange, PathChangeKind, WorkspaceDiff};

--- a/src/workspace_overlay/resolver/chain.rs
+++ b/src/workspace_overlay/resolver/chain.rs
@@ -1,0 +1,89 @@
+use std::collections::HashSet;
+
+use crate::workspace_overlay::error::WorkspaceError;
+use crate::workspace_overlay::ids::LayerId;
+use crate::workspace_overlay::model::{
+    LAYER_CHAIN_HARD_LIMIT, LayerRecord, LayerState, WORKSPACE_SCHEMA_VERSION,
+};
+
+pub fn validate_layer_chain(
+    expected_head: LayerId,
+    chain: &[LayerRecord],
+) -> Result<(), WorkspaceError> {
+    if chain.is_empty() {
+        return Err(WorkspaceError::LayerNotFound(expected_head));
+    }
+    if chain.len() > LAYER_CHAIN_HARD_LIMIT as usize {
+        return Err(WorkspaceError::LayerDepthLimit {
+            depth: chain.len() as u32,
+            hard_limit: LAYER_CHAIN_HARD_LIMIT,
+        });
+    }
+    if chain[0].layer_id != expected_head {
+        return Err(WorkspaceError::CorruptMetadata(format!(
+            "chain starts at {}, expected {expected_head}",
+            chain[0].layer_id
+        )));
+    }
+    if !matches!(chain[0].state, LayerState::Writable | LayerState::Sealed) {
+        return Err(WorkspaceError::CorruptMetadata(format!(
+            "head layer {} is not resolvable in state {:?}",
+            chain[0].layer_id, chain[0].state
+        )));
+    }
+
+    let mut seen = HashSet::with_capacity(chain.len());
+    for (index, layer) in chain.iter().enumerate() {
+        if !seen.insert(layer.layer_id) {
+            return Err(WorkspaceError::CorruptMetadata(format!(
+                "layer chain contains cycle at {}",
+                layer.layer_id
+            )));
+        }
+        if layer.schema_version != WORKSPACE_SCHEMA_VERSION {
+            return Err(WorkspaceError::UnsupportedSchemaVersion(
+                layer.schema_version,
+            ));
+        }
+        let expected_depth = (chain.len() - index) as u32;
+        if layer.depth != expected_depth {
+            return Err(WorkspaceError::CorruptMetadata(format!(
+                "layer {} has depth {}, expected {expected_depth}",
+                layer.layer_id, layer.depth
+            )));
+        }
+        if index > 0 && layer.state != LayerState::Sealed {
+            return Err(WorkspaceError::CorruptMetadata(format!(
+                "non-head layer {} is not sealed",
+                layer.layer_id
+            )));
+        }
+        if layer.state == LayerState::Sealed
+            && (layer.sealed_version.is_none()
+                || layer.delta_digest.is_none()
+                || layer.root_hash.is_none())
+        {
+            return Err(WorkspaceError::CorruptMetadata(format!(
+                "sealed layer {} is missing immutable revision fields",
+                layer.layer_id
+            )));
+        }
+        match chain.get(index + 1) {
+            Some(parent) if layer.parent_layer_id == Some(parent.layer_id) => {}
+            Some(parent) => {
+                return Err(WorkspaceError::CorruptMetadata(format!(
+                    "layer {} points to {:?}, expected parent {}",
+                    layer.layer_id, layer.parent_layer_id, parent.layer_id
+                )));
+            }
+            None if layer.parent_layer_id.is_none() => {}
+            None => {
+                return Err(WorkspaceError::CorruptMetadata(format!(
+                    "root layer {} has a parent",
+                    layer.layer_id
+                )));
+            }
+        }
+    }
+    Ok(())
+}

--- a/src/workspace_overlay/resolver/dentry.rs
+++ b/src/workspace_overlay/resolver/dentry.rs
@@ -1,0 +1,102 @@
+use std::collections::BTreeMap;
+
+use crate::workspace_overlay::error::WorkspaceError;
+use crate::workspace_overlay::ids::LayerId;
+use crate::workspace_overlay::model::{DentryDelta, DentryOp, LayerRecord};
+
+use super::validate_layer_chain;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ResolvedDentry {
+    pub layer_id: LayerId,
+    pub parent_ino: i64,
+    pub name: Vec<u8>,
+    pub ino: i64,
+    pub entry_type: u8,
+    pub sequence: u64,
+}
+
+fn newest_in_layer<'a>(
+    deltas: impl Iterator<Item = &'a DentryDelta>,
+) -> Result<Option<&'a DentryDelta>, WorkspaceError> {
+    let mut winner: Option<&DentryDelta> = None;
+    for delta in deltas {
+        delta.validate()?;
+        if winner.is_none_or(|current| delta.sequence > current.sequence) {
+            winner = Some(delta);
+        }
+    }
+    Ok(winner)
+}
+
+fn materialize(delta: &DentryDelta) -> Result<Option<ResolvedDentry>, WorkspaceError> {
+    match delta.op {
+        DentryOp::Whiteout => Ok(None),
+        DentryOp::Put => Ok(Some(ResolvedDentry {
+            layer_id: delta.layer_id,
+            parent_ino: delta.parent_ino,
+            name: delta.name.clone(),
+            ino: delta.ino.ok_or_else(|| {
+                WorkspaceError::CorruptMetadata("put dentry without inode".into())
+            })?,
+            entry_type: delta.entry_type.ok_or_else(|| {
+                WorkspaceError::CorruptMetadata("put dentry without entry type".into())
+            })?,
+            sequence: delta.sequence,
+        })),
+    }
+}
+
+pub fn resolve_dentry(
+    chain: &[LayerRecord],
+    deltas: &[DentryDelta],
+    parent_ino: i64,
+    name: &[u8],
+) -> Result<Option<ResolvedDentry>, WorkspaceError> {
+    let head = chain
+        .first()
+        .ok_or_else(|| WorkspaceError::CorruptMetadata("empty layer chain".into()))?;
+    validate_layer_chain(head.layer_id, chain)?;
+    for layer in chain {
+        let winner = newest_in_layer(deltas.iter().filter(|delta| {
+            delta.layer_id == layer.layer_id && delta.parent_ino == parent_ino && delta.name == name
+        }))?;
+        if let Some(winner) = winner {
+            return materialize(winner);
+        }
+    }
+    Ok(None)
+}
+
+pub fn resolve_directory(
+    chain: &[LayerRecord],
+    deltas: &[DentryDelta],
+    parent_ino: i64,
+) -> Result<Vec<ResolvedDentry>, WorkspaceError> {
+    let head = chain
+        .first()
+        .ok_or_else(|| WorkspaceError::CorruptMetadata("empty layer chain".into()))?;
+    validate_layer_chain(head.layer_id, chain)?;
+    let mut winners: BTreeMap<Vec<u8>, Option<ResolvedDentry>> = BTreeMap::new();
+    for layer in chain {
+        let mut layer_rows: BTreeMap<Vec<u8>, &DentryDelta> = BTreeMap::new();
+        for delta in deltas
+            .iter()
+            .filter(|delta| delta.layer_id == layer.layer_id && delta.parent_ino == parent_ino)
+        {
+            delta.validate()?;
+            let replace = layer_rows
+                .get(&delta.name)
+                .is_none_or(|current| delta.sequence > current.sequence);
+            if replace {
+                layer_rows.insert(delta.name.clone(), delta);
+            }
+        }
+        for (name, delta) in layer_rows {
+            if let std::collections::btree_map::Entry::Vacant(entry) = winners.entry(name) {
+                entry.insert(materialize(delta)?);
+            }
+        }
+    }
+    Ok(winners.into_values().flatten().collect())
+}

--- a/src/workspace_overlay/resolver/extent.rs
+++ b/src/workspace_overlay/resolver/extent.rs
@@ -1,0 +1,183 @@
+use std::collections::HashSet;
+use std::ops::Range;
+
+use crate::workspace_overlay::error::WorkspaceError;
+use crate::workspace_overlay::model::{DataExtentDelta, ExtentKind, LayerRecord};
+
+use super::validate_layer_chain;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ResolvedExtent {
+    pub logical_offset: u64,
+    pub length: u64,
+    pub kind: ExtentKind,
+}
+
+impl ResolvedExtent {
+    fn end(&self) -> Result<u64, WorkspaceError> {
+        self.logical_offset.checked_add(self.length).ok_or_else(|| {
+            WorkspaceError::CorruptMetadata("resolved extent range overflows".into())
+        })
+    }
+}
+
+pub fn resolve_extents(
+    chain: &[LayerRecord],
+    deltas: &[DataExtentDelta],
+    ino: i64,
+    chunk_index: u64,
+    requested: Range<u64>,
+) -> Result<Vec<ResolvedExtent>, WorkspaceError> {
+    let head = chain
+        .first()
+        .ok_or_else(|| WorkspaceError::CorruptMetadata("empty layer chain".into()))?;
+    validate_layer_chain(head.layer_id, chain)?;
+    if requested.start > requested.end {
+        return Err(WorkspaceError::InvalidReadPlan(
+            "requested range starts after its end".into(),
+        ));
+    }
+    if requested.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let chain_ids: HashSet<_> = chain.iter().map(|layer| layer.layer_id).collect();
+    for delta in deltas.iter().filter(|delta| {
+        chain_ids.contains(&delta.layer_id) && delta.ino == ino && delta.chunk_index == chunk_index
+    }) {
+        delta.validate()?;
+    }
+
+    let mut uncovered = vec![requested.clone()];
+    let mut resolved = Vec::new();
+    for layer in chain {
+        let mut layer_extents = deltas
+            .iter()
+            .filter(|delta| {
+                delta.layer_id == layer.layer_id
+                    && delta.ino == ino
+                    && delta.chunk_index == chunk_index
+            })
+            .collect::<Vec<_>>();
+        layer_extents.sort_by_key(|extent| std::cmp::Reverse(extent.sequence));
+
+        let mut sequences = HashSet::with_capacity(layer_extents.len());
+        for extent in layer_extents {
+            if !sequences.insert(extent.sequence) {
+                return Err(WorkspaceError::CorruptMetadata(format!(
+                    "duplicate extent sequence {} in layer {}",
+                    extent.sequence, extent.layer_id
+                )));
+            }
+            if uncovered.is_empty() {
+                break;
+            }
+            let extent_end = extent
+                .logical_offset
+                .checked_add(extent.length)
+                .ok_or_else(|| {
+                    WorkspaceError::CorruptMetadata("data extent logical range overflows".into())
+                })?;
+            let extent_range = extent.logical_offset..extent_end;
+            let mut remaining = Vec::with_capacity(uncovered.len() + 1);
+            for gap in uncovered {
+                let start = gap.start.max(extent_range.start);
+                let end = gap.end.min(extent_range.end);
+                if start >= end {
+                    remaining.push(gap);
+                    continue;
+                }
+                if gap.start < start {
+                    remaining.push(gap.start..start);
+                }
+                if end < gap.end {
+                    remaining.push(end..gap.end);
+                }
+
+                let kind = match extent.kind {
+                    ExtentKind::Data {
+                        slice_id,
+                        slice_offset,
+                    } => {
+                        let clipped =
+                            start.checked_sub(extent.logical_offset).ok_or_else(|| {
+                                WorkspaceError::CorruptMetadata(
+                                    "extent intersection precedes logical start".into(),
+                                )
+                            })?;
+                        ExtentKind::Data {
+                            slice_id,
+                            slice_offset: slice_offset.checked_add(clipped).ok_or_else(|| {
+                                WorkspaceError::CorruptMetadata(
+                                    "resolved slice offset overflows".into(),
+                                )
+                            })?,
+                        }
+                    }
+                    ExtentKind::Hole => ExtentKind::Hole,
+                };
+                resolved.push(ResolvedExtent {
+                    logical_offset: start,
+                    length: end - start,
+                    kind,
+                });
+            }
+            uncovered = remaining;
+        }
+    }
+
+    resolved.extend(uncovered.into_iter().map(|gap| ResolvedExtent {
+        logical_offset: gap.start,
+        length: gap.end - gap.start,
+        kind: ExtentKind::Hole,
+    }));
+    resolved.sort_by_key(|extent| extent.logical_offset);
+    merge_adjacent(resolved)
+}
+
+fn merge_adjacent(extents: Vec<ResolvedExtent>) -> Result<Vec<ResolvedExtent>, WorkspaceError> {
+    let mut merged: Vec<ResolvedExtent> = Vec::with_capacity(extents.len());
+    for extent in extents {
+        if extent.length == 0 {
+            return Err(WorkspaceError::CorruptMetadata(
+                "resolver emitted a zero-length extent".into(),
+            ));
+        }
+        if let Some(previous) = merged.last_mut() {
+            let previous_end = previous.end()?;
+            if extent.logical_offset < previous_end {
+                return Err(WorkspaceError::InvalidReadPlan(
+                    "resolved extents overlap".into(),
+                ));
+            }
+            let can_merge = previous_end == extent.logical_offset
+                && match (previous.kind, extent.kind) {
+                    (ExtentKind::Hole, ExtentKind::Hole) => true,
+                    (
+                        ExtentKind::Data {
+                            slice_id: left_id,
+                            slice_offset: left_offset,
+                        },
+                        ExtentKind::Data {
+                            slice_id: right_id,
+                            slice_offset: right_offset,
+                        },
+                    ) => {
+                        left_id == right_id
+                            && left_offset
+                                .checked_add(previous.length)
+                                .is_some_and(|end| end == right_offset)
+                    }
+                    _ => false,
+                };
+            if can_merge {
+                previous.length = previous.length.checked_add(extent.length).ok_or_else(|| {
+                    WorkspaceError::CorruptMetadata("merged extent length overflows".into())
+                })?;
+                continue;
+            }
+        }
+        merged.push(extent);
+    }
+    Ok(merged)
+}

--- a/src/workspace_overlay/resolver/inode.rs
+++ b/src/workspace_overlay/resolver/inode.rs
@@ -1,0 +1,38 @@
+use crate::workspace_overlay::error::WorkspaceError;
+use crate::workspace_overlay::ids::LayerId;
+use crate::workspace_overlay::model::{InodeDelta, InodeState, LayerRecord};
+
+use super::validate_layer_chain;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ResolvedInode {
+    pub layer_id: LayerId,
+    pub inode: InodeDelta,
+}
+
+pub fn resolve_inode(
+    chain: &[LayerRecord],
+    deltas: &[InodeDelta],
+    ino: i64,
+) -> Result<Option<ResolvedInode>, WorkspaceError> {
+    let head = chain
+        .first()
+        .ok_or_else(|| WorkspaceError::CorruptMetadata("empty layer chain".into()))?;
+    validate_layer_chain(head.layer_id, chain)?;
+    for layer in chain {
+        let winner = deltas
+            .iter()
+            .filter(|delta| delta.layer_id == layer.layer_id && delta.ino == ino)
+            .max_by_key(|delta| delta.sequence);
+        if let Some(winner) = winner {
+            return match winner.state {
+                InodeState::Deleted => Ok(None),
+                InodeState::Present => Ok(Some(ResolvedInode {
+                    layer_id: layer.layer_id,
+                    inode: winner.clone(),
+                })),
+            };
+        }
+    }
+    Ok(None)
+}

--- a/src/workspace_overlay/resolver/mod.rs
+++ b/src/workspace_overlay/resolver/mod.rs
@@ -1,0 +1,11 @@
+mod chain;
+mod dentry;
+mod extent;
+mod inode;
+mod xattr;
+
+pub use chain::validate_layer_chain;
+pub use dentry::{ResolvedDentry, resolve_dentry, resolve_directory};
+pub use extent::{ResolvedExtent, resolve_extents};
+pub use inode::{ResolvedInode, resolve_inode};
+pub use xattr::{ResolvedAcl, ResolvedXattr, resolve_acl, resolve_xattr};

--- a/src/workspace_overlay/resolver/xattr.rs
+++ b/src/workspace_overlay/resolver/xattr.rs
@@ -1,0 +1,93 @@
+use crate::workspace_overlay::error::WorkspaceError;
+use crate::workspace_overlay::ids::LayerId;
+use crate::workspace_overlay::model::{AclDelta, LayerRecord, ValueOp, XattrDelta};
+
+use super::validate_layer_chain;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ResolvedXattr {
+    pub layer_id: LayerId,
+    pub value: Vec<u8>,
+    pub sequence: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ResolvedAcl {
+    pub layer_id: LayerId,
+    pub value: Vec<u8>,
+    pub sequence: u64,
+}
+
+pub fn resolve_xattr(
+    chain: &[LayerRecord],
+    deltas: &[XattrDelta],
+    ino: i64,
+    name: &[u8],
+) -> Result<Option<ResolvedXattr>, WorkspaceError> {
+    let head = chain
+        .first()
+        .ok_or_else(|| WorkspaceError::CorruptMetadata("empty layer chain".into()))?;
+    validate_layer_chain(head.layer_id, chain)?;
+    for layer in chain {
+        let winner = deltas
+            .iter()
+            .filter(|delta| {
+                delta.layer_id == layer.layer_id && delta.ino == ino && delta.name == name
+            })
+            .max_by_key(|delta| delta.sequence);
+        if let Some(winner) = winner {
+            return resolve_value(winner.op, winner.value.as_ref()).map(|value| {
+                value.map(|value| ResolvedXattr {
+                    layer_id: layer.layer_id,
+                    value: value.clone(),
+                    sequence: winner.sequence,
+                })
+            });
+        }
+    }
+    Ok(None)
+}
+
+pub fn resolve_acl(
+    chain: &[LayerRecord],
+    deltas: &[AclDelta],
+    ino: i64,
+    acl_type: u8,
+    acl_id: i64,
+) -> Result<Option<ResolvedAcl>, WorkspaceError> {
+    let head = chain
+        .first()
+        .ok_or_else(|| WorkspaceError::CorruptMetadata("empty layer chain".into()))?;
+    validate_layer_chain(head.layer_id, chain)?;
+    for layer in chain {
+        let winner = deltas
+            .iter()
+            .filter(|delta| {
+                delta.layer_id == layer.layer_id
+                    && delta.ino == ino
+                    && delta.acl_type == acl_type
+                    && delta.acl_id == acl_id
+            })
+            .max_by_key(|delta| delta.sequence);
+        if let Some(winner) = winner {
+            return resolve_value(winner.op, winner.value.as_ref()).map(|value| {
+                value.map(|value| ResolvedAcl {
+                    layer_id: layer.layer_id,
+                    value: value.clone(),
+                    sequence: winner.sequence,
+                })
+            });
+        }
+    }
+    Ok(None)
+}
+
+fn resolve_value(op: ValueOp, value: Option<&Vec<u8>>) -> Result<Option<&Vec<u8>>, WorkspaceError> {
+    match (op, value) {
+        (ValueOp::Put, Some(value)) => Ok(Some(value)),
+        (ValueOp::Whiteout, None) => Ok(None),
+        _ => Err(WorkspaceError::CorruptMetadata(
+            "value op/payload mismatch".into(),
+        )),
+    }
+}

--- a/src/workspace_overlay/stores/database.rs
+++ b/src/workspace_overlay/stores/database.rs
@@ -1,0 +1,3285 @@
+//! SQLite implementation of the workspace catalog.
+
+use std::collections::BTreeSet;
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+#[cfg(test)]
+use std::sync::atomic::{AtomicU8, Ordering};
+
+use async_trait::async_trait;
+use sea_orm::sqlx::sqlite::{
+    SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteRow,
+};
+use sea_orm::sqlx::{Row, Sqlite, SqlitePool, Transaction};
+use tokio::sync::Mutex;
+use uuid::Uuid;
+
+use crate::workspace_overlay::catalog::{
+    AbortSeal, AclMutation, AclQuery, AcquireLease, AdvanceSeal, AppendDataExtent, BeginSeal,
+    CompactionResult, CreateSnapshot, CreateVolumeRoot, CreateWorkspace, DataMutation,
+    DataMutationResult, DeleteLayerMetadata, DentryQuery, ExtentQuery, FastForwardCommit,
+    GcSnapshot, HeadGuard, InodeMutation, InodeQuery, InstallCompaction, MarkDeleting,
+    MutationResult, NamespaceMutation, RecordOrphanSlice, ReleaseLease, RenewLease, SliceReference,
+    WorkspaceStore, WorkspaceStoreCapabilities, XattrMutation, XattrQuery,
+};
+use crate::workspace_overlay::digest::{CanonicalLayerDelta, delta_digest, root_hash};
+use crate::workspace_overlay::error::WorkspaceError;
+use crate::workspace_overlay::ids::{JournalId, LayerId, SnapshotId, WorkspaceId};
+use crate::workspace_overlay::model::{
+    AclDelta, BaseRevision, CommitResult, DataExtentDelta, DentryDelta, DentryOp, ExtentKind,
+    InodeDelta, InodeState, LayerRecord, LayerState, LeaseState, SealJournal, SealPhase,
+    SealResult, SnapshotLease, SnapshotRecord, ValueOp, VolumeHeader, WORKSPACE_SCHEMA_VERSION,
+    WorkspaceRecord, WorkspaceState, XattrDelta,
+};
+use crate::workspace_overlay::resolver::validate_layer_chain;
+
+const VOLUME_FORMAT: &str = "workspace-v1";
+
+const SCHEMA: &str = r#"
+CREATE TABLE IF NOT EXISTS ws_v1_volume_header (
+    singleton_id INTEGER PRIMARY KEY CHECK(singleton_id = 1),
+    volume_format TEXT NOT NULL,
+    schema_version INTEGER NOT NULL,
+    volume_id BLOB NOT NULL,
+    created_at_ns INTEGER NOT NULL
+);
+CREATE TABLE IF NOT EXISTS ws_v1_workspaces (
+    workspace_id BLOB PRIMARY KEY,
+    head_layer_id BLOB NOT NULL,
+    head_epoch INTEGER NOT NULL,
+    fork_base_layer_id BLOB,
+    fork_base_version INTEGER,
+    fork_base_root_hash BLOB,
+    owner_id TEXT,
+    state INTEGER NOT NULL,
+    created_at_ns INTEGER NOT NULL,
+    updated_at_ns INTEGER NOT NULL
+);
+CREATE TABLE IF NOT EXISTS ws_v1_layers (
+    layer_id BLOB PRIMARY KEY,
+    parent_layer_id BLOB,
+    state INTEGER NOT NULL,
+    schema_version INTEGER NOT NULL,
+    sealed_version INTEGER,
+    delta_digest BLOB,
+    root_hash BLOB,
+    depth INTEGER NOT NULL,
+    owner_workspace_id BLOB,
+    next_sequence INTEGER NOT NULL,
+    owned_slice_count INTEGER NOT NULL DEFAULT 0,
+    owned_bytes INTEGER NOT NULL DEFAULT 0,
+    created_at_ns INTEGER NOT NULL,
+    sealed_at_ns INTEGER
+);
+CREATE INDEX IF NOT EXISTS ws_v1_layers_parent_idx ON ws_v1_layers(parent_layer_id);
+CREATE TABLE IF NOT EXISTS ws_v1_dentry_delta (
+    layer_id BLOB NOT NULL,
+    parent_ino INTEGER NOT NULL,
+    name BLOB NOT NULL,
+    op INTEGER NOT NULL,
+    ino INTEGER,
+    entry_type INTEGER,
+    sequence INTEGER NOT NULL,
+    PRIMARY KEY(layer_id, parent_ino, name),
+    CHECK((op = 0 AND ino IS NOT NULL AND entry_type IS NOT NULL) OR
+          (op = 1 AND ino IS NULL AND entry_type IS NULL))
+);
+CREATE INDEX IF NOT EXISTS ws_v1_dentry_parent_idx
+    ON ws_v1_dentry_delta(layer_id, parent_ino);
+CREATE TABLE IF NOT EXISTS ws_v1_inode_delta (
+    layer_id BLOB NOT NULL,
+    ino INTEGER NOT NULL,
+    state INTEGER NOT NULL,
+    kind INTEGER NOT NULL,
+    size INTEGER NOT NULL,
+    mode INTEGER NOT NULL,
+    uid INTEGER NOT NULL,
+    gid INTEGER NOT NULL,
+    rdev INTEGER NOT NULL,
+    nlink INTEGER NOT NULL,
+    atime_ns INTEGER NOT NULL,
+    mtime_ns INTEGER NOT NULL,
+    ctime_ns INTEGER NOT NULL,
+    symlink_target BLOB,
+    parent_hint INTEGER,
+    data_version INTEGER NOT NULL,
+    sequence INTEGER NOT NULL,
+    PRIMARY KEY(layer_id, ino)
+);
+CREATE TABLE IF NOT EXISTS ws_v1_xattr_delta (
+    layer_id BLOB NOT NULL,
+    ino INTEGER NOT NULL,
+    name BLOB NOT NULL,
+    op INTEGER NOT NULL,
+    value BLOB,
+    sequence INTEGER NOT NULL,
+    PRIMARY KEY(layer_id, ino, name),
+    CHECK((op = 0 AND value IS NOT NULL) OR (op = 1 AND value IS NULL))
+);
+CREATE TABLE IF NOT EXISTS ws_v1_acl_delta (
+    layer_id BLOB NOT NULL,
+    ino INTEGER NOT NULL,
+    acl_type INTEGER NOT NULL,
+    acl_id INTEGER NOT NULL,
+    op INTEGER NOT NULL,
+    value BLOB,
+    sequence INTEGER NOT NULL,
+    PRIMARY KEY(layer_id, ino, acl_type, acl_id),
+    CHECK((op = 0 AND value IS NOT NULL) OR (op = 1 AND value IS NULL))
+);
+CREATE TABLE IF NOT EXISTS ws_v1_data_extent_delta (
+    layer_id BLOB NOT NULL,
+    ino INTEGER NOT NULL,
+    chunk_index INTEGER NOT NULL,
+    logical_offset INTEGER NOT NULL,
+    length INTEGER NOT NULL CHECK(length > 0),
+    kind INTEGER NOT NULL,
+    slice_id INTEGER,
+    slice_offset INTEGER,
+    sequence INTEGER NOT NULL,
+    PRIMARY KEY(layer_id, ino, chunk_index, sequence),
+    CHECK((kind = 0 AND slice_id IS NOT NULL AND slice_offset IS NOT NULL) OR
+          (kind = 1 AND slice_id IS NULL AND slice_offset IS NULL))
+);
+CREATE INDEX IF NOT EXISTS ws_v1_extent_lookup_idx
+    ON ws_v1_data_extent_delta(layer_id, ino, chunk_index, sequence);
+CREATE TABLE IF NOT EXISTS ws_v1_snapshot_leases (
+    lease_id BLOB PRIMARY KEY,
+    workspace_id BLOB NOT NULL,
+    base_layer_id BLOB NOT NULL,
+    base_version INTEGER NOT NULL,
+    base_root_hash BLOB NOT NULL,
+    holder_generation INTEGER NOT NULL,
+    writable INTEGER NOT NULL,
+    state INTEGER NOT NULL,
+    expires_at_ns INTEGER NOT NULL,
+    created_at_ns INTEGER NOT NULL,
+    updated_at_ns INTEGER NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS ws_v1_one_writer_idx
+    ON ws_v1_snapshot_leases(workspace_id) WHERE writable = 1 AND state = 0;
+CREATE TABLE IF NOT EXISTS ws_v1_snapshots (
+    snapshot_id BLOB PRIMARY KEY,
+    name TEXT,
+    layer_id BLOB NOT NULL,
+    sealed_version INTEGER NOT NULL,
+    root_hash BLOB NOT NULL,
+    owner_id TEXT,
+    created_at_ns INTEGER NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS ws_v1_snapshot_name_idx
+    ON ws_v1_snapshots(name) WHERE name IS NOT NULL;
+CREATE TABLE IF NOT EXISTS ws_v1_seal_journal (
+    journal_id BLOB PRIMARY KEY,
+    workspace_id BLOB NOT NULL,
+    old_head_layer_id BLOB NOT NULL,
+    expected_head_epoch INTEGER NOT NULL,
+    phase INTEGER NOT NULL,
+    pending_bytes INTEGER NOT NULL,
+    delta_digest BLOB,
+    root_hash BLOB,
+    new_head_layer_id BLOB,
+    last_error TEXT,
+    created_at_ns INTEGER NOT NULL,
+    updated_at_ns INTEGER NOT NULL
+);
+CREATE TABLE IF NOT EXISTS ws_v1_allocators (
+    name TEXT PRIMARY KEY,
+    next_value INTEGER NOT NULL
+);
+"#;
+
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u8)]
+pub enum StoreFailpoint {
+    Disabled = 0,
+    BeforeCommit = 1,
+}
+
+pub struct SqliteWorkspaceStore {
+    pool: SqlitePool,
+    write_gate: Arc<Mutex<()>>,
+    #[cfg(test)]
+    failpoint: AtomicU8,
+}
+
+impl SqliteWorkspaceStore {
+    pub async fn connect(url: &str) -> Result<Self, WorkspaceError> {
+        let is_memory = url.contains("::memory:");
+        let mut options = SqliteConnectOptions::from_str(url)
+            .map_err(backend)?
+            .create_if_missing(true)
+            .foreign_keys(true)
+            .busy_timeout(Duration::from_secs(30));
+        if !is_memory {
+            options = options.journal_mode(SqliteJournalMode::Wal);
+        }
+        let max_connections = if is_memory { 1 } else { 8 };
+        let pool = SqlitePoolOptions::new()
+            .min_connections(1)
+            .max_connections(max_connections)
+            .acquire_timeout(Duration::from_secs(30))
+            .connect_with(options)
+            .await
+            .map_err(backend)?;
+        Ok(Self {
+            pool,
+            write_gate: Arc::new(Mutex::new(())),
+            #[cfg(test)]
+            failpoint: AtomicU8::new(StoreFailpoint::Disabled as u8),
+        })
+    }
+
+    /// Start a write transaction while holding SQLite's reserved write lock.
+    ///
+    /// A deferred transaction can successfully read and then fail immediately
+    /// when it upgrades to a writer if another BrewFS process has modified the
+    /// shared catalog. `BEGIN IMMEDIATE` acquires that lock up front, so the
+    /// configured busy timeout can serialize writers across mount processes.
+    async fn begin_write(&self) -> Result<Transaction<'static, Sqlite>, WorkspaceError> {
+        self.pool
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .map_err(backend)
+    }
+
+    pub async fn schema_table_names(&self) -> Result<Vec<String>, WorkspaceError> {
+        let rows = sea_orm::sqlx::query(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name LIKE 'ws_v1_%' ORDER BY name",
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(backend)?;
+        rows.into_iter()
+            .map(|row| row.try_get("name").map_err(backend))
+            .collect()
+    }
+
+    #[cfg(test)]
+    pub fn set_failpoint(&self, failpoint: StoreFailpoint) {
+        self.failpoint.store(failpoint as u8, Ordering::SeqCst);
+    }
+
+    #[cfg(test)]
+    pub async fn journal_mode(&self) -> Result<String, WorkspaceError> {
+        sea_orm::sqlx::query_scalar("PRAGMA journal_mode")
+            .fetch_one(&self.pool)
+            .await
+            .map_err(backend)
+    }
+
+    async fn checked_guard(
+        tx: &mut Transaction<'_, Sqlite>,
+        guard: &HeadGuard,
+    ) -> Result<(), WorkspaceError> {
+        let now = now_ns()?;
+        let matched = sea_orm::sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM ws_v1_workspaces w
+             JOIN ws_v1_layers l ON l.layer_id = w.head_layer_id
+             JOIN ws_v1_snapshot_leases s ON s.workspace_id = w.workspace_id
+             WHERE w.workspace_id = ? AND w.state = ?
+               AND w.head_layer_id = ? AND w.head_epoch = ?
+               AND l.state = ? AND l.owner_workspace_id = w.workspace_id
+               AND s.lease_id = ? AND s.state = ? AND s.writable = 1
+               AND s.holder_generation = ? AND s.expires_at_ns > ?",
+        )
+        .bind(guard.workspace_id.as_bytes().as_slice())
+        .bind(WorkspaceState::Active.discriminant() as i64)
+        .bind(guard.expected_head_layer_id.as_bytes().as_slice())
+        .bind(to_i64(guard.expected_head_epoch, "head epoch")?)
+        .bind(LayerState::Writable.discriminant() as i64)
+        .bind(guard.lease_id.as_bytes().as_slice())
+        .bind(LeaseState::Active.discriminant() as i64)
+        .bind(to_i64(guard.holder_generation, "holder generation")?)
+        .bind(now)
+        .fetch_one(&mut **tx)
+        .await
+        .map_err(backend)?;
+        if matched != 1 {
+            return Err(WorkspaceError::Fenced);
+        }
+        Ok(())
+    }
+
+    async fn allocate_sequences(
+        tx: &mut Transaction<'_, Sqlite>,
+        layer_id: LayerId,
+        count: usize,
+    ) -> Result<Option<(u64, u64)>, WorkspaceError> {
+        if count == 0 {
+            return Ok(None);
+        }
+        let first = sea_orm::sqlx::query_scalar::<_, i64>(
+            "SELECT next_sequence FROM ws_v1_layers WHERE layer_id = ? AND state = ?",
+        )
+        .bind(layer_id.as_bytes().as_slice())
+        .bind(LayerState::Writable.discriminant() as i64)
+        .fetch_optional(&mut **tx)
+        .await
+        .map_err(backend)?
+        .ok_or(WorkspaceError::Fenced)?;
+        let first = to_u64(first, "next sequence")?;
+        let count = u64::try_from(count)
+            .map_err(|_| WorkspaceError::CorruptMetadata("mutation is too large".into()))?;
+        let next = first.checked_add(count).ok_or_else(|| {
+            WorkspaceError::CorruptMetadata("layer sequence allocator overflow".into())
+        })?;
+        let updated = sea_orm::sqlx::query(
+            "UPDATE ws_v1_layers SET next_sequence = ? WHERE layer_id = ? AND next_sequence = ?",
+        )
+        .bind(to_i64(next, "next sequence")?)
+        .bind(layer_id.as_bytes().as_slice())
+        .bind(to_i64(first, "first sequence")?)
+        .execute(&mut **tx)
+        .await
+        .map_err(backend)?;
+        if updated.rows_affected() != 1 {
+            return Err(WorkspaceError::Fenced);
+        }
+        Ok(Some((first, next - 1)))
+    }
+}
+
+#[async_trait]
+impl WorkspaceStore for SqliteWorkspaceStore {
+    fn name(&self) -> &'static str {
+        "workspace-sqlite"
+    }
+
+    fn capabilities(&self) -> WorkspaceStoreCapabilities {
+        WorkspaceStoreCapabilities {
+            atomic_head_switch: true,
+            durable_lease: true,
+            transactional_namespace_mutation: true,
+            transactional_rename: true,
+            watch_head_change: false,
+        }
+    }
+
+    async fn initialize_workspace_schema(&self) -> Result<(), WorkspaceError> {
+        let _guard = self.write_gate.lock().await;
+        sea_orm::sqlx::raw_sql(SCHEMA)
+            .execute(&self.pool)
+            .await
+            .map_err(backend)?;
+        Ok(())
+    }
+
+    async fn load_volume_header(&self) -> Result<Option<VolumeHeader>, WorkspaceError> {
+        let row = sea_orm::sqlx::query(
+            "SELECT volume_format, schema_version, volume_id, created_at_ns
+             FROM ws_v1_volume_header WHERE singleton_id = 1",
+        )
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(backend)?;
+        row.map(decode_volume_header).transpose()
+    }
+
+    async fn load_workspace(&self, id: WorkspaceId) -> Result<WorkspaceRecord, WorkspaceError> {
+        let row = sea_orm::sqlx::query(
+            "SELECT workspace_id, head_layer_id, head_epoch,
+                    fork_base_layer_id, fork_base_version, fork_base_root_hash,
+                    owner_id, state, created_at_ns, updated_at_ns
+             FROM ws_v1_workspaces WHERE workspace_id = ?",
+        )
+        .bind(id.as_bytes().as_slice())
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(backend)?
+        .ok_or(WorkspaceError::WorkspaceNotFound(id))?;
+        decode_workspace(&row)
+    }
+
+    async fn load_layer(&self, id: LayerId) -> Result<LayerRecord, WorkspaceError> {
+        let row = sea_orm::sqlx::query(
+            "SELECT layer_id, parent_layer_id, state, schema_version, sealed_version,
+                    delta_digest, root_hash, depth, owner_workspace_id, next_sequence,
+                    owned_slice_count, owned_bytes, created_at_ns, sealed_at_ns
+             FROM ws_v1_layers WHERE layer_id = ?",
+        )
+        .bind(id.as_bytes().as_slice())
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(backend)?
+        .ok_or(WorkspaceError::LayerNotFound(id))?;
+        decode_layer(&row)
+    }
+
+    async fn load_layer_chain(&self, head: LayerId) -> Result<Vec<LayerRecord>, WorkspaceError> {
+        let mut chain = Vec::new();
+        let mut current = Some(head);
+        while let Some(layer_id) = current {
+            if chain.len() > crate::workspace_overlay::model::LAYER_CHAIN_HARD_LIMIT as usize {
+                return Err(WorkspaceError::LayerDepthLimit {
+                    depth: chain.len() as u32,
+                    hard_limit: crate::workspace_overlay::model::LAYER_CHAIN_HARD_LIMIT,
+                });
+            }
+            let layer = self.load_layer(layer_id).await?;
+            current = layer.parent_layer_id;
+            chain.push(layer);
+        }
+        validate_layer_chain(head, &chain)?;
+        Ok(chain)
+    }
+
+    async fn allocate_id(&self, name: &str) -> Result<i64, WorkspaceError> {
+        if !matches!(name, "inode" | "slice" | "sealed_version") {
+            return Err(WorkspaceError::CorruptMetadata(format!(
+                "unknown workspace allocator {name}"
+            )));
+        }
+        let _guard = self.write_gate.lock().await;
+        sea_orm::sqlx::query_scalar::<_, i64>(
+            "UPDATE ws_v1_allocators SET next_value = next_value + 1
+             WHERE name = ? AND next_value < ? RETURNING next_value - 1",
+        )
+        .bind(name)
+        .bind(i64::MAX)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(backend)?
+        .ok_or_else(|| {
+            WorkspaceError::CorruptMetadata(format!(
+                "workspace allocator {name} is missing or exhausted"
+            ))
+        })
+    }
+
+    async fn create_volume_root(
+        &self,
+        request: CreateVolumeRoot,
+    ) -> Result<WorkspaceRecord, WorkspaceError> {
+        if request.root_layer_id == request.writable_layer_id {
+            return Err(WorkspaceError::CorruptMetadata(
+                "root and writable layer IDs must differ".into(),
+            ));
+        }
+        let _guard = self.write_gate.lock().await;
+        let mut tx = self.begin_write().await?;
+        let marker_exists = sea_orm::sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM ws_v1_volume_header WHERE singleton_id = 1",
+        )
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(backend)?;
+        if marker_exists != 0 {
+            return Err(WorkspaceError::InvalidStateTransition {
+                from: "initialized".into(),
+                to: "create-volume-root".into(),
+            });
+        }
+
+        let now = now_ns()?;
+        let root_inode = InodeDelta {
+            layer_id: request.root_layer_id,
+            ino: 1,
+            state: InodeState::Present,
+            kind: 1,
+            size: 0,
+            mode: 0o755,
+            uid: 0,
+            gid: 0,
+            rdev: 0,
+            nlink: 2,
+            atime_ns: now,
+            mtime_ns: now,
+            ctime_ns: now,
+            symlink_target: None,
+            parent_hint: Some(1),
+            data_version: 1,
+            sequence: 1,
+        };
+        let root_delta = CanonicalLayerDelta {
+            inodes: vec![root_inode.clone()],
+            ..CanonicalLayerDelta::default()
+        };
+        let root_delta_digest = delta_digest(&root_delta)?;
+        let root_hash = root_hash([0; 32], root_delta_digest);
+
+        sea_orm::sqlx::query(
+            "INSERT INTO ws_v1_layers
+             (layer_id, parent_layer_id, state, schema_version, sealed_version,
+              delta_digest, root_hash, depth, owner_workspace_id, next_sequence,
+              owned_slice_count, owned_bytes, created_at_ns, sealed_at_ns)
+             VALUES (?, NULL, ?, ?, 1, ?, ?, 1, NULL, 2, 0, 0, ?, ?)",
+        )
+        .bind(request.root_layer_id.as_bytes().as_slice())
+        .bind(LayerState::Sealed.discriminant() as i64)
+        .bind(WORKSPACE_SCHEMA_VERSION as i64)
+        .bind(root_delta_digest.as_slice())
+        .bind(root_hash.as_slice())
+        .bind(now)
+        .bind(now)
+        .execute(&mut *tx)
+        .await
+        .map_err(backend)?;
+        insert_inode(&mut tx, &root_inode).await?;
+
+        sea_orm::sqlx::query(
+            "INSERT INTO ws_v1_layers
+             (layer_id, parent_layer_id, state, schema_version, sealed_version,
+              delta_digest, root_hash, depth, owner_workspace_id, next_sequence,
+              owned_slice_count, owned_bytes, created_at_ns, sealed_at_ns)
+             VALUES (?, ?, ?, ?, NULL, NULL, NULL, 2, ?, 1, 0, 0, ?, NULL)",
+        )
+        .bind(request.writable_layer_id.as_bytes().as_slice())
+        .bind(request.root_layer_id.as_bytes().as_slice())
+        .bind(LayerState::Writable.discriminant() as i64)
+        .bind(WORKSPACE_SCHEMA_VERSION as i64)
+        .bind(request.workspace_id.as_bytes().as_slice())
+        .bind(now)
+        .execute(&mut *tx)
+        .await
+        .map_err(backend)?;
+
+        sea_orm::sqlx::query(
+            "INSERT INTO ws_v1_workspaces
+             (workspace_id, head_layer_id, head_epoch,
+              fork_base_layer_id, fork_base_version, fork_base_root_hash,
+              owner_id, state, created_at_ns, updated_at_ns)
+             VALUES (?, ?, 0, ?, 1, ?, ?, ?, ?, ?)",
+        )
+        .bind(request.workspace_id.as_bytes().as_slice())
+        .bind(request.writable_layer_id.as_bytes().as_slice())
+        .bind(request.root_layer_id.as_bytes().as_slice())
+        .bind(root_hash.as_slice())
+        .bind(request.owner_id.as_deref())
+        .bind(WorkspaceState::Active.discriminant() as i64)
+        .bind(now)
+        .bind(now)
+        .execute(&mut *tx)
+        .await
+        .map_err(backend)?;
+        for (name, next_value) in [
+            ("inode", 2_i64),
+            ("slice", 1_i64),
+            ("sealed_version", 2_i64),
+        ] {
+            sea_orm::sqlx::query("INSERT INTO ws_v1_allocators(name, next_value) VALUES (?, ?)")
+                .bind(name)
+                .bind(next_value)
+                .execute(&mut *tx)
+                .await
+                .map_err(backend)?;
+        }
+
+        // The immutable marker is deliberately the last row written. A crash
+        // before this point leaves a retryable, unmarked workspace schema.
+        sea_orm::sqlx::query(
+            "INSERT INTO ws_v1_volume_header
+             (singleton_id, volume_format, schema_version, volume_id, created_at_ns)
+             VALUES (1, ?, ?, ?, ?)",
+        )
+        .bind(VOLUME_FORMAT)
+        .bind(WORKSPACE_SCHEMA_VERSION as i64)
+        .bind(request.volume_id.as_bytes().as_slice())
+        .bind(now)
+        .execute(&mut *tx)
+        .await
+        .map_err(backend)?;
+        tx.commit().await.map_err(backend)?;
+
+        Ok(WorkspaceRecord {
+            workspace_id: request.workspace_id,
+            head_layer_id: request.writable_layer_id,
+            head_epoch: 0,
+            fork_base: Some(BaseRevision {
+                layer_id: request.root_layer_id,
+                sealed_version: 1,
+                root_hash,
+            }),
+            owner_id: request.owner_id,
+            state: WorkspaceState::Active,
+            created_at_ns: now,
+            updated_at_ns: now,
+        })
+    }
+
+    async fn create_workspace(
+        &self,
+        request: CreateWorkspace,
+    ) -> Result<WorkspaceRecord, WorkspaceError> {
+        let _guard = self.write_gate.lock().await;
+        let mut tx = self.begin_write().await?;
+        let base = load_revision_tx(&mut tx, request.base_revision.layer_id).await?;
+        if base != request.base_revision {
+            return Err(WorkspaceError::Conflict(
+                crate::workspace_overlay::error::ConflictDetail {
+                    path: Vec::new(),
+                    reason: "fork base revision changed".into(),
+                },
+            ));
+        }
+        let parent = sea_orm::sqlx::query(
+            "SELECT parent_layer_id, depth FROM ws_v1_layers WHERE layer_id = ? AND state = ?",
+        )
+        .bind(request.base_revision.layer_id.as_bytes().as_slice())
+        .bind(LayerState::Sealed.discriminant() as i64)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(backend)?
+        .ok_or(WorkspaceError::LayerNotFound(
+            request.base_revision.layer_id,
+        ))?;
+        let parent_layer_id = parent
+            .try_get::<Option<Vec<u8>>, _>("parent_layer_id")
+            .map_err(backend)?;
+        let parent_depth = to_u32(
+            parent.try_get("depth").map_err(backend)?,
+            "parent layer depth",
+        )?;
+        if parent_layer_id.is_some() || parent_depth != 1 {
+            return Err(WorkspaceError::CorruptMetadata(
+                "workspace base revision must be a flat sealed layer".into(),
+            ));
+        }
+        let now = now_ns()?;
+        insert_writable_layer(
+            &mut tx,
+            request.head_layer_id,
+            request.base_revision.layer_id,
+            2,
+            request.workspace_id,
+            now,
+        )
+        .await?;
+        sea_orm::sqlx::query(
+            "INSERT INTO ws_v1_workspaces
+             (workspace_id, head_layer_id, head_epoch, fork_base_layer_id,
+              fork_base_version, fork_base_root_hash, owner_id, state,
+              created_at_ns, updated_at_ns)
+             VALUES (?, ?, 0, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(request.workspace_id.as_bytes().as_slice())
+        .bind(request.head_layer_id.as_bytes().as_slice())
+        .bind(request.base_revision.layer_id.as_bytes().as_slice())
+        .bind(to_i64(
+            request.base_revision.sealed_version,
+            "sealed version",
+        )?)
+        .bind(request.base_revision.root_hash.as_slice())
+        .bind(request.owner_id.as_deref())
+        .bind(WorkspaceState::Active.discriminant() as i64)
+        .bind(now)
+        .bind(now)
+        .execute(&mut *tx)
+        .await
+        .map_err(|error| {
+            if is_unique_violation(&error) {
+                WorkspaceError::Conflict(crate::workspace_overlay::error::ConflictDetail {
+                    path: Vec::new(),
+                    reason: "workspace already exists".into(),
+                })
+            } else {
+                backend(error)
+            }
+        })?;
+        tx.commit().await.map_err(backend)?;
+        Ok(WorkspaceRecord {
+            workspace_id: request.workspace_id,
+            head_layer_id: request.head_layer_id,
+            head_epoch: 0,
+            fork_base: Some(request.base_revision),
+            owner_id: request.owner_id,
+            state: WorkspaceState::Active,
+            created_at_ns: now,
+            updated_at_ns: now,
+        })
+    }
+
+    async fn list_workspaces(&self) -> Result<Vec<WorkspaceRecord>, WorkspaceError> {
+        let rows = sea_orm::sqlx::query(
+            "SELECT workspace_id, head_layer_id, head_epoch,
+                    fork_base_layer_id, fork_base_version, fork_base_root_hash,
+                    owner_id, state, created_at_ns, updated_at_ns
+             FROM ws_v1_workspaces ORDER BY created_at_ns, workspace_id",
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(backend)?;
+        rows.iter().map(decode_workspace).collect()
+    }
+
+    async fn create_snapshot(
+        &self,
+        request: CreateSnapshot,
+    ) -> Result<SnapshotRecord, WorkspaceError> {
+        let _guard = self.write_gate.lock().await;
+        let mut tx = self.begin_write().await?;
+        if load_revision_tx(&mut tx, request.revision.layer_id).await? != request.revision {
+            return Err(WorkspaceError::Conflict(
+                crate::workspace_overlay::error::ConflictDetail {
+                    path: Vec::new(),
+                    reason: "snapshot revision changed".into(),
+                },
+            ));
+        }
+        let now = now_ns()?;
+        let result = sea_orm::sqlx::query(
+            "INSERT INTO ws_v1_snapshots
+             (snapshot_id, name, layer_id, sealed_version, root_hash, owner_id, created_at_ns)
+             VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(request.snapshot_id.as_bytes().as_slice())
+        .bind(request.name.as_deref())
+        .bind(request.revision.layer_id.as_bytes().as_slice())
+        .bind(to_i64(request.revision.sealed_version, "sealed version")?)
+        .bind(request.revision.root_hash.as_slice())
+        .bind(request.owner_id.as_deref())
+        .bind(now)
+        .execute(&mut *tx)
+        .await;
+        if let Err(error) = result {
+            if is_unique_violation(&error) {
+                return Err(WorkspaceError::Conflict(
+                    crate::workspace_overlay::error::ConflictDetail {
+                        path: Vec::new(),
+                        reason: "snapshot ID or name already exists".into(),
+                    },
+                ));
+            }
+            return Err(backend(error));
+        }
+        tx.commit().await.map_err(backend)?;
+        Ok(SnapshotRecord {
+            snapshot_id: request.snapshot_id,
+            name: request.name,
+            revision: request.revision,
+            owner_id: request.owner_id,
+            created_at_ns: now,
+        })
+    }
+
+    async fn load_snapshot(&self, id: SnapshotId) -> Result<SnapshotRecord, WorkspaceError> {
+        let row = sea_orm::sqlx::query(
+            "SELECT snapshot_id, name, layer_id, sealed_version, root_hash,
+                    owner_id, created_at_ns
+             FROM ws_v1_snapshots WHERE snapshot_id = ?",
+        )
+        .bind(id.as_bytes().as_slice())
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(backend)?
+        .ok_or_else(|| WorkspaceError::Backend(format!("snapshot not found: {id}")))?;
+        decode_snapshot(&row)
+    }
+
+    async fn list_snapshots(&self) -> Result<Vec<SnapshotRecord>, WorkspaceError> {
+        let rows = sea_orm::sqlx::query(
+            "SELECT snapshot_id, name, layer_id, sealed_version, root_hash,
+                    owner_id, created_at_ns
+             FROM ws_v1_snapshots ORDER BY created_at_ns, snapshot_id",
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(backend)?;
+        rows.iter().map(decode_snapshot).collect()
+    }
+
+    async fn delete_snapshot(&self, id: SnapshotId) -> Result<(), WorkspaceError> {
+        let _guard = self.write_gate.lock().await;
+        let result = sea_orm::sqlx::query("DELETE FROM ws_v1_snapshots WHERE snapshot_id = ?")
+            .bind(id.as_bytes().as_slice())
+            .execute(&self.pool)
+            .await
+            .map_err(backend)?;
+        if result.rows_affected() != 1 {
+            return Err(WorkspaceError::Backend(format!("snapshot not found: {id}")));
+        }
+        Ok(())
+    }
+
+    async fn acquire_lease(&self, request: AcquireLease) -> Result<SnapshotLease, WorkspaceError> {
+        if request.ttl_ns == 0 {
+            return Err(WorkspaceError::CorruptMetadata(
+                "lease TTL must be positive".into(),
+            ));
+        }
+        let _guard = self.write_gate.lock().await;
+        let mut tx = self.begin_write().await?;
+        let row = sea_orm::sqlx::query(
+            "SELECT w.state AS workspace_state, l.parent_layer_id,
+                    p.sealed_version, p.root_hash
+             FROM ws_v1_workspaces w
+             JOIN ws_v1_layers l ON l.layer_id = w.head_layer_id
+             JOIN ws_v1_layers p ON p.layer_id = l.parent_layer_id
+             WHERE w.workspace_id = ? AND l.state = ? AND p.state = ?",
+        )
+        .bind(request.workspace_id.as_bytes().as_slice())
+        .bind(LayerState::Writable.discriminant() as i64)
+        .bind(LayerState::Sealed.discriminant() as i64)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(backend)?
+        .ok_or(WorkspaceError::WorkspaceNotFound(request.workspace_id))?;
+        let workspace_state = WorkspaceState::try_from(to_u8(
+            row.try_get::<i64, _>("workspace_state").map_err(backend)?,
+            "workspace state",
+        )?)?;
+        if workspace_state != WorkspaceState::Active {
+            return Err(WorkspaceError::Busy);
+        }
+        let base_revision = BaseRevision {
+            layer_id: LayerId::from_uuid(uuid_from_blob(
+                row.try_get("parent_layer_id").map_err(backend)?,
+                "lease base layer",
+            )?),
+            sealed_version: to_u64(
+                row.try_get("sealed_version").map_err(backend)?,
+                "sealed version",
+            )?,
+            root_hash: hash_from_blob(
+                row.try_get("root_hash").map_err(backend)?,
+                "lease base root hash",
+            )?,
+        };
+        let now = now_ns()?;
+        sea_orm::sqlx::query(
+            "UPDATE ws_v1_snapshot_leases SET state = ?, updated_at_ns = ?
+             WHERE workspace_id = ? AND state = ? AND expires_at_ns <= ?",
+        )
+        .bind(LeaseState::Expired.discriminant() as i64)
+        .bind(now)
+        .bind(request.workspace_id.as_bytes().as_slice())
+        .bind(LeaseState::Active.discriminant() as i64)
+        .bind(now)
+        .execute(&mut *tx)
+        .await
+        .map_err(backend)?;
+        let expires = now
+            .checked_add(to_i64(request.ttl_ns, "lease TTL")?)
+            .ok_or_else(|| WorkspaceError::CorruptMetadata("lease expiry overflows".into()))?;
+        let insert = sea_orm::sqlx::query(
+            "INSERT INTO ws_v1_snapshot_leases
+             (lease_id, workspace_id, base_layer_id, base_version, base_root_hash,
+              holder_generation, writable, state, expires_at_ns, created_at_ns, updated_at_ns)
+             VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?)",
+        )
+        .bind(request.lease_id.as_bytes().as_slice())
+        .bind(request.workspace_id.as_bytes().as_slice())
+        .bind(base_revision.layer_id.as_bytes().as_slice())
+        .bind(to_i64(base_revision.sealed_version, "sealed version")?)
+        .bind(base_revision.root_hash.as_slice())
+        .bind(to_i64(request.holder_generation, "holder generation")?)
+        .bind(LeaseState::Active.discriminant() as i64)
+        .bind(expires)
+        .bind(now)
+        .bind(now)
+        .execute(&mut *tx)
+        .await;
+        if let Err(error) = insert {
+            if is_unique_violation(&error) {
+                return Err(WorkspaceError::Busy);
+            }
+            return Err(backend(error));
+        }
+        tx.commit().await.map_err(backend)?;
+        Ok(SnapshotLease {
+            lease_id: request.lease_id,
+            workspace_id: request.workspace_id,
+            base_revision,
+            holder_generation: request.holder_generation,
+            writable: true,
+            state: LeaseState::Active,
+            expires_at_ns: expires,
+            created_at_ns: now,
+            updated_at_ns: now,
+        })
+    }
+
+    async fn renew_lease(&self, request: RenewLease) -> Result<SnapshotLease, WorkspaceError> {
+        if request.ttl_ns == 0 {
+            return Err(WorkspaceError::CorruptMetadata(
+                "lease TTL must be positive".into(),
+            ));
+        }
+        let _guard = self.write_gate.lock().await;
+        let mut tx = self.begin_write().await?;
+        let now = now_ns()?;
+        let expires = now
+            .checked_add(to_i64(request.ttl_ns, "lease TTL")?)
+            .ok_or_else(|| WorkspaceError::CorruptMetadata("lease expiry overflows".into()))?;
+        let row = sea_orm::sqlx::query(
+            "UPDATE ws_v1_snapshot_leases
+             SET expires_at_ns = ?, updated_at_ns = ?
+             WHERE lease_id = ? AND holder_generation = ? AND state = ?
+               AND expires_at_ns > ?
+             RETURNING lease_id, workspace_id, base_layer_id, base_version,
+                       base_root_hash, holder_generation, writable, state,
+                       expires_at_ns, created_at_ns, updated_at_ns",
+        )
+        .bind(expires)
+        .bind(now)
+        .bind(request.lease_id.as_bytes().as_slice())
+        .bind(to_i64(request.holder_generation, "holder generation")?)
+        .bind(LeaseState::Active.discriminant() as i64)
+        .bind(now)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(backend)?
+        .ok_or(WorkspaceError::Fenced)?;
+        let lease = decode_lease(&row)?;
+        tx.commit().await.map_err(backend)?;
+        Ok(lease)
+    }
+
+    async fn release_lease(&self, request: ReleaseLease) -> Result<(), WorkspaceError> {
+        let _guard = self.write_gate.lock().await;
+        let now = now_ns()?;
+        let updated = sea_orm::sqlx::query(
+            "UPDATE ws_v1_snapshot_leases SET state = ?, updated_at_ns = ?
+             WHERE lease_id = ? AND holder_generation = ? AND state = ?",
+        )
+        .bind(LeaseState::Released.discriminant() as i64)
+        .bind(now)
+        .bind(request.lease_id.as_bytes().as_slice())
+        .bind(to_i64(request.holder_generation, "holder generation")?)
+        .bind(LeaseState::Active.discriminant() as i64)
+        .execute(&self.pool)
+        .await
+        .map_err(backend)?;
+        if updated.rows_affected() != 1 {
+            return Err(WorkspaceError::Fenced);
+        }
+        Ok(())
+    }
+
+    async fn reap_expired_leases(&self) -> Result<u64, WorkspaceError> {
+        let _guard = self.write_gate.lock().await;
+        let now = now_ns()?;
+        let updated = sea_orm::sqlx::query(
+            "UPDATE ws_v1_snapshot_leases SET state = ?, updated_at_ns = ?
+             WHERE state = ? AND expires_at_ns <= ?",
+        )
+        .bind(LeaseState::Expired.discriminant() as i64)
+        .bind(now)
+        .bind(LeaseState::Active.discriminant() as i64)
+        .bind(now)
+        .execute(&self.pool)
+        .await
+        .map_err(backend)?;
+        Ok(updated.rows_affected())
+    }
+
+    async fn list_leases(
+        &self,
+        workspace_id: WorkspaceId,
+    ) -> Result<Vec<SnapshotLease>, WorkspaceError> {
+        let rows = sea_orm::sqlx::query(
+            "SELECT lease_id, workspace_id, base_layer_id, base_version,
+                    base_root_hash, holder_generation, writable, state,
+                    expires_at_ns, created_at_ns, updated_at_ns
+             FROM ws_v1_snapshot_leases WHERE workspace_id = ?
+             ORDER BY created_at_ns, lease_id",
+        )
+        .bind(workspace_id.as_bytes().as_slice())
+        .fetch_all(&self.pool)
+        .await
+        .map_err(backend)?;
+        rows.iter().map(decode_lease).collect()
+    }
+
+    async fn get_dentry_deltas(
+        &self,
+        request: DentryQuery,
+    ) -> Result<Vec<DentryDelta>, WorkspaceError> {
+        let mut rows = Vec::new();
+        for layer_id in request.layer_ids {
+            let found = if let Some(name) = request.name.as_deref() {
+                sea_orm::sqlx::query(
+                    "SELECT layer_id, parent_ino, name, op, ino, entry_type, sequence
+                     FROM ws_v1_dentry_delta
+                     WHERE layer_id = ? AND parent_ino = ? AND name = ?",
+                )
+                .bind(layer_id.as_bytes().as_slice())
+                .bind(request.parent_ino)
+                .bind(name)
+                .fetch_all(&self.pool)
+                .await
+                .map_err(backend)?
+            } else {
+                sea_orm::sqlx::query(
+                    "SELECT layer_id, parent_ino, name, op, ino, entry_type, sequence
+                     FROM ws_v1_dentry_delta
+                     WHERE layer_id = ? AND parent_ino = ? ORDER BY name",
+                )
+                .bind(layer_id.as_bytes().as_slice())
+                .bind(request.parent_ino)
+                .fetch_all(&self.pool)
+                .await
+                .map_err(backend)?
+            };
+            rows.extend(
+                found
+                    .into_iter()
+                    .map(decode_dentry)
+                    .collect::<Result<Vec<_>, _>>()?,
+            );
+        }
+        Ok(rows)
+    }
+
+    async fn get_inode_deltas(
+        &self,
+        request: InodeQuery,
+    ) -> Result<Vec<InodeDelta>, WorkspaceError> {
+        let mut rows = Vec::new();
+        for layer_id in request.layer_ids {
+            if let Some(row) = sea_orm::sqlx::query(
+                "SELECT layer_id, ino, state, kind, size, mode, uid, gid, rdev, nlink,
+                        atime_ns, mtime_ns, ctime_ns, symlink_target, parent_hint,
+                        data_version, sequence
+                 FROM ws_v1_inode_delta WHERE layer_id = ? AND ino = ?",
+            )
+            .bind(layer_id.as_bytes().as_slice())
+            .bind(request.ino)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(backend)?
+            {
+                rows.push(decode_inode(&row)?);
+            }
+        }
+        Ok(rows)
+    }
+
+    async fn get_extent_deltas(
+        &self,
+        request: ExtentQuery,
+    ) -> Result<Vec<DataExtentDelta>, WorkspaceError> {
+        if request.range_start > request.range_end {
+            return Err(WorkspaceError::InvalidReadPlan(
+                "extent query starts after its end".into(),
+            ));
+        }
+        if request.range_start == request.range_end {
+            return Ok(Vec::new());
+        }
+        let chunk_index = to_i64(request.chunk_index, "chunk index")?;
+        let range_start = to_i64(request.range_start, "range start")?;
+        let range_end = to_i64(request.range_end, "range end")?;
+        let mut rows = Vec::new();
+        for layer_id in request.layer_ids {
+            let found = sea_orm::sqlx::query(
+                "SELECT layer_id, ino, chunk_index, logical_offset, length, kind,
+                        slice_id, slice_offset, sequence
+                 FROM ws_v1_data_extent_delta
+                 WHERE layer_id = ? AND ino = ? AND chunk_index = ?
+                   AND logical_offset < ? AND logical_offset + length > ?
+                 ORDER BY sequence DESC",
+            )
+            .bind(layer_id.as_bytes().as_slice())
+            .bind(request.ino)
+            .bind(chunk_index)
+            .bind(range_end)
+            .bind(range_start)
+            .fetch_all(&self.pool)
+            .await
+            .map_err(backend)?;
+            rows.extend(
+                found
+                    .iter()
+                    .map(decode_extent)
+                    .collect::<Result<Vec<_>, _>>()?,
+            );
+        }
+        Ok(rows)
+    }
+
+    async fn get_xattr_deltas(
+        &self,
+        request: XattrQuery,
+    ) -> Result<Vec<XattrDelta>, WorkspaceError> {
+        let mut rows = Vec::new();
+        for layer_id in request.layer_ids {
+            let found = if let Some(name) = request.name.as_deref() {
+                sea_orm::sqlx::query(
+                    "SELECT layer_id, ino, name, op, value, sequence
+                     FROM ws_v1_xattr_delta WHERE layer_id = ? AND ino = ? AND name = ?",
+                )
+                .bind(layer_id.as_bytes().as_slice())
+                .bind(request.ino)
+                .bind(name)
+                .fetch_all(&self.pool)
+                .await
+                .map_err(backend)?
+            } else {
+                sea_orm::sqlx::query(
+                    "SELECT layer_id, ino, name, op, value, sequence
+                     FROM ws_v1_xattr_delta WHERE layer_id = ? AND ino = ? ORDER BY name",
+                )
+                .bind(layer_id.as_bytes().as_slice())
+                .bind(request.ino)
+                .fetch_all(&self.pool)
+                .await
+                .map_err(backend)?
+            };
+            rows.extend(
+                found
+                    .iter()
+                    .map(decode_xattr)
+                    .collect::<Result<Vec<_>, _>>()?,
+            );
+        }
+        Ok(rows)
+    }
+
+    async fn get_acl_deltas(&self, request: AclQuery) -> Result<Vec<AclDelta>, WorkspaceError> {
+        if request.acl_type.is_some() != request.acl_id.is_some() {
+            return Err(WorkspaceError::CorruptMetadata(
+                "ACL type and ID filters must be provided together".into(),
+            ));
+        }
+        let mut rows = Vec::new();
+        for layer_id in request.layer_ids {
+            let found = if let (Some(acl_type), Some(acl_id)) = (request.acl_type, request.acl_id) {
+                sea_orm::sqlx::query(
+                    "SELECT layer_id, ino, acl_type, acl_id, op, value, sequence
+                     FROM ws_v1_acl_delta
+                     WHERE layer_id = ? AND ino = ? AND acl_type = ? AND acl_id = ?",
+                )
+                .bind(layer_id.as_bytes().as_slice())
+                .bind(request.ino)
+                .bind(i64::from(acl_type))
+                .bind(acl_id)
+                .fetch_all(&self.pool)
+                .await
+                .map_err(backend)?
+            } else {
+                sea_orm::sqlx::query(
+                    "SELECT layer_id, ino, acl_type, acl_id, op, value, sequence
+                     FROM ws_v1_acl_delta WHERE layer_id = ? AND ino = ?
+                     ORDER BY acl_type, acl_id",
+                )
+                .bind(layer_id.as_bytes().as_slice())
+                .bind(request.ino)
+                .fetch_all(&self.pool)
+                .await
+                .map_err(backend)?
+            };
+            rows.extend(
+                found
+                    .iter()
+                    .map(decode_acl)
+                    .collect::<Result<Vec<_>, _>>()?,
+            );
+        }
+        Ok(rows)
+    }
+
+    async fn apply_namespace_mutation(
+        &self,
+        request: NamespaceMutation,
+    ) -> Result<MutationResult, WorkspaceError> {
+        if request.dentries.is_empty() && request.inodes.is_empty() {
+            return Ok(MutationResult {
+                first_sequence: None,
+                last_sequence: None,
+            });
+        }
+        for dentry in &request.dentries {
+            if dentry.layer_id != request.guard.expected_head_layer_id {
+                return Err(WorkspaceError::Fenced);
+            }
+            dentry.validate()?;
+        }
+        if request
+            .inodes
+            .iter()
+            .any(|inode| inode.layer_id != request.guard.expected_head_layer_id)
+        {
+            return Err(WorkspaceError::Fenced);
+        }
+
+        let _guard = self.write_gate.lock().await;
+        let mut tx = self.begin_write().await?;
+        Self::checked_guard(&mut tx, &request.guard).await?;
+        let count = request
+            .dentries
+            .len()
+            .checked_add(request.inodes.len())
+            .ok_or_else(|| WorkspaceError::CorruptMetadata("mutation is too large".into()))?;
+        let range = Self::allocate_sequences(&mut tx, request.guard.expected_head_layer_id, count)
+            .await?
+            .expect("non-empty mutation has a sequence range");
+        let mut sequence = range.0;
+        for mut dentry in request.dentries {
+            dentry.sequence = sequence;
+            upsert_dentry(&mut tx, &dentry).await?;
+            sequence += 1;
+        }
+        for mut inode in request.inodes {
+            inode.sequence = sequence;
+            upsert_inode(&mut tx, &inode).await?;
+            sequence += 1;
+        }
+
+        #[cfg(test)]
+        if self.failpoint.load(Ordering::SeqCst) == StoreFailpoint::BeforeCommit as u8 {
+            return Err(WorkspaceError::Backend(
+                "injected failure before transaction commit".into(),
+            ));
+        }
+
+        tx.commit().await.map_err(backend)?;
+        Ok(MutationResult {
+            first_sequence: Some(range.0),
+            last_sequence: Some(range.1),
+        })
+    }
+
+    async fn apply_inode_mutation(
+        &self,
+        request: InodeMutation,
+    ) -> Result<InodeDelta, WorkspaceError> {
+        let mut inode = request.inode;
+        if inode.layer_id != request.guard.expected_head_layer_id {
+            return Err(WorkspaceError::Fenced);
+        }
+        let _guard = self.write_gate.lock().await;
+        let mut tx = self.begin_write().await?;
+        Self::checked_guard(&mut tx, &request.guard).await?;
+        let (sequence, _) = Self::allocate_sequences(&mut tx, inode.layer_id, 1)
+            .await?
+            .expect("single mutation has a sequence");
+        inode.sequence = sequence;
+        upsert_inode(&mut tx, &inode).await?;
+        tx.commit().await.map_err(backend)?;
+        Ok(inode)
+    }
+
+    async fn append_data_extent(
+        &self,
+        request: AppendDataExtent,
+    ) -> Result<DataExtentDelta, WorkspaceError> {
+        let mut extent = request.extent;
+        if extent.layer_id != request.guard.expected_head_layer_id {
+            return Err(WorkspaceError::Fenced);
+        }
+        extent.validate()?;
+        let end = extent
+            .logical_offset
+            .checked_add(extent.length)
+            .ok_or_else(|| WorkspaceError::CorruptMetadata("extent range overflows".into()))?;
+        if end > request.chunk_size {
+            return Err(WorkspaceError::CorruptMetadata(format!(
+                "extent end {end} exceeds chunk size {}",
+                request.chunk_size
+            )));
+        }
+        let _guard = self.write_gate.lock().await;
+        let mut tx = self.begin_write().await?;
+        Self::checked_guard(&mut tx, &request.guard).await?;
+        let (sequence, _) = Self::allocate_sequences(&mut tx, extent.layer_id, 1)
+            .await?
+            .expect("single mutation has a sequence");
+        extent.sequence = sequence;
+        insert_extent(&mut tx, &extent).await?;
+        if matches!(extent.kind, ExtentKind::Data { .. }) {
+            sea_orm::sqlx::query(
+                "UPDATE ws_v1_layers
+                 SET owned_slice_count = owned_slice_count + 1,
+                     owned_bytes = owned_bytes + ?
+                 WHERE layer_id = ?",
+            )
+            .bind(to_i64(extent.length, "extent length")?)
+            .bind(extent.layer_id.as_bytes().as_slice())
+            .execute(&mut *tx)
+            .await
+            .map_err(backend)?;
+        }
+        tx.commit().await.map_err(backend)?;
+        Ok(extent)
+    }
+
+    async fn apply_data_mutation(
+        &self,
+        request: DataMutation,
+    ) -> Result<DataMutationResult, WorkspaceError> {
+        let DataMutation {
+            guard,
+            mut inode,
+            mut extents,
+            chunk_size,
+        } = request;
+        let head = guard.expected_head_layer_id;
+        if inode.layer_id != head
+            || extents
+                .iter()
+                .any(|extent| extent.layer_id != head || extent.ino != inode.ino)
+        {
+            return Err(WorkspaceError::Fenced);
+        }
+        for extent in &extents {
+            extent.validate()?;
+            let end = extent
+                .logical_offset
+                .checked_add(extent.length)
+                .ok_or_else(|| WorkspaceError::CorruptMetadata("extent range overflows".into()))?;
+            if end > chunk_size {
+                return Err(WorkspaceError::CorruptMetadata(format!(
+                    "extent end {end} exceeds chunk size {chunk_size}"
+                )));
+            }
+        }
+
+        let sequence_count = extents
+            .len()
+            .checked_add(1)
+            .ok_or_else(|| WorkspaceError::Backend("too many data mutations".into()))?;
+        let _write_guard = self.write_gate.lock().await;
+        let mut tx = self.begin_write().await?;
+        Self::checked_guard(&mut tx, &guard).await?;
+        let (first, last) = Self::allocate_sequences(&mut tx, head, sequence_count)
+            .await?
+            .expect("data mutation always allocates an inode sequence");
+        inode.sequence = first;
+        upsert_inode(&mut tx, &inode).await?;
+
+        let mut owned_slice_count = 0u64;
+        let mut owned_bytes = 0u64;
+        for (index, extent) in extents.iter_mut().enumerate() {
+            extent.sequence = first
+                .checked_add(
+                    u64::try_from(index)
+                        .map_err(|_| WorkspaceError::Backend("extent index exceeds u64".into()))?,
+                )
+                .and_then(|sequence| sequence.checked_add(1))
+                .ok_or_else(|| WorkspaceError::Backend("extent sequence overflows".into()))?;
+            insert_extent(&mut tx, extent).await?;
+            if matches!(extent.kind, ExtentKind::Data { .. }) {
+                owned_slice_count = owned_slice_count
+                    .checked_add(1)
+                    .ok_or_else(|| WorkspaceError::Backend("owned slice count overflows".into()))?;
+                owned_bytes = owned_bytes
+                    .checked_add(extent.length)
+                    .ok_or_else(|| WorkspaceError::Backend("owned byte count overflows".into()))?;
+            }
+        }
+        debug_assert_eq!(
+            extents.last().map(|extent| extent.sequence),
+            (!extents.is_empty()).then_some(last)
+        );
+        if owned_slice_count != 0 {
+            sea_orm::sqlx::query(
+                "UPDATE ws_v1_layers
+                 SET owned_slice_count = owned_slice_count + ?,
+                     owned_bytes = owned_bytes + ?
+                 WHERE layer_id = ?",
+            )
+            .bind(to_i64(owned_slice_count, "owned slice count")?)
+            .bind(to_i64(owned_bytes, "owned bytes")?)
+            .bind(head.as_bytes().as_slice())
+            .execute(&mut *tx)
+            .await
+            .map_err(backend)?;
+        }
+        tx.commit().await.map_err(backend)?;
+        Ok(DataMutationResult { inode, extents })
+    }
+
+    async fn apply_xattr_mutation(&self, request: XattrMutation) -> Result<(), WorkspaceError> {
+        let mut xattr = request.xattr;
+        let mut inode = request.inode;
+        validate_value(xattr.op, xattr.value.as_deref(), "xattr")?;
+        if xattr.layer_id != request.guard.expected_head_layer_id
+            || inode.layer_id != request.guard.expected_head_layer_id
+            || inode.ino != xattr.ino
+        {
+            return Err(WorkspaceError::Fenced);
+        }
+        let _guard = self.write_gate.lock().await;
+        let mut tx = self.begin_write().await?;
+        Self::checked_guard(&mut tx, &request.guard).await?;
+        let (first_sequence, last_sequence) = Self::allocate_sequences(&mut tx, xattr.layer_id, 2)
+            .await?
+            .expect("xattr mutation has a sequence range");
+        xattr.sequence = first_sequence;
+        inode.sequence = last_sequence;
+        upsert_xattr(&mut tx, &xattr).await?;
+        upsert_inode(&mut tx, &inode).await?;
+        tx.commit().await.map_err(backend)?;
+        Ok(())
+    }
+
+    async fn apply_acl_mutation(&self, request: AclMutation) -> Result<(), WorkspaceError> {
+        let mut acl = request.acl;
+        validate_value(acl.op, acl.value.as_deref(), "ACL")?;
+        if acl.layer_id != request.guard.expected_head_layer_id {
+            return Err(WorkspaceError::Fenced);
+        }
+        let _guard = self.write_gate.lock().await;
+        let mut tx = self.begin_write().await?;
+        Self::checked_guard(&mut tx, &request.guard).await?;
+        let (sequence, _) = Self::allocate_sequences(&mut tx, acl.layer_id, 1)
+            .await?
+            .expect("single mutation has a sequence");
+        acl.sequence = sequence;
+        upsert_acl(&mut tx, &acl).await?;
+        tx.commit().await.map_err(backend)?;
+        Ok(())
+    }
+
+    async fn load_layer_delta(
+        &self,
+        layer_id: LayerId,
+    ) -> Result<CanonicalLayerDelta, WorkspaceError> {
+        self.load_layer(layer_id).await?;
+        load_layer_delta_pool(&self.pool, layer_id).await
+    }
+
+    async fn begin_seal(&self, request: BeginSeal) -> Result<SealJournal, WorkspaceError> {
+        if request.new_head_layer_id == request.guard.expected_head_layer_id {
+            return Err(WorkspaceError::CorruptMetadata(
+                "seal new head must differ from old head".into(),
+            ));
+        }
+        let _guard = self.write_gate.lock().await;
+        let mut tx = self.begin_write().await?;
+        Self::checked_guard(&mut tx, &request.guard).await?;
+        let now = now_ns()?;
+        let workspace = sea_orm::sqlx::query(
+            "UPDATE ws_v1_workspaces SET state = ?, updated_at_ns = ?
+             WHERE workspace_id = ? AND state = ? AND head_layer_id = ? AND head_epoch = ?
+             RETURNING workspace_id",
+        )
+        .bind(WorkspaceState::Sealing.discriminant() as i64)
+        .bind(now)
+        .bind(request.guard.workspace_id.as_bytes().as_slice())
+        .bind(WorkspaceState::Active.discriminant() as i64)
+        .bind(request.guard.expected_head_layer_id.as_bytes().as_slice())
+        .bind(to_i64(request.guard.expected_head_epoch, "head epoch")?)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(backend)?;
+        if workspace.is_none() {
+            return Err(WorkspaceError::Fenced);
+        }
+        let changed = sea_orm::sqlx::query(
+            "UPDATE ws_v1_layers SET state = ?
+             WHERE layer_id = ? AND state = ? AND owner_workspace_id = ?",
+        )
+        .bind(LayerState::Sealing.discriminant() as i64)
+        .bind(request.guard.expected_head_layer_id.as_bytes().as_slice())
+        .bind(LayerState::Writable.discriminant() as i64)
+        .bind(request.guard.workspace_id.as_bytes().as_slice())
+        .execute(&mut *tx)
+        .await
+        .map_err(backend)?;
+        if changed.rows_affected() != 1 {
+            return Err(WorkspaceError::Fenced);
+        }
+        sea_orm::sqlx::query(
+            "INSERT INTO ws_v1_seal_journal
+             (journal_id, workspace_id, old_head_layer_id, expected_head_epoch,
+              phase, pending_bytes, delta_digest, root_hash, new_head_layer_id,
+              last_error, created_at_ns, updated_at_ns)
+             VALUES (?, ?, ?, ?, ?, 0, NULL, NULL, ?, NULL, ?, ?)",
+        )
+        .bind(request.journal_id.as_bytes().as_slice())
+        .bind(request.guard.workspace_id.as_bytes().as_slice())
+        .bind(request.guard.expected_head_layer_id.as_bytes().as_slice())
+        .bind(to_i64(request.guard.expected_head_epoch, "head epoch")?)
+        .bind(SealPhase::Prepare.discriminant() as i64)
+        .bind(request.new_head_layer_id.as_bytes().as_slice())
+        .bind(now)
+        .bind(now)
+        .execute(&mut *tx)
+        .await
+        .map_err(backend)?;
+        tx.commit().await.map_err(backend)?;
+        Ok(SealJournal {
+            journal_id: request.journal_id,
+            workspace_id: request.guard.workspace_id,
+            old_head_layer_id: request.guard.expected_head_layer_id,
+            expected_head_epoch: request.guard.expected_head_epoch,
+            phase: SealPhase::Prepare,
+            pending_bytes: 0,
+            delta_digest: None,
+            root_hash: None,
+            new_head_layer_id: Some(request.new_head_layer_id),
+            last_error: None,
+            created_at_ns: now,
+            updated_at_ns: now,
+        })
+    }
+
+    async fn advance_seal(&self, request: AdvanceSeal) -> Result<SealJournal, WorkspaceError> {
+        let allowed = matches!(
+            (request.expected_phase, request.next_phase),
+            (SealPhase::Prepare, SealPhase::Quiesced)
+                | (SealPhase::Quiesced, SealPhase::DataDrained)
+                | (SealPhase::HeadSwitched, SealPhase::Completed)
+        );
+        if !allowed {
+            return Err(WorkspaceError::InvalidStateTransition {
+                from: format!("{:?}", request.expected_phase),
+                to: format!("{:?}", request.next_phase),
+            });
+        }
+        let _guard = self.write_gate.lock().await;
+        let now = now_ns()?;
+        let pending = request
+            .pending_bytes
+            .map(|value| to_i64(value, "pending bytes"));
+        let pending = pending.transpose()?;
+        let row = sea_orm::sqlx::query(
+            "UPDATE ws_v1_seal_journal
+             SET phase = ?, pending_bytes = COALESCE(?, pending_bytes),
+                 last_error = ?, updated_at_ns = ?
+             WHERE journal_id = ? AND phase = ?
+             RETURNING journal_id, workspace_id, old_head_layer_id,
+                       expected_head_epoch, phase, pending_bytes, delta_digest,
+                       root_hash, new_head_layer_id, last_error, created_at_ns, updated_at_ns",
+        )
+        .bind(request.next_phase.discriminant() as i64)
+        .bind(pending)
+        .bind(request.last_error.as_deref())
+        .bind(now)
+        .bind(request.journal_id.as_bytes().as_slice())
+        .bind(request.expected_phase.discriminant() as i64)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(backend)?
+        .ok_or_else(|| WorkspaceError::InvalidStateTransition {
+            from: format!("not {:?}", request.expected_phase),
+            to: format!("{:?}", request.next_phase),
+        })?;
+        decode_seal_journal(&row)
+    }
+
+    async fn hash_seal(&self, journal_id: JournalId) -> Result<SealJournal, WorkspaceError> {
+        let _guard = self.write_gate.lock().await;
+        let current = load_seal_journal_pool(&self.pool, journal_id).await?;
+        if current.phase != SealPhase::DataDrained {
+            return Err(WorkspaceError::InvalidStateTransition {
+                from: format!("{:?}", current.phase),
+                to: "Hashed".into(),
+            });
+        }
+        let delta = load_layer_delta_pool(&self.pool, current.old_head_layer_id).await?;
+        let digest = delta_digest(&delta)?;
+        let layer = self.load_layer(current.old_head_layer_id).await?;
+        let parent_hash = match layer.parent_layer_id {
+            Some(parent) => self.load_layer(parent).await?.root_hash.ok_or_else(|| {
+                WorkspaceError::CorruptMetadata("sealed parent has no root hash".into())
+            })?,
+            None => [0; 32],
+        };
+        let root = root_hash(parent_hash, digest);
+        let now = now_ns()?;
+        let row = sea_orm::sqlx::query(
+            "UPDATE ws_v1_seal_journal
+             SET phase = ?, delta_digest = ?, root_hash = ?, updated_at_ns = ?
+             WHERE journal_id = ? AND phase = ?
+             RETURNING journal_id, workspace_id, old_head_layer_id,
+                       expected_head_epoch, phase, pending_bytes, delta_digest,
+                       root_hash, new_head_layer_id, last_error, created_at_ns, updated_at_ns",
+        )
+        .bind(SealPhase::Hashed.discriminant() as i64)
+        .bind(digest.as_slice())
+        .bind(root.as_slice())
+        .bind(now)
+        .bind(journal_id.as_bytes().as_slice())
+        .bind(SealPhase::DataDrained.discriminant() as i64)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(backend)?
+        .ok_or(WorkspaceError::Fenced)?;
+        decode_seal_journal(&row)
+    }
+
+    async fn commit_seal(&self, journal_id: JournalId) -> Result<SealResult, WorkspaceError> {
+        let _guard = self.write_gate.lock().await;
+        let mut tx = self.begin_write().await?;
+        let row = load_seal_journal_tx(&mut tx, journal_id).await?;
+        if row.phase == SealPhase::Completed {
+            let old = load_revision_tx(&mut tx, row.old_head_layer_id).await?;
+            let workspace = load_workspace_tx(&mut tx, row.workspace_id).await?;
+            return Ok(SealResult {
+                revision: old,
+                new_head_layer_id: workspace.head_layer_id,
+                head_epoch: workspace.head_epoch,
+            });
+        }
+        if row.phase == SealPhase::HeadSwitched {
+            let old = load_revision_tx(&mut tx, row.old_head_layer_id).await?;
+            let workspace = load_workspace_tx(&mut tx, row.workspace_id).await?;
+            let now = now_ns()?;
+            sea_orm::sqlx::query(
+                "UPDATE ws_v1_seal_journal SET phase = ?, updated_at_ns = ?
+                 WHERE journal_id = ? AND phase = ?",
+            )
+            .bind(SealPhase::Completed.discriminant() as i64)
+            .bind(now)
+            .bind(journal_id.as_bytes().as_slice())
+            .bind(SealPhase::HeadSwitched.discriminant() as i64)
+            .execute(&mut *tx)
+            .await
+            .map_err(backend)?;
+            tx.commit().await.map_err(backend)?;
+            return Ok(SealResult {
+                revision: old,
+                new_head_layer_id: workspace.head_layer_id,
+                head_epoch: workspace.head_epoch,
+            });
+        }
+        if row.phase != SealPhase::Hashed {
+            return Err(WorkspaceError::InvalidStateTransition {
+                from: format!("{:?}", row.phase),
+                to: "HeadSwitched".into(),
+            });
+        }
+        let digest = row
+            .delta_digest
+            .ok_or_else(|| WorkspaceError::CorruptMetadata("hashed journal lacks digest".into()))?;
+        let root = row.root_hash.ok_or_else(|| {
+            WorkspaceError::CorruptMetadata("hashed journal lacks root hash".into())
+        })?;
+        let new_head = row
+            .new_head_layer_id
+            .ok_or_else(|| WorkspaceError::CorruptMetadata("seal journal lacks new head".into()))?;
+        let old_layer_row =
+            sea_orm::sqlx::query("SELECT depth FROM ws_v1_layers WHERE layer_id = ? AND state = ?")
+                .bind(row.old_head_layer_id.as_bytes().as_slice())
+                .bind(LayerState::Sealing.discriminant() as i64)
+                .fetch_optional(&mut *tx)
+                .await
+                .map_err(backend)?
+                .ok_or(WorkspaceError::Fenced)?;
+        let new_depth = to_u32(
+            old_layer_row.try_get("depth").map_err(backend)?,
+            "layer depth",
+        )?
+        .checked_add(1)
+        .ok_or_else(|| WorkspaceError::CorruptMetadata("layer depth overflows".into()))?;
+        if new_depth > crate::workspace_overlay::model::LAYER_CHAIN_HARD_LIMIT {
+            return Err(WorkspaceError::LayerDepthLimit {
+                depth: new_depth,
+                hard_limit: crate::workspace_overlay::model::LAYER_CHAIN_HARD_LIMIT,
+            });
+        }
+        let sealed_version = allocate_id_tx(&mut tx, "sealed_version").await?;
+        let sealed_version = to_u64(sealed_version, "sealed version")?;
+        let now = now_ns()?;
+        let updated = sea_orm::sqlx::query(
+            "UPDATE ws_v1_layers
+             SET state = ?, sealed_version = ?, delta_digest = ?, root_hash = ?,
+                 owner_workspace_id = NULL, sealed_at_ns = ?
+             WHERE layer_id = ? AND state = ?",
+        )
+        .bind(LayerState::Sealed.discriminant() as i64)
+        .bind(to_i64(sealed_version, "sealed version")?)
+        .bind(digest.as_slice())
+        .bind(root.as_slice())
+        .bind(now)
+        .bind(row.old_head_layer_id.as_bytes().as_slice())
+        .bind(LayerState::Sealing.discriminant() as i64)
+        .execute(&mut *tx)
+        .await
+        .map_err(backend)?;
+        if updated.rows_affected() != 1 {
+            return Err(WorkspaceError::Fenced);
+        }
+        insert_writable_layer(
+            &mut tx,
+            new_head,
+            row.old_head_layer_id,
+            new_depth,
+            row.workspace_id,
+            now,
+        )
+        .await?;
+        let new_epoch = row
+            .expected_head_epoch
+            .checked_add(1)
+            .ok_or_else(|| WorkspaceError::CorruptMetadata("head epoch overflows".into()))?;
+        let switched = sea_orm::sqlx::query(
+            "UPDATE ws_v1_workspaces
+             SET head_layer_id = ?, head_epoch = ?, state = ?, updated_at_ns = ?
+             WHERE workspace_id = ? AND head_layer_id = ? AND head_epoch = ? AND state = ?",
+        )
+        .bind(new_head.as_bytes().as_slice())
+        .bind(to_i64(new_epoch, "head epoch")?)
+        .bind(WorkspaceState::Active.discriminant() as i64)
+        .bind(now)
+        .bind(row.workspace_id.as_bytes().as_slice())
+        .bind(row.old_head_layer_id.as_bytes().as_slice())
+        .bind(to_i64(row.expected_head_epoch, "head epoch")?)
+        .bind(WorkspaceState::Sealing.discriminant() as i64)
+        .execute(&mut *tx)
+        .await
+        .map_err(backend)?;
+        if switched.rows_affected() != 1 {
+            return Err(WorkspaceError::Fenced);
+        }
+        sea_orm::sqlx::query(
+            "UPDATE ws_v1_snapshot_leases
+             SET base_layer_id = ?, base_version = ?, base_root_hash = ?, updated_at_ns = ?
+             WHERE workspace_id = ? AND state = ?",
+        )
+        .bind(row.old_head_layer_id.as_bytes().as_slice())
+        .bind(to_i64(sealed_version, "sealed version")?)
+        .bind(root.as_slice())
+        .bind(now)
+        .bind(row.workspace_id.as_bytes().as_slice())
+        .bind(LeaseState::Active.discriminant() as i64)
+        .execute(&mut *tx)
+        .await
+        .map_err(backend)?;
+        sea_orm::sqlx::query(
+            "UPDATE ws_v1_seal_journal SET phase = ?, updated_at_ns = ?
+             WHERE journal_id = ? AND phase = ?",
+        )
+        .bind(SealPhase::Completed.discriminant() as i64)
+        .bind(now)
+        .bind(journal_id.as_bytes().as_slice())
+        .bind(SealPhase::Hashed.discriminant() as i64)
+        .execute(&mut *tx)
+        .await
+        .map_err(backend)?;
+        tx.commit().await.map_err(backend)?;
+        Ok(SealResult {
+            revision: BaseRevision {
+                layer_id: row.old_head_layer_id,
+                sealed_version,
+                root_hash: root,
+            },
+            new_head_layer_id: new_head,
+            head_epoch: new_epoch,
+        })
+    }
+
+    async fn abort_recoverable_seal(&self, request: AbortSeal) -> Result<(), WorkspaceError> {
+        let _guard = self.write_gate.lock().await;
+        let mut tx = self.begin_write().await?;
+        let journal = load_seal_journal_tx(&mut tx, request.journal_id).await?;
+        if !matches!(
+            journal.phase,
+            SealPhase::Prepare | SealPhase::Quiesced | SealPhase::DataDrained
+        ) {
+            return Err(WorkspaceError::InvalidStateTransition {
+                from: format!("{:?}", journal.phase),
+                to: "Aborted".into(),
+            });
+        }
+        let now = now_ns()?;
+        sea_orm::sqlx::query("UPDATE ws_v1_layers SET state = ? WHERE layer_id = ? AND state = ?")
+            .bind(LayerState::Writable.discriminant() as i64)
+            .bind(journal.old_head_layer_id.as_bytes().as_slice())
+            .bind(LayerState::Sealing.discriminant() as i64)
+            .execute(&mut *tx)
+            .await
+            .map_err(backend)?;
+        sea_orm::sqlx::query(
+            "UPDATE ws_v1_workspaces SET state = ?, updated_at_ns = ?
+             WHERE workspace_id = ? AND head_layer_id = ? AND head_epoch = ?",
+        )
+        .bind(WorkspaceState::Active.discriminant() as i64)
+        .bind(now)
+        .bind(journal.workspace_id.as_bytes().as_slice())
+        .bind(journal.old_head_layer_id.as_bytes().as_slice())
+        .bind(to_i64(journal.expected_head_epoch, "head epoch")?)
+        .execute(&mut *tx)
+        .await
+        .map_err(backend)?;
+        sea_orm::sqlx::query(
+            "UPDATE ws_v1_seal_journal SET phase = ?, last_error = ?, updated_at_ns = ?
+             WHERE journal_id = ?",
+        )
+        .bind(SealPhase::Aborted.discriminant() as i64)
+        .bind(request.reason)
+        .bind(now)
+        .bind(request.journal_id.as_bytes().as_slice())
+        .execute(&mut *tx)
+        .await
+        .map_err(backend)?;
+        tx.commit().await.map_err(backend)?;
+        Ok(())
+    }
+
+    async fn load_seal_journal(
+        &self,
+        journal_id: JournalId,
+    ) -> Result<SealJournal, WorkspaceError> {
+        load_seal_journal_pool(&self.pool, journal_id).await
+    }
+
+    async fn list_incomplete_seal_journals(&self) -> Result<Vec<SealJournal>, WorkspaceError> {
+        let rows = sea_orm::sqlx::query(
+            "SELECT journal_id, workspace_id, old_head_layer_id, expected_head_epoch,
+                    phase, pending_bytes, delta_digest, root_hash, new_head_layer_id,
+                    last_error, created_at_ns, updated_at_ns
+             FROM ws_v1_seal_journal WHERE phase NOT IN (?, ?) ORDER BY created_at_ns",
+        )
+        .bind(SealPhase::Completed.discriminant() as i64)
+        .bind(SealPhase::Aborted.discriminant() as i64)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(backend)?;
+        rows.iter().map(decode_seal_journal).collect()
+    }
+
+    async fn fast_forward_commit(
+        &self,
+        request: FastForwardCommit,
+    ) -> Result<CommitResult, WorkspaceError> {
+        let _guard = self.write_gate.lock().await;
+        let mut tx = self.begin_write().await?;
+        if load_revision_tx(&mut tx, request.source_revision.layer_id).await?
+            != request.source_revision
+        {
+            return Err(commit_conflict("source revision changed"));
+        }
+        let target = load_workspace_tx(&mut tx, request.target_workspace_id).await?;
+        if target.head_layer_id != request.target_expected_head_layer_id
+            || target.head_epoch != request.target_expected_head_epoch
+            || target.state != WorkspaceState::Active
+            || target.fork_base.as_ref() != Some(&request.source_fork_base)
+        {
+            return Err(commit_conflict("target revision changed"));
+        }
+        let target_head = sea_orm::sqlx::query(
+            "SELECT parent_layer_id, next_sequence, depth FROM ws_v1_layers
+             WHERE layer_id = ? AND state = ? AND owner_workspace_id = ?",
+        )
+        .bind(target.head_layer_id.as_bytes().as_slice())
+        .bind(LayerState::Writable.discriminant() as i64)
+        .bind(target.workspace_id.as_bytes().as_slice())
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(backend)?
+        .ok_or_else(|| commit_conflict("target head is not writable"))?;
+        if target_head
+            .try_get::<i64, _>("next_sequence")
+            .map_err(backend)?
+            != 1
+        {
+            return Err(commit_conflict("target writable head is not empty"));
+        }
+        let parent = LayerId::from_uuid(uuid_from_blob(
+            target_head.try_get("parent_layer_id").map_err(backend)?,
+            "target parent layer",
+        )?);
+        if load_revision_tx(&mut tx, parent).await? != request.source_fork_base {
+            return Err(commit_conflict("target base revision changed"));
+        }
+        let now = now_ns()?;
+        let active_lease = sea_orm::sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM ws_v1_snapshot_leases
+             WHERE workspace_id = ? AND writable = 1 AND state = ? AND expires_at_ns > ?",
+        )
+        .bind(target.workspace_id.as_bytes().as_slice())
+        .bind(LeaseState::Active.discriminant() as i64)
+        .bind(now)
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(backend)?;
+        if active_lease != 0 {
+            return Err(commit_conflict("target has an active writable lease"));
+        }
+        let source_depth = sea_orm::sqlx::query_scalar::<_, i64>(
+            "SELECT depth FROM ws_v1_layers WHERE layer_id = ?",
+        )
+        .bind(request.source_revision.layer_id.as_bytes().as_slice())
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(backend)?;
+        let depth = to_u32(source_depth, "source depth")?
+            .checked_add(1)
+            .ok_or_else(|| WorkspaceError::CorruptMetadata("layer depth overflows".into()))?;
+        if depth > crate::workspace_overlay::model::LAYER_CHAIN_HARD_LIMIT {
+            return Err(WorkspaceError::LayerDepthLimit {
+                depth,
+                hard_limit: crate::workspace_overlay::model::LAYER_CHAIN_HARD_LIMIT,
+            });
+        }
+        insert_writable_layer(
+            &mut tx,
+            request.new_head_layer_id,
+            request.source_revision.layer_id,
+            depth,
+            target.workspace_id,
+            now,
+        )
+        .await?;
+        let epoch = target
+            .head_epoch
+            .checked_add(1)
+            .ok_or_else(|| WorkspaceError::CorruptMetadata("head epoch overflows".into()))?;
+        sea_orm::sqlx::query(
+            "UPDATE ws_v1_workspaces
+             SET head_layer_id = ?, head_epoch = ?, fork_base_layer_id = ?,
+                 fork_base_version = ?, fork_base_root_hash = ?, updated_at_ns = ?
+             WHERE workspace_id = ? AND head_layer_id = ? AND head_epoch = ?",
+        )
+        .bind(request.new_head_layer_id.as_bytes().as_slice())
+        .bind(to_i64(epoch, "head epoch")?)
+        .bind(request.source_revision.layer_id.as_bytes().as_slice())
+        .bind(to_i64(
+            request.source_revision.sealed_version,
+            "sealed version",
+        )?)
+        .bind(request.source_revision.root_hash.as_slice())
+        .bind(now)
+        .bind(target.workspace_id.as_bytes().as_slice())
+        .bind(target.head_layer_id.as_bytes().as_slice())
+        .bind(to_i64(target.head_epoch, "head epoch")?)
+        .execute(&mut *tx)
+        .await
+        .map_err(backend)?;
+        sea_orm::sqlx::query(
+            "UPDATE ws_v1_layers SET state = ?, owner_workspace_id = NULL
+             WHERE layer_id = ? AND state = ?",
+        )
+        .bind(LayerState::Deleting.discriminant() as i64)
+        .bind(target.head_layer_id.as_bytes().as_slice())
+        .bind(LayerState::Writable.discriminant() as i64)
+        .execute(&mut *tx)
+        .await
+        .map_err(backend)?;
+        tx.commit().await.map_err(backend)?;
+        Ok(CommitResult {
+            revision: request.source_revision,
+            target_head_layer_id: request.new_head_layer_id,
+            target_head_epoch: epoch,
+        })
+    }
+
+    async fn mark_workspace_deleting(&self, request: MarkDeleting) -> Result<(), WorkspaceError> {
+        let _guard = self.write_gate.lock().await;
+        let mut tx = self.begin_write().await?;
+        let now = now_ns()?;
+        let active = sea_orm::sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM ws_v1_snapshot_leases
+             WHERE workspace_id = ? AND state = ? AND expires_at_ns > ?",
+        )
+        .bind(request.workspace_id.as_bytes().as_slice())
+        .bind(LeaseState::Active.discriminant() as i64)
+        .bind(now)
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(backend)?;
+        if active != 0 && !request.force_fence_lease {
+            return Err(WorkspaceError::Busy);
+        }
+        if request.force_fence_lease {
+            sea_orm::sqlx::query(
+                "UPDATE ws_v1_snapshot_leases SET state = ?, updated_at_ns = ?
+                 WHERE workspace_id = ? AND state = ?",
+            )
+            .bind(LeaseState::Released.discriminant() as i64)
+            .bind(now)
+            .bind(request.workspace_id.as_bytes().as_slice())
+            .bind(LeaseState::Active.discriminant() as i64)
+            .execute(&mut *tx)
+            .await
+            .map_err(backend)?;
+        }
+        let row = sea_orm::sqlx::query(
+            "UPDATE ws_v1_workspaces SET state = ?, updated_at_ns = ?
+             WHERE workspace_id = ? AND state = ? RETURNING head_layer_id",
+        )
+        .bind(WorkspaceState::Deleting.discriminant() as i64)
+        .bind(now)
+        .bind(request.workspace_id.as_bytes().as_slice())
+        .bind(WorkspaceState::Active.discriminant() as i64)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(backend)?
+        .ok_or(WorkspaceError::WorkspaceNotFound(request.workspace_id))?;
+        let head = row
+            .try_get::<Vec<u8>, _>("head_layer_id")
+            .map_err(backend)?;
+        sea_orm::sqlx::query(
+            "UPDATE ws_v1_layers SET state = ?, owner_workspace_id = NULL
+             WHERE layer_id = ? AND state = ?",
+        )
+        .bind(LayerState::Deleting.discriminant() as i64)
+        .bind(head)
+        .bind(LayerState::Writable.discriminant() as i64)
+        .execute(&mut *tx)
+        .await
+        .map_err(backend)?;
+        tx.commit().await.map_err(backend)?;
+        Ok(())
+    }
+
+    async fn record_orphan_slice(&self, request: RecordOrphanSlice) -> Result<(), WorkspaceError> {
+        if request.slice_end == 0 {
+            return Err(WorkspaceError::CorruptMetadata(
+                "orphan slice length must be non-zero".into(),
+            ));
+        }
+        let _guard = self.write_gate.lock().await;
+        let mut tx = self.begin_write().await?;
+        let now = now_ns()?;
+        sea_orm::sqlx::query(
+            "INSERT INTO ws_v1_layers
+             (layer_id, parent_layer_id, state, schema_version, sealed_version,
+              delta_digest, root_hash, depth, owner_workspace_id, next_sequence,
+              owned_slice_count, owned_bytes, created_at_ns, sealed_at_ns)
+             VALUES (?, NULL, ?, ?, NULL, NULL, NULL, 1, NULL, 2, 1, ?, ?, NULL)",
+        )
+        .bind(request.orphan_layer_id.as_bytes().as_slice())
+        .bind(LayerState::Deleting.discriminant() as i64)
+        .bind(WORKSPACE_SCHEMA_VERSION as i64)
+        .bind(to_i64(request.slice_end, "orphan slice end")?)
+        .bind(now)
+        .execute(&mut *tx)
+        .await
+        .map_err(backend)?;
+        insert_extent(
+            &mut tx,
+            &DataExtentDelta::data(
+                request.orphan_layer_id,
+                1,
+                0,
+                0,
+                request.slice_end,
+                request.slice_id,
+                0,
+                1,
+            ),
+        )
+        .await?;
+        tx.commit().await.map_err(backend)?;
+        Ok(())
+    }
+
+    async fn gc_snapshot(
+        &self,
+        now_ns: i64,
+        lease_grace_ns: u64,
+    ) -> Result<GcSnapshot, WorkspaceError> {
+        let grace = to_i64(lease_grace_ns, "lease grace")?;
+        let lease_cutoff = now_ns.saturating_sub(grace);
+        let mut roots = BTreeSet::new();
+        let workspace_roots =
+            sea_orm::sqlx::query("SELECT head_layer_id FROM ws_v1_workspaces WHERE state != ?")
+                .bind(WorkspaceState::Deleting.discriminant() as i64)
+                .fetch_all(&self.pool)
+                .await
+                .map_err(backend)?;
+        for row in workspace_roots {
+            roots.insert(LayerId::from_uuid(uuid_from_blob(
+                row.try_get("head_layer_id").map_err(backend)?,
+                "workspace GC root",
+            )?));
+        }
+        let lease_roots = sea_orm::sqlx::query(
+            "SELECT base_layer_id FROM ws_v1_snapshot_leases
+             WHERE state IN (?, ?) AND expires_at_ns > ?",
+        )
+        .bind(LeaseState::Active.discriminant() as i64)
+        .bind(LeaseState::Releasing.discriminant() as i64)
+        .bind(lease_cutoff)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(backend)?;
+        for row in lease_roots {
+            roots.insert(LayerId::from_uuid(uuid_from_blob(
+                row.try_get("base_layer_id").map_err(backend)?,
+                "lease GC root",
+            )?));
+        }
+        let snapshot_roots = sea_orm::sqlx::query("SELECT layer_id FROM ws_v1_snapshots")
+            .fetch_all(&self.pool)
+            .await
+            .map_err(backend)?;
+        for row in snapshot_roots {
+            roots.insert(LayerId::from_uuid(uuid_from_blob(
+                row.try_get("layer_id").map_err(backend)?,
+                "snapshot GC root",
+            )?));
+        }
+        let journal_roots = sea_orm::sqlx::query(
+            "SELECT old_head_layer_id, new_head_layer_id FROM ws_v1_seal_journal
+             WHERE phase NOT IN (?, ?)",
+        )
+        .bind(SealPhase::Completed.discriminant() as i64)
+        .bind(SealPhase::Aborted.discriminant() as i64)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(backend)?;
+        for row in journal_roots {
+            roots.insert(LayerId::from_uuid(uuid_from_blob(
+                row.try_get("old_head_layer_id").map_err(backend)?,
+                "journal old-head GC root",
+            )?));
+            if let Some(bytes) = row
+                .try_get::<Option<Vec<u8>>, _>("new_head_layer_id")
+                .map_err(backend)?
+            {
+                roots.insert(LayerId::from_uuid(uuid_from_blob(
+                    bytes,
+                    "journal new-head GC root",
+                )?));
+            }
+        }
+        let layer_rows = sea_orm::sqlx::query(
+            "SELECT layer_id, parent_layer_id, state, schema_version, sealed_version,
+                    delta_digest, root_hash, depth, owner_workspace_id, next_sequence,
+                    owned_slice_count, owned_bytes, created_at_ns, sealed_at_ns
+             FROM ws_v1_layers ORDER BY created_at_ns, layer_id",
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(backend)?;
+        let layers = layer_rows
+            .iter()
+            .map(decode_layer)
+            .collect::<Result<Vec<_>, _>>()?;
+        let slice_rows = sea_orm::sqlx::query(
+            "SELECT layer_id, slice_id, slice_offset, length
+             FROM ws_v1_data_extent_delta WHERE kind = 0",
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(backend)?;
+        let mut slice_references = Vec::with_capacity(slice_rows.len());
+        for row in slice_rows {
+            let slice_offset = to_u64(
+                row.try_get("slice_offset").map_err(backend)?,
+                "slice offset",
+            )?;
+            let length = to_u64(row.try_get("length").map_err(backend)?, "extent length")?;
+            slice_references.push(SliceReference {
+                layer_id: LayerId::from_uuid(uuid_from_blob(
+                    row.try_get("layer_id").map_err(backend)?,
+                    "slice reference layer",
+                )?),
+                slice_id: to_u64(row.try_get("slice_id").map_err(backend)?, "slice ID")?,
+                slice_end: slice_offset.checked_add(length).ok_or_else(|| {
+                    WorkspaceError::CorruptMetadata("slice reference overflows".into())
+                })?,
+            });
+        }
+        Ok(GcSnapshot {
+            root_layers: roots.into_iter().collect(),
+            layers,
+            slice_references,
+        })
+    }
+
+    async fn delete_layer_metadata(
+        &self,
+        request: DeleteLayerMetadata,
+    ) -> Result<(), WorkspaceError> {
+        if request.layer_ids.is_empty() {
+            return Ok(());
+        }
+        let _guard = self.write_gate.lock().await;
+        let mut tx = self.begin_write().await?;
+        let lease_cutoff = request
+            .now_ns
+            .saturating_sub(to_i64(request.lease_grace_ns, "lease grace")?);
+        for layer_id in &request.layer_ids {
+            let reachable = sea_orm::sqlx::query_scalar::<_, i64>(
+                "WITH RECURSIVE roots(layer_id) AS (
+                     SELECT head_layer_id FROM ws_v1_workspaces WHERE state != ?
+                     UNION SELECT layer_id FROM ws_v1_snapshots
+                     UNION SELECT base_layer_id FROM ws_v1_snapshot_leases
+                       WHERE state IN (?, ?) AND expires_at_ns > ?
+                     UNION SELECT old_head_layer_id FROM ws_v1_seal_journal
+                       WHERE phase NOT IN (?, ?)
+                     UNION SELECT new_head_layer_id FROM ws_v1_seal_journal
+                       WHERE phase NOT IN (?, ?) AND new_head_layer_id IS NOT NULL
+                 ), reachable(layer_id) AS (
+                     SELECT layer_id FROM roots
+                     UNION
+                     SELECT l.parent_layer_id FROM ws_v1_layers l
+                     JOIN reachable r ON l.layer_id = r.layer_id
+                     WHERE l.parent_layer_id IS NOT NULL
+                 ) SELECT COUNT(*) FROM reachable WHERE layer_id = ?",
+            )
+            .bind(WorkspaceState::Deleting.discriminant() as i64)
+            .bind(LeaseState::Active.discriminant() as i64)
+            .bind(LeaseState::Releasing.discriminant() as i64)
+            .bind(lease_cutoff)
+            .bind(SealPhase::Completed.discriminant() as i64)
+            .bind(SealPhase::Aborted.discriminant() as i64)
+            .bind(SealPhase::Completed.discriminant() as i64)
+            .bind(SealPhase::Aborted.discriminant() as i64)
+            .bind(layer_id.as_bytes().as_slice())
+            .fetch_one(&mut *tx)
+            .await
+            .map_err(backend)?;
+            if reachable != 0 {
+                return Err(WorkspaceError::Busy);
+            }
+        }
+        for layer_id in &request.layer_ids {
+            sea_orm::sqlx::query(
+                "UPDATE ws_v1_layers SET state = ?, owner_workspace_id = NULL
+                 WHERE layer_id = ?",
+            )
+            .bind(LayerState::Deleting.discriminant() as i64)
+            .bind(layer_id.as_bytes().as_slice())
+            .execute(&mut *tx)
+            .await
+            .map_err(backend)?;
+        }
+        tx.commit().await.map_err(backend)?;
+        Ok(())
+    }
+
+    async fn finalize_layer_metadata_deletion(
+        &self,
+        layer_ids: Vec<LayerId>,
+    ) -> Result<(), WorkspaceError> {
+        let _guard = self.write_gate.lock().await;
+        let mut tx = self.begin_write().await?;
+        for layer_id in &layer_ids {
+            let state = sea_orm::sqlx::query_scalar::<_, i64>(
+                "SELECT state FROM ws_v1_layers WHERE layer_id = ?",
+            )
+            .bind(layer_id.as_bytes().as_slice())
+            .fetch_optional(&mut *tx)
+            .await
+            .map_err(backend)?;
+            if state.is_some_and(|state| state != LayerState::Deleting.discriminant() as i64) {
+                return Err(WorkspaceError::Busy);
+            }
+            for table in [
+                "ws_v1_dentry_delta",
+                "ws_v1_inode_delta",
+                "ws_v1_xattr_delta",
+                "ws_v1_acl_delta",
+                "ws_v1_data_extent_delta",
+            ] {
+                let sql = format!("DELETE FROM {table} WHERE layer_id = ?");
+                sea_orm::sqlx::query(&sql)
+                    .bind(layer_id.as_bytes().as_slice())
+                    .execute(&mut *tx)
+                    .await
+                    .map_err(backend)?;
+            }
+            sea_orm::sqlx::query("DELETE FROM ws_v1_layers WHERE layer_id = ? AND state = ?")
+                .bind(layer_id.as_bytes().as_slice())
+                .bind(LayerState::Deleting.discriminant() as i64)
+                .execute(&mut *tx)
+                .await
+                .map_err(backend)?;
+        }
+        tx.commit().await.map_err(backend)?;
+        Ok(())
+    }
+
+    async fn install_compaction(
+        &self,
+        request: InstallCompaction,
+    ) -> Result<CompactionResult, WorkspaceError> {
+        if request.compacted_layer_id == request.replacement_head_layer_id {
+            return Err(WorkspaceError::CorruptMetadata(
+                "compacted and replacement head IDs must differ".into(),
+            ));
+        }
+        for layer_id in request
+            .delta
+            .dentries
+            .iter()
+            .map(|row| row.layer_id)
+            .chain(request.delta.inodes.iter().map(|row| row.layer_id))
+            .chain(request.delta.xattrs.iter().map(|row| row.layer_id))
+            .chain(request.delta.acls.iter().map(|row| row.layer_id))
+            .chain(request.delta.extents.iter().map(|row| row.layer_id))
+        {
+            if layer_id != request.compacted_layer_id {
+                return Err(WorkspaceError::CorruptMetadata(
+                    "compaction delta contains a foreign layer ID".into(),
+                ));
+            }
+        }
+        let digest = delta_digest(&request.delta)?;
+        let root = root_hash([0; 32], digest);
+        let max_sequence = request
+            .delta
+            .dentries
+            .iter()
+            .map(|row| row.sequence)
+            .chain(request.delta.inodes.iter().map(|row| row.sequence))
+            .chain(request.delta.xattrs.iter().map(|row| row.sequence))
+            .chain(request.delta.acls.iter().map(|row| row.sequence))
+            .chain(request.delta.extents.iter().map(|row| row.sequence))
+            .max()
+            .unwrap_or(0);
+        let next_sequence = max_sequence
+            .checked_add(1)
+            .ok_or_else(|| WorkspaceError::CorruptMetadata("sequence overflows".into()))?;
+
+        let _guard = self.write_gate.lock().await;
+        let mut tx = self.begin_write().await?;
+        let now = now_ns()?;
+        let head = sea_orm::sqlx::query(
+            "SELECT parent_layer_id, next_sequence FROM ws_v1_layers
+             WHERE layer_id = ? AND state = ? AND owner_workspace_id = ?",
+        )
+        .bind(request.expected_head_layer_id.as_bytes().as_slice())
+        .bind(LayerState::Writable.discriminant() as i64)
+        .bind(request.workspace_id.as_bytes().as_slice())
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(backend)?
+        .ok_or(WorkspaceError::Fenced)?;
+        let parent = LayerId::from_uuid(uuid_from_blob(
+            head.try_get("parent_layer_id").map_err(backend)?,
+            "compaction head parent",
+        )?);
+        if parent != request.expected_parent_layer_id
+            || head.try_get::<i64, _>("next_sequence").map_err(backend)? != 1
+        {
+            return Err(WorkspaceError::Fenced);
+        }
+        let workspace = load_workspace_tx(&mut tx, request.workspace_id).await?;
+        if workspace.head_layer_id != request.expected_head_layer_id
+            || workspace.head_epoch != request.expected_head_epoch
+            || workspace.state != WorkspaceState::Active
+        {
+            return Err(WorkspaceError::Fenced);
+        }
+        let sealed_version = to_u64(
+            allocate_id_tx(&mut tx, "sealed_version").await?,
+            "sealed version",
+        )?;
+        sea_orm::sqlx::query(
+            "INSERT INTO ws_v1_layers
+             (layer_id, parent_layer_id, state, schema_version, sealed_version,
+              delta_digest, root_hash, depth, owner_workspace_id, next_sequence,
+              owned_slice_count, owned_bytes, created_at_ns, sealed_at_ns)
+             VALUES (?, NULL, ?, ?, ?, ?, ?, 1, NULL, ?, 0, 0, ?, ?)",
+        )
+        .bind(request.compacted_layer_id.as_bytes().as_slice())
+        .bind(LayerState::Sealed.discriminant() as i64)
+        .bind(WORKSPACE_SCHEMA_VERSION as i64)
+        .bind(to_i64(sealed_version, "sealed version")?)
+        .bind(digest.as_slice())
+        .bind(root.as_slice())
+        .bind(to_i64(next_sequence, "next sequence")?)
+        .bind(now)
+        .bind(now)
+        .execute(&mut *tx)
+        .await
+        .map_err(backend)?;
+        for row in &request.delta.dentries {
+            upsert_dentry(&mut tx, row).await?;
+        }
+        for row in &request.delta.inodes {
+            upsert_inode(&mut tx, row).await?;
+        }
+        for row in &request.delta.xattrs {
+            upsert_xattr(&mut tx, row).await?;
+        }
+        for row in &request.delta.acls {
+            upsert_acl(&mut tx, row).await?;
+        }
+        for row in &request.delta.extents {
+            insert_extent(&mut tx, row).await?;
+        }
+        insert_writable_layer(
+            &mut tx,
+            request.replacement_head_layer_id,
+            request.compacted_layer_id,
+            2,
+            request.workspace_id,
+            now,
+        )
+        .await?;
+        let epoch = workspace
+            .head_epoch
+            .checked_add(1)
+            .ok_or_else(|| WorkspaceError::CorruptMetadata("head epoch overflows".into()))?;
+        let switched = sea_orm::sqlx::query(
+            "UPDATE ws_v1_workspaces
+             SET head_layer_id = ?, head_epoch = ?, fork_base_layer_id = ?,
+                 fork_base_version = ?, fork_base_root_hash = ?, updated_at_ns = ?
+             WHERE workspace_id = ? AND head_layer_id = ? AND head_epoch = ? AND state = ?",
+        )
+        .bind(request.replacement_head_layer_id.as_bytes().as_slice())
+        .bind(to_i64(epoch, "head epoch")?)
+        .bind(request.compacted_layer_id.as_bytes().as_slice())
+        .bind(to_i64(sealed_version, "sealed version")?)
+        .bind(root.as_slice())
+        .bind(now)
+        .bind(request.workspace_id.as_bytes().as_slice())
+        .bind(request.expected_head_layer_id.as_bytes().as_slice())
+        .bind(to_i64(request.expected_head_epoch, "head epoch")?)
+        .bind(WorkspaceState::Active.discriminant() as i64)
+        .execute(&mut *tx)
+        .await
+        .map_err(backend)?;
+        if switched.rows_affected() != 1 {
+            return Err(WorkspaceError::Fenced);
+        }
+        sea_orm::sqlx::query(
+            "UPDATE ws_v1_snapshot_leases
+             SET base_layer_id = ?, base_version = ?, base_root_hash = ?, updated_at_ns = ?
+             WHERE workspace_id = ? AND state = ?",
+        )
+        .bind(request.compacted_layer_id.as_bytes().as_slice())
+        .bind(to_i64(sealed_version, "sealed version")?)
+        .bind(root.as_slice())
+        .bind(now)
+        .bind(request.workspace_id.as_bytes().as_slice())
+        .bind(LeaseState::Active.discriminant() as i64)
+        .execute(&mut *tx)
+        .await
+        .map_err(backend)?;
+        sea_orm::sqlx::query(
+            "UPDATE ws_v1_layers SET state = ?, owner_workspace_id = NULL
+             WHERE layer_id = ? AND state = ?",
+        )
+        .bind(LayerState::Deleting.discriminant() as i64)
+        .bind(request.expected_head_layer_id.as_bytes().as_slice())
+        .bind(LayerState::Writable.discriminant() as i64)
+        .execute(&mut *tx)
+        .await
+        .map_err(backend)?;
+        tx.commit().await.map_err(backend)?;
+        Ok(CompactionResult {
+            revision: BaseRevision {
+                layer_id: request.compacted_layer_id,
+                sealed_version,
+                root_hash: root,
+            },
+            replacement_head_layer_id: request.replacement_head_layer_id,
+            head_epoch: epoch,
+        })
+    }
+}
+
+async fn insert_writable_layer(
+    tx: &mut Transaction<'_, Sqlite>,
+    layer_id: LayerId,
+    parent_layer_id: LayerId,
+    depth: u32,
+    workspace_id: WorkspaceId,
+    now: i64,
+) -> Result<(), WorkspaceError> {
+    sea_orm::sqlx::query(
+        "INSERT INTO ws_v1_layers
+         (layer_id, parent_layer_id, state, schema_version, sealed_version,
+          delta_digest, root_hash, depth, owner_workspace_id, next_sequence,
+          owned_slice_count, owned_bytes, created_at_ns, sealed_at_ns)
+         VALUES (?, ?, ?, ?, NULL, NULL, NULL, ?, ?, 1, 0, 0, ?, NULL)",
+    )
+    .bind(layer_id.as_bytes().as_slice())
+    .bind(parent_layer_id.as_bytes().as_slice())
+    .bind(LayerState::Writable.discriminant() as i64)
+    .bind(WORKSPACE_SCHEMA_VERSION as i64)
+    .bind(i64::from(depth))
+    .bind(workspace_id.as_bytes().as_slice())
+    .bind(now)
+    .execute(&mut **tx)
+    .await
+    .map_err(backend)?;
+    Ok(())
+}
+
+async fn allocate_id_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    name: &str,
+) -> Result<i64, WorkspaceError> {
+    sea_orm::sqlx::query_scalar::<_, i64>(
+        "UPDATE ws_v1_allocators SET next_value = next_value + 1
+         WHERE name = ? AND next_value < ? RETURNING next_value - 1",
+    )
+    .bind(name)
+    .bind(i64::MAX)
+    .fetch_optional(&mut **tx)
+    .await
+    .map_err(backend)?
+    .ok_or_else(|| {
+        WorkspaceError::CorruptMetadata(format!(
+            "workspace allocator {name} is missing or exhausted"
+        ))
+    })
+}
+
+async fn load_revision_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    layer_id: LayerId,
+) -> Result<BaseRevision, WorkspaceError> {
+    let row = sea_orm::sqlx::query(
+        "SELECT state, sealed_version, root_hash FROM ws_v1_layers WHERE layer_id = ?",
+    )
+    .bind(layer_id.as_bytes().as_slice())
+    .fetch_optional(&mut **tx)
+    .await
+    .map_err(backend)?
+    .ok_or(WorkspaceError::LayerNotFound(layer_id))?;
+    let state = LayerState::try_from(to_u8(
+        row.try_get::<i64, _>("state").map_err(backend)?,
+        "layer state",
+    )?)?;
+    if state != LayerState::Sealed {
+        return Err(commit_conflict("revision layer is not sealed"));
+    }
+    Ok(BaseRevision {
+        layer_id,
+        sealed_version: to_u64(
+            row.try_get::<Option<i64>, _>("sealed_version")
+                .map_err(backend)?
+                .ok_or_else(|| {
+                    WorkspaceError::CorruptMetadata("sealed layer lacks version".into())
+                })?,
+            "sealed version",
+        )?,
+        root_hash: hash_from_blob(
+            row.try_get::<Option<Vec<u8>>, _>("root_hash")
+                .map_err(backend)?
+                .ok_or_else(|| {
+                    WorkspaceError::CorruptMetadata("sealed layer lacks root hash".into())
+                })?,
+            "root hash",
+        )?,
+    })
+}
+
+async fn load_workspace_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    workspace_id: WorkspaceId,
+) -> Result<WorkspaceRecord, WorkspaceError> {
+    let row = sea_orm::sqlx::query(
+        "SELECT workspace_id, head_layer_id, head_epoch,
+                fork_base_layer_id, fork_base_version, fork_base_root_hash,
+                owner_id, state, created_at_ns, updated_at_ns
+         FROM ws_v1_workspaces WHERE workspace_id = ?",
+    )
+    .bind(workspace_id.as_bytes().as_slice())
+    .fetch_optional(&mut **tx)
+    .await
+    .map_err(backend)?
+    .ok_or(WorkspaceError::WorkspaceNotFound(workspace_id))?;
+    decode_workspace(&row)
+}
+
+async fn load_seal_journal_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    journal_id: JournalId,
+) -> Result<SealJournal, WorkspaceError> {
+    let row = sea_orm::sqlx::query(
+        "SELECT journal_id, workspace_id, old_head_layer_id, expected_head_epoch,
+                phase, pending_bytes, delta_digest, root_hash, new_head_layer_id,
+                last_error, created_at_ns, updated_at_ns
+         FROM ws_v1_seal_journal WHERE journal_id = ?",
+    )
+    .bind(journal_id.as_bytes().as_slice())
+    .fetch_optional(&mut **tx)
+    .await
+    .map_err(backend)?
+    .ok_or_else(|| WorkspaceError::Backend(format!("seal journal not found: {journal_id}")))?;
+    decode_seal_journal(&row)
+}
+
+async fn load_seal_journal_pool(
+    pool: &SqlitePool,
+    journal_id: JournalId,
+) -> Result<SealJournal, WorkspaceError> {
+    let row = sea_orm::sqlx::query(
+        "SELECT journal_id, workspace_id, old_head_layer_id, expected_head_epoch,
+                phase, pending_bytes, delta_digest, root_hash, new_head_layer_id,
+                last_error, created_at_ns, updated_at_ns
+         FROM ws_v1_seal_journal WHERE journal_id = ?",
+    )
+    .bind(journal_id.as_bytes().as_slice())
+    .fetch_optional(pool)
+    .await
+    .map_err(backend)?
+    .ok_or_else(|| WorkspaceError::Backend(format!("seal journal not found: {journal_id}")))?;
+    decode_seal_journal(&row)
+}
+
+async fn load_layer_delta_pool(
+    pool: &SqlitePool,
+    layer_id: LayerId,
+) -> Result<CanonicalLayerDelta, WorkspaceError> {
+    let dentries = sea_orm::sqlx::query(
+        "SELECT layer_id, parent_ino, name, op, ino, entry_type, sequence
+         FROM ws_v1_dentry_delta WHERE layer_id = ?",
+    )
+    .bind(layer_id.as_bytes().as_slice())
+    .fetch_all(pool)
+    .await
+    .map_err(backend)?
+    .into_iter()
+    .map(decode_dentry)
+    .collect::<Result<Vec<_>, _>>()?;
+    let inode_rows = sea_orm::sqlx::query(
+        "SELECT layer_id, ino, state, kind, size, mode, uid, gid, rdev, nlink,
+                atime_ns, mtime_ns, ctime_ns, symlink_target, parent_hint,
+                data_version, sequence
+         FROM ws_v1_inode_delta WHERE layer_id = ?",
+    )
+    .bind(layer_id.as_bytes().as_slice())
+    .fetch_all(pool)
+    .await
+    .map_err(backend)?;
+    let inodes = inode_rows
+        .iter()
+        .map(decode_inode)
+        .collect::<Result<Vec<_>, _>>()?;
+    let xattr_rows = sea_orm::sqlx::query(
+        "SELECT layer_id, ino, name, op, value, sequence
+         FROM ws_v1_xattr_delta WHERE layer_id = ?",
+    )
+    .bind(layer_id.as_bytes().as_slice())
+    .fetch_all(pool)
+    .await
+    .map_err(backend)?;
+    let xattrs = xattr_rows
+        .iter()
+        .map(decode_xattr)
+        .collect::<Result<Vec<_>, _>>()?;
+    let acl_rows = sea_orm::sqlx::query(
+        "SELECT layer_id, ino, acl_type, acl_id, op, value, sequence
+         FROM ws_v1_acl_delta WHERE layer_id = ?",
+    )
+    .bind(layer_id.as_bytes().as_slice())
+    .fetch_all(pool)
+    .await
+    .map_err(backend)?;
+    let acls = acl_rows
+        .iter()
+        .map(decode_acl)
+        .collect::<Result<Vec<_>, _>>()?;
+    let extent_rows = sea_orm::sqlx::query(
+        "SELECT layer_id, ino, chunk_index, logical_offset, length, kind,
+                slice_id, slice_offset, sequence
+         FROM ws_v1_data_extent_delta WHERE layer_id = ?",
+    )
+    .bind(layer_id.as_bytes().as_slice())
+    .fetch_all(pool)
+    .await
+    .map_err(backend)?;
+    let extents = extent_rows
+        .iter()
+        .map(decode_extent)
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(CanonicalLayerDelta {
+        dentries,
+        inodes,
+        xattrs,
+        acls,
+        extents,
+    })
+}
+
+fn commit_conflict(reason: impl Into<String>) -> WorkspaceError {
+    WorkspaceError::Conflict(crate::workspace_overlay::error::ConflictDetail {
+        path: Vec::new(),
+        reason: reason.into(),
+    })
+}
+
+async fn upsert_dentry(
+    tx: &mut Transaction<'_, Sqlite>,
+    row: &DentryDelta,
+) -> Result<(), WorkspaceError> {
+    sea_orm::sqlx::query(
+        "INSERT INTO ws_v1_dentry_delta
+         (layer_id, parent_ino, name, op, ino, entry_type, sequence)
+         VALUES (?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(layer_id, parent_ino, name) DO UPDATE SET
+             op = excluded.op, ino = excluded.ino, entry_type = excluded.entry_type,
+             sequence = excluded.sequence",
+    )
+    .bind(row.layer_id.as_bytes().as_slice())
+    .bind(row.parent_ino)
+    .bind(row.name.as_slice())
+    .bind(row.op.discriminant() as i64)
+    .bind(row.ino)
+    .bind(row.entry_type.map(i64::from))
+    .bind(to_i64(row.sequence, "dentry sequence")?)
+    .execute(&mut **tx)
+    .await
+    .map_err(backend)?;
+    Ok(())
+}
+
+async fn insert_inode(
+    tx: &mut Transaction<'_, Sqlite>,
+    row: &InodeDelta,
+) -> Result<(), WorkspaceError> {
+    sea_orm::sqlx::query(
+        "INSERT INTO ws_v1_inode_delta
+         (layer_id, ino, state, kind, size, mode, uid, gid, rdev, nlink,
+          atime_ns, mtime_ns, ctime_ns, symlink_target, parent_hint,
+          data_version, sequence)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(row.layer_id.as_bytes().as_slice())
+    .bind(row.ino)
+    .bind(row.state.discriminant() as i64)
+    .bind(i64::from(row.kind))
+    .bind(to_i64(row.size, "inode size")?)
+    .bind(i64::from(row.mode))
+    .bind(i64::from(row.uid))
+    .bind(i64::from(row.gid))
+    .bind(i64::from(row.rdev))
+    .bind(i64::from(row.nlink))
+    .bind(row.atime_ns)
+    .bind(row.mtime_ns)
+    .bind(row.ctime_ns)
+    .bind(row.symlink_target.as_deref())
+    .bind(row.parent_hint)
+    .bind(to_i64(row.data_version, "data version")?)
+    .bind(to_i64(row.sequence, "inode sequence")?)
+    .execute(&mut **tx)
+    .await
+    .map_err(backend)?;
+    Ok(())
+}
+
+async fn upsert_inode(
+    tx: &mut Transaction<'_, Sqlite>,
+    row: &InodeDelta,
+) -> Result<(), WorkspaceError> {
+    sea_orm::sqlx::query(
+        "INSERT INTO ws_v1_inode_delta
+         (layer_id, ino, state, kind, size, mode, uid, gid, rdev, nlink,
+          atime_ns, mtime_ns, ctime_ns, symlink_target, parent_hint,
+          data_version, sequence)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(layer_id, ino) DO UPDATE SET
+             state = excluded.state, kind = excluded.kind, size = excluded.size,
+             mode = excluded.mode, uid = excluded.uid, gid = excluded.gid,
+             rdev = excluded.rdev, nlink = excluded.nlink,
+             atime_ns = excluded.atime_ns, mtime_ns = excluded.mtime_ns,
+             ctime_ns = excluded.ctime_ns, symlink_target = excluded.symlink_target,
+             parent_hint = excluded.parent_hint, data_version = excluded.data_version,
+             sequence = excluded.sequence",
+    )
+    .bind(row.layer_id.as_bytes().as_slice())
+    .bind(row.ino)
+    .bind(row.state.discriminant() as i64)
+    .bind(i64::from(row.kind))
+    .bind(to_i64(row.size, "inode size")?)
+    .bind(i64::from(row.mode))
+    .bind(i64::from(row.uid))
+    .bind(i64::from(row.gid))
+    .bind(i64::from(row.rdev))
+    .bind(i64::from(row.nlink))
+    .bind(row.atime_ns)
+    .bind(row.mtime_ns)
+    .bind(row.ctime_ns)
+    .bind(row.symlink_target.as_deref())
+    .bind(row.parent_hint)
+    .bind(to_i64(row.data_version, "data version")?)
+    .bind(to_i64(row.sequence, "inode sequence")?)
+    .execute(&mut **tx)
+    .await
+    .map_err(backend)?;
+    Ok(())
+}
+
+async fn insert_extent(
+    tx: &mut Transaction<'_, Sqlite>,
+    row: &DataExtentDelta,
+) -> Result<(), WorkspaceError> {
+    let (slice_id, slice_offset) = match row.kind {
+        ExtentKind::Data {
+            slice_id,
+            slice_offset,
+        } => (
+            Some(to_i64(slice_id, "slice ID")?),
+            Some(to_i64(slice_offset, "slice offset")?),
+        ),
+        ExtentKind::Hole => (None, None),
+    };
+    sea_orm::sqlx::query(
+        "INSERT INTO ws_v1_data_extent_delta
+         (layer_id, ino, chunk_index, logical_offset, length, kind,
+          slice_id, slice_offset, sequence)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(row.layer_id.as_bytes().as_slice())
+    .bind(row.ino)
+    .bind(to_i64(row.chunk_index, "chunk index")?)
+    .bind(to_i64(row.logical_offset, "logical offset")?)
+    .bind(to_i64(row.length, "extent length")?)
+    .bind(row.kind.discriminant() as i64)
+    .bind(slice_id)
+    .bind(slice_offset)
+    .bind(to_i64(row.sequence, "extent sequence")?)
+    .execute(&mut **tx)
+    .await
+    .map_err(backend)?;
+    Ok(())
+}
+
+async fn upsert_xattr(
+    tx: &mut Transaction<'_, Sqlite>,
+    row: &XattrDelta,
+) -> Result<(), WorkspaceError> {
+    sea_orm::sqlx::query(
+        "INSERT INTO ws_v1_xattr_delta(layer_id, ino, name, op, value, sequence)
+         VALUES (?, ?, ?, ?, ?, ?)
+         ON CONFLICT(layer_id, ino, name) DO UPDATE SET
+             op = excluded.op, value = excluded.value, sequence = excluded.sequence",
+    )
+    .bind(row.layer_id.as_bytes().as_slice())
+    .bind(row.ino)
+    .bind(row.name.as_slice())
+    .bind(row.op.discriminant() as i64)
+    .bind(row.value.as_deref())
+    .bind(to_i64(row.sequence, "xattr sequence")?)
+    .execute(&mut **tx)
+    .await
+    .map_err(backend)?;
+    Ok(())
+}
+
+async fn upsert_acl(
+    tx: &mut Transaction<'_, Sqlite>,
+    row: &AclDelta,
+) -> Result<(), WorkspaceError> {
+    sea_orm::sqlx::query(
+        "INSERT INTO ws_v1_acl_delta
+         (layer_id, ino, acl_type, acl_id, op, value, sequence)
+         VALUES (?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(layer_id, ino, acl_type, acl_id) DO UPDATE SET
+             op = excluded.op, value = excluded.value, sequence = excluded.sequence",
+    )
+    .bind(row.layer_id.as_bytes().as_slice())
+    .bind(row.ino)
+    .bind(i64::from(row.acl_type))
+    .bind(row.acl_id)
+    .bind(row.op.discriminant() as i64)
+    .bind(row.value.as_deref())
+    .bind(to_i64(row.sequence, "ACL sequence")?)
+    .execute(&mut **tx)
+    .await
+    .map_err(backend)?;
+    Ok(())
+}
+
+fn decode_volume_header(row: SqliteRow) -> Result<VolumeHeader, WorkspaceError> {
+    let schema_version = to_u32(row.try_get("schema_version").map_err(backend)?, "schema")?;
+    if schema_version != WORKSPACE_SCHEMA_VERSION {
+        return Err(WorkspaceError::UnsupportedSchemaVersion(schema_version));
+    }
+    let volume_format: String = row.try_get("volume_format").map_err(backend)?;
+    if volume_format != VOLUME_FORMAT {
+        return Err(WorkspaceError::UnsupportedVolumeFormat(volume_format));
+    }
+    Ok(VolumeHeader {
+        volume_format,
+        schema_version,
+        volume_id: uuid_from_blob(row.try_get("volume_id").map_err(backend)?, "volume ID")?,
+        created_at_ns: row.try_get("created_at_ns").map_err(backend)?,
+    })
+}
+
+fn decode_workspace(row: &SqliteRow) -> Result<WorkspaceRecord, WorkspaceError> {
+    let base_layer: Option<Vec<u8>> = row.try_get("fork_base_layer_id").map_err(backend)?;
+    let base_version: Option<i64> = row.try_get("fork_base_version").map_err(backend)?;
+    let base_hash: Option<Vec<u8>> = row.try_get("fork_base_root_hash").map_err(backend)?;
+    let fork_base = match (base_layer, base_version, base_hash) {
+        (None, None, None) => None,
+        (Some(layer), Some(version), Some(hash)) => Some(BaseRevision {
+            layer_id: LayerId::from_uuid(uuid_from_blob(layer, "fork base layer")?),
+            sealed_version: to_u64(version, "fork base version")?,
+            root_hash: hash_from_blob(hash, "fork base root hash")?,
+        }),
+        _ => {
+            return Err(WorkspaceError::CorruptMetadata(
+                "partial fork base revision".into(),
+            ));
+        }
+    };
+    Ok(WorkspaceRecord {
+        workspace_id: WorkspaceId::from_uuid(uuid_from_blob(
+            row.try_get("workspace_id").map_err(backend)?,
+            "workspace ID",
+        )?),
+        head_layer_id: LayerId::from_uuid(uuid_from_blob(
+            row.try_get("head_layer_id").map_err(backend)?,
+            "head layer ID",
+        )?),
+        head_epoch: to_u64(row.try_get("head_epoch").map_err(backend)?, "head epoch")?,
+        fork_base,
+        owner_id: row.try_get("owner_id").map_err(backend)?,
+        state: WorkspaceState::try_from(to_u8(
+            row.try_get("state").map_err(backend)?,
+            "workspace state",
+        )?)?,
+        created_at_ns: row.try_get("created_at_ns").map_err(backend)?,
+        updated_at_ns: row.try_get("updated_at_ns").map_err(backend)?,
+    })
+}
+
+fn decode_snapshot(row: &SqliteRow) -> Result<SnapshotRecord, WorkspaceError> {
+    Ok(SnapshotRecord {
+        snapshot_id: SnapshotId::from_uuid(uuid_from_blob(
+            row.try_get("snapshot_id").map_err(backend)?,
+            "snapshot ID",
+        )?),
+        name: row.try_get("name").map_err(backend)?,
+        revision: BaseRevision {
+            layer_id: LayerId::from_uuid(uuid_from_blob(
+                row.try_get("layer_id").map_err(backend)?,
+                "snapshot layer ID",
+            )?),
+            sealed_version: to_u64(
+                row.try_get("sealed_version").map_err(backend)?,
+                "snapshot sealed version",
+            )?,
+            root_hash: hash_from_blob(
+                row.try_get("root_hash").map_err(backend)?,
+                "snapshot root hash",
+            )?,
+        },
+        owner_id: row.try_get("owner_id").map_err(backend)?,
+        created_at_ns: row.try_get("created_at_ns").map_err(backend)?,
+    })
+}
+
+fn decode_seal_journal(row: &SqliteRow) -> Result<SealJournal, WorkspaceError> {
+    Ok(SealJournal {
+        journal_id: JournalId::from_uuid(uuid_from_blob(
+            row.try_get("journal_id").map_err(backend)?,
+            "journal ID",
+        )?),
+        workspace_id: WorkspaceId::from_uuid(uuid_from_blob(
+            row.try_get("workspace_id").map_err(backend)?,
+            "journal workspace ID",
+        )?),
+        old_head_layer_id: LayerId::from_uuid(uuid_from_blob(
+            row.try_get("old_head_layer_id").map_err(backend)?,
+            "journal old head",
+        )?),
+        expected_head_epoch: to_u64(
+            row.try_get("expected_head_epoch").map_err(backend)?,
+            "journal head epoch",
+        )?,
+        phase: SealPhase::try_from(to_u8(row.try_get("phase").map_err(backend)?, "seal phase")?)?,
+        pending_bytes: to_u64(
+            row.try_get("pending_bytes").map_err(backend)?,
+            "pending bytes",
+        )?,
+        delta_digest: row
+            .try_get::<Option<Vec<u8>>, _>("delta_digest")
+            .map_err(backend)?
+            .map(|bytes| hash_from_blob(bytes, "journal delta digest"))
+            .transpose()?,
+        root_hash: row
+            .try_get::<Option<Vec<u8>>, _>("root_hash")
+            .map_err(backend)?
+            .map(|bytes| hash_from_blob(bytes, "journal root hash"))
+            .transpose()?,
+        new_head_layer_id: row
+            .try_get::<Option<Vec<u8>>, _>("new_head_layer_id")
+            .map_err(backend)?
+            .map(|bytes| uuid_from_blob(bytes, "journal new head").map(LayerId::from_uuid))
+            .transpose()?,
+        last_error: row.try_get("last_error").map_err(backend)?,
+        created_at_ns: row.try_get("created_at_ns").map_err(backend)?,
+        updated_at_ns: row.try_get("updated_at_ns").map_err(backend)?,
+    })
+}
+
+fn decode_layer(row: &SqliteRow) -> Result<LayerRecord, WorkspaceError> {
+    let schema_version = to_u32(row.try_get("schema_version").map_err(backend)?, "schema")?;
+    if schema_version != WORKSPACE_SCHEMA_VERSION {
+        return Err(WorkspaceError::UnsupportedSchemaVersion(schema_version));
+    }
+    Ok(LayerRecord {
+        layer_id: LayerId::from_uuid(uuid_from_blob(
+            row.try_get("layer_id").map_err(backend)?,
+            "layer ID",
+        )?),
+        parent_layer_id: row
+            .try_get::<Option<Vec<u8>>, _>("parent_layer_id")
+            .map_err(backend)?
+            .map(|bytes| uuid_from_blob(bytes, "parent layer ID").map(LayerId::from_uuid))
+            .transpose()?,
+        state: LayerState::try_from(to_u8(
+            row.try_get("state").map_err(backend)?,
+            "layer state",
+        )?)?,
+        schema_version,
+        sealed_version: row
+            .try_get::<Option<i64>, _>("sealed_version")
+            .map_err(backend)?
+            .map(|value| to_u64(value, "sealed version"))
+            .transpose()?,
+        delta_digest: row
+            .try_get::<Option<Vec<u8>>, _>("delta_digest")
+            .map_err(backend)?
+            .map(|bytes| hash_from_blob(bytes, "delta digest"))
+            .transpose()?,
+        root_hash: row
+            .try_get::<Option<Vec<u8>>, _>("root_hash")
+            .map_err(backend)?
+            .map(|bytes| hash_from_blob(bytes, "root hash"))
+            .transpose()?,
+        depth: to_u32(row.try_get("depth").map_err(backend)?, "layer depth")?,
+        owner_workspace_id: row
+            .try_get::<Option<Vec<u8>>, _>("owner_workspace_id")
+            .map_err(backend)?
+            .map(|bytes| uuid_from_blob(bytes, "owner workspace ID").map(WorkspaceId::from_uuid))
+            .transpose()?,
+        next_sequence: to_u64(
+            row.try_get("next_sequence").map_err(backend)?,
+            "next sequence",
+        )?,
+        owned_slice_count: to_u64(
+            row.try_get("owned_slice_count").map_err(backend)?,
+            "owned slice count",
+        )?,
+        owned_bytes: to_u64(row.try_get("owned_bytes").map_err(backend)?, "owned bytes")?,
+        created_at_ns: row.try_get("created_at_ns").map_err(backend)?,
+        sealed_at_ns: row.try_get("sealed_at_ns").map_err(backend)?,
+    })
+}
+
+fn decode_dentry(row: SqliteRow) -> Result<DentryDelta, WorkspaceError> {
+    let delta = DentryDelta {
+        layer_id: LayerId::from_uuid(uuid_from_blob(
+            row.try_get("layer_id").map_err(backend)?,
+            "dentry layer ID",
+        )?),
+        parent_ino: row.try_get("parent_ino").map_err(backend)?,
+        name: row.try_get("name").map_err(backend)?,
+        op: DentryOp::try_from(to_u8(row.try_get("op").map_err(backend)?, "dentry op")?)?,
+        ino: row.try_get("ino").map_err(backend)?,
+        entry_type: row
+            .try_get::<Option<i64>, _>("entry_type")
+            .map_err(backend)?
+            .map(|value| to_u8(value, "entry type"))
+            .transpose()?,
+        sequence: to_u64(row.try_get("sequence").map_err(backend)?, "sequence")?,
+    };
+    delta.validate()?;
+    Ok(delta)
+}
+
+fn decode_inode(row: &SqliteRow) -> Result<InodeDelta, WorkspaceError> {
+    Ok(InodeDelta {
+        layer_id: LayerId::from_uuid(uuid_from_blob(
+            row.try_get("layer_id").map_err(backend)?,
+            "inode layer ID",
+        )?),
+        ino: row.try_get("ino").map_err(backend)?,
+        state: InodeState::try_from(to_u8(
+            row.try_get("state").map_err(backend)?,
+            "inode state",
+        )?)?,
+        kind: to_u8(row.try_get("kind").map_err(backend)?, "inode kind")?,
+        size: to_u64(row.try_get("size").map_err(backend)?, "inode size")?,
+        mode: to_u32(row.try_get("mode").map_err(backend)?, "inode mode")?,
+        uid: to_u32(row.try_get("uid").map_err(backend)?, "inode uid")?,
+        gid: to_u32(row.try_get("gid").map_err(backend)?, "inode gid")?,
+        rdev: to_u32(row.try_get("rdev").map_err(backend)?, "inode rdev")?,
+        nlink: to_u32(row.try_get("nlink").map_err(backend)?, "inode nlink")?,
+        atime_ns: row.try_get("atime_ns").map_err(backend)?,
+        mtime_ns: row.try_get("mtime_ns").map_err(backend)?,
+        ctime_ns: row.try_get("ctime_ns").map_err(backend)?,
+        symlink_target: row.try_get("symlink_target").map_err(backend)?,
+        parent_hint: row.try_get("parent_hint").map_err(backend)?,
+        data_version: to_u64(
+            row.try_get("data_version").map_err(backend)?,
+            "data version",
+        )?,
+        sequence: to_u64(row.try_get("sequence").map_err(backend)?, "sequence")?,
+    })
+}
+
+fn decode_extent(row: &SqliteRow) -> Result<DataExtentDelta, WorkspaceError> {
+    let kind = match to_u8(row.try_get("kind").map_err(backend)?, "extent kind")? {
+        0 => ExtentKind::Data {
+            slice_id: to_u64(
+                row.try_get::<Option<i64>, _>("slice_id")
+                    .map_err(backend)?
+                    .ok_or_else(|| {
+                        WorkspaceError::CorruptMetadata("data extent without slice ID".into())
+                    })?,
+                "slice ID",
+            )?,
+            slice_offset: to_u64(
+                row.try_get::<Option<i64>, _>("slice_offset")
+                    .map_err(backend)?
+                    .ok_or_else(|| {
+                        WorkspaceError::CorruptMetadata("data extent without slice offset".into())
+                    })?,
+                "slice offset",
+            )?,
+        },
+        1 => {
+            let slice_id: Option<i64> = row.try_get("slice_id").map_err(backend)?;
+            let slice_offset: Option<i64> = row.try_get("slice_offset").map_err(backend)?;
+            if slice_id.is_some() || slice_offset.is_some() {
+                return Err(WorkspaceError::CorruptMetadata(
+                    "hole extent carries slice fields".into(),
+                ));
+            }
+            ExtentKind::Hole
+        }
+        unknown => {
+            return Err(WorkspaceError::CorruptMetadata(format!(
+                "unknown extent kind {unknown}"
+            )));
+        }
+    };
+    let extent = DataExtentDelta {
+        layer_id: LayerId::from_uuid(uuid_from_blob(
+            row.try_get("layer_id").map_err(backend)?,
+            "extent layer ID",
+        )?),
+        ino: row.try_get("ino").map_err(backend)?,
+        chunk_index: to_u64(row.try_get("chunk_index").map_err(backend)?, "chunk index")?,
+        logical_offset: to_u64(
+            row.try_get("logical_offset").map_err(backend)?,
+            "logical offset",
+        )?,
+        length: to_u64(row.try_get("length").map_err(backend)?, "extent length")?,
+        kind,
+        sequence: to_u64(row.try_get("sequence").map_err(backend)?, "sequence")?,
+    };
+    extent.validate()?;
+    Ok(extent)
+}
+
+fn decode_xattr(row: &SqliteRow) -> Result<XattrDelta, WorkspaceError> {
+    let delta = XattrDelta {
+        layer_id: LayerId::from_uuid(uuid_from_blob(
+            row.try_get("layer_id").map_err(backend)?,
+            "xattr layer ID",
+        )?),
+        ino: row.try_get("ino").map_err(backend)?,
+        name: row.try_get("name").map_err(backend)?,
+        op: ValueOp::try_from(to_u8(row.try_get("op").map_err(backend)?, "xattr op")?)?,
+        value: row.try_get("value").map_err(backend)?,
+        sequence: to_u64(row.try_get("sequence").map_err(backend)?, "sequence")?,
+    };
+    validate_value(delta.op, delta.value.as_deref(), "xattr")?;
+    Ok(delta)
+}
+
+fn decode_acl(row: &SqliteRow) -> Result<AclDelta, WorkspaceError> {
+    let delta = AclDelta {
+        layer_id: LayerId::from_uuid(uuid_from_blob(
+            row.try_get("layer_id").map_err(backend)?,
+            "ACL layer ID",
+        )?),
+        ino: row.try_get("ino").map_err(backend)?,
+        acl_type: to_u8(row.try_get("acl_type").map_err(backend)?, "ACL type")?,
+        acl_id: row.try_get("acl_id").map_err(backend)?,
+        op: ValueOp::try_from(to_u8(row.try_get("op").map_err(backend)?, "ACL op")?)?,
+        value: row.try_get("value").map_err(backend)?,
+        sequence: to_u64(row.try_get("sequence").map_err(backend)?, "sequence")?,
+    };
+    validate_value(delta.op, delta.value.as_deref(), "ACL")?;
+    Ok(delta)
+}
+
+fn decode_lease(row: &SqliteRow) -> Result<SnapshotLease, WorkspaceError> {
+    let writable = match row.try_get::<i64, _>("writable").map_err(backend)? {
+        0 => false,
+        1 => true,
+        value => {
+            return Err(WorkspaceError::CorruptMetadata(format!(
+                "invalid lease writable value {value}"
+            )));
+        }
+    };
+    Ok(SnapshotLease {
+        lease_id: crate::workspace_overlay::ids::LeaseId::from_uuid(uuid_from_blob(
+            row.try_get("lease_id").map_err(backend)?,
+            "lease ID",
+        )?),
+        workspace_id: WorkspaceId::from_uuid(uuid_from_blob(
+            row.try_get("workspace_id").map_err(backend)?,
+            "lease workspace ID",
+        )?),
+        base_revision: BaseRevision {
+            layer_id: LayerId::from_uuid(uuid_from_blob(
+                row.try_get("base_layer_id").map_err(backend)?,
+                "lease base layer ID",
+            )?),
+            sealed_version: to_u64(
+                row.try_get("base_version").map_err(backend)?,
+                "lease base version",
+            )?,
+            root_hash: hash_from_blob(
+                row.try_get("base_root_hash").map_err(backend)?,
+                "lease base root hash",
+            )?,
+        },
+        holder_generation: to_u64(
+            row.try_get("holder_generation").map_err(backend)?,
+            "holder generation",
+        )?,
+        writable,
+        state: LeaseState::try_from(to_u8(
+            row.try_get("state").map_err(backend)?,
+            "lease state",
+        )?)?,
+        expires_at_ns: row.try_get("expires_at_ns").map_err(backend)?,
+        created_at_ns: row.try_get("created_at_ns").map_err(backend)?,
+        updated_at_ns: row.try_get("updated_at_ns").map_err(backend)?,
+    })
+}
+
+fn validate_value(op: ValueOp, value: Option<&[u8]>, kind: &str) -> Result<(), WorkspaceError> {
+    match (op, value) {
+        (ValueOp::Put, Some(_)) | (ValueOp::Whiteout, None) => Ok(()),
+        _ => Err(WorkspaceError::CorruptMetadata(format!(
+            "{kind} op/payload mismatch"
+        ))),
+    }
+}
+
+fn now_ns() -> Result<i64, WorkspaceError> {
+    let duration = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|error| WorkspaceError::Backend(format!("system clock before epoch: {error}")))?;
+    i64::try_from(duration.as_nanos())
+        .map_err(|_| WorkspaceError::Backend("system time exceeds SQLite range".into()))
+}
+
+fn to_i64(value: u64, field: &str) -> Result<i64, WorkspaceError> {
+    i64::try_from(value)
+        .map_err(|_| WorkspaceError::CorruptMetadata(format!("{field} exceeds SQLite range")))
+}
+
+fn to_u64(value: i64, field: &str) -> Result<u64, WorkspaceError> {
+    u64::try_from(value).map_err(|_| WorkspaceError::CorruptMetadata(format!("negative {field}")))
+}
+
+fn to_u32(value: i64, field: &str) -> Result<u32, WorkspaceError> {
+    u32::try_from(value).map_err(|_| WorkspaceError::CorruptMetadata(format!("invalid {field}")))
+}
+
+fn to_u8(value: i64, field: &str) -> Result<u8, WorkspaceError> {
+    u8::try_from(value).map_err(|_| WorkspaceError::CorruptMetadata(format!("invalid {field}")))
+}
+
+fn uuid_from_blob(bytes: Vec<u8>, field: &str) -> Result<Uuid, WorkspaceError> {
+    Uuid::from_slice(&bytes)
+        .map_err(|error| WorkspaceError::CorruptMetadata(format!("invalid {field}: {error}")))
+}
+
+fn hash_from_blob(bytes: Vec<u8>, field: &str) -> Result<[u8; 32], WorkspaceError> {
+    bytes.try_into().map_err(|bytes: Vec<u8>| {
+        WorkspaceError::CorruptMetadata(format!(
+            "invalid {field} length {}, expected 32",
+            bytes.len()
+        ))
+    })
+}
+
+fn is_unique_violation(error: &sea_orm::sqlx::Error) -> bool {
+    let message = error.to_string().to_ascii_lowercase();
+    message.contains("unique constraint") || message.contains("primary key")
+}
+
+fn backend(error: impl std::fmt::Display) -> WorkspaceError {
+    WorkspaceError::Backend(error.to_string())
+}

--- a/src/workspace_overlay/stores/kv_backend.rs
+++ b/src/workspace_overlay/stores/kv_backend.rs
@@ -1,0 +1,68 @@
+//! Transactional key/value substrate shared by remote workspace catalogs.
+
+use async_trait::async_trait;
+
+use crate::workspace_overlay::error::WorkspaceError;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct KvCheck {
+    pub key: Vec<u8>,
+    pub expected: Option<Vec<u8>>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum KvWrite {
+    Put { key: Vec<u8>, value: Vec<u8> },
+    Delete { key: Vec<u8> },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct KvEntry {
+    pub key: Vec<u8>,
+    pub value: Vec<u8>,
+}
+
+#[async_trait]
+pub trait WorkspaceKvBackend: Send + Sync + 'static {
+    fn name(&self) -> &'static str;
+
+    async fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, WorkspaceError>;
+
+    /// Return exact values in the same order as `keys`.
+    ///
+    /// Remote backends override this to collapse a fixed two-layer lookup into
+    /// one network round trip. The default keeps lightweight test backends
+    /// simple without changing their semantics.
+    async fn get_many(&self, keys: &[Vec<u8>]) -> Result<Vec<Option<Vec<u8>>>, WorkspaceError> {
+        let mut values = Vec::with_capacity(keys.len());
+        for key in keys {
+            values.push(self.get(key).await?);
+        }
+        Ok(values)
+    }
+
+    /// Return exact values and a backend-authoritative timestamp. Remote
+    /// backends override this to share the transaction/pipeline used by the
+    /// read instead of paying a second round trip for lease validation time.
+    async fn get_many_with_time(
+        &self,
+        keys: &[Vec<u8>],
+    ) -> Result<(Vec<Option<Vec<u8>>>, i64), WorkspaceError> {
+        let now = self.server_time_ns().await?;
+        Ok((self.get_many(keys).await?, now))
+    }
+
+    /// Return logical key/value pairs whose keys start with `prefix`.
+    async fn scan_prefix(&self, prefix: &[u8]) -> Result<Vec<KvEntry>, WorkspaceError>;
+
+    /// Atomically verify every exact-value condition and apply all writes.
+    /// Returns `false` when any condition changed and the caller should retry.
+    async fn compare_and_swap(
+        &self,
+        checks: &[KvCheck],
+        writes: &[KvWrite],
+    ) -> Result<bool, WorkspaceError>;
+
+    /// Backend-authoritative wall-clock time for lease expiry.
+    async fn server_time_ns(&self) -> Result<i64, WorkspaceError>;
+}

--- a/src/workspace_overlay/stores/kv_store.rs
+++ b/src/workspace_overlay/stores/kv_store.rs
@@ -1,0 +1,2906 @@
+//! Backend-neutral workspace catalog stored in Redis or TiKV.
+//!
+//! Lifecycle transitions retain a versioned topology document for atomicity.
+//! Hot workspace heads, layer sequences, leases, and allocators are mirrored in
+//! independently CAS-able records, so agent writes and heartbeats do not contend
+//! on that topology document.
+
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use tokio::sync::Mutex;
+
+use super::kv_backend::{KvCheck, KvEntry, KvWrite, WorkspaceKvBackend};
+use crate::workspace_overlay::catalog::*;
+use crate::workspace_overlay::digest::{CanonicalLayerDelta, delta_digest, root_hash};
+use crate::workspace_overlay::error::{ConflictDetail, WorkspaceError};
+use crate::workspace_overlay::ids::{JournalId, LayerId, LeaseId, SnapshotId, WorkspaceId};
+use crate::workspace_overlay::model::*;
+use crate::workspace_overlay::resolver::validate_layer_chain;
+
+const CONTROL_KEY: &[u8] = b"control";
+const HOT_WORKSPACE_PREFIX: &[u8] = b"hot/workspace/";
+const HOT_LAYER_PREFIX: &[u8] = b"hot/layer/";
+const HOT_LEASE_PREFIX: &[u8] = b"hot/lease/";
+const HOT_ALLOCATOR_PREFIX: &[u8] = b"hot/allocator/";
+const ENVELOPE_MAGIC: &[u8; 8] = b"BWSKV001";
+const CAS_MAX_RETRIES: usize = 64;
+const VOLUME_FORMAT: &str = "workspace-v1";
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct ControlState {
+    schema_version: u32,
+    header: Option<VolumeHeader>,
+    workspaces: BTreeMap<WorkspaceId, WorkspaceRecord>,
+    layers: BTreeMap<LayerId, LayerRecord>,
+    snapshots: BTreeMap<SnapshotId, SnapshotRecord>,
+    leases: BTreeMap<LeaseId, SnapshotLease>,
+    journals: BTreeMap<JournalId, SealJournal>,
+    allocators: BTreeMap<String, i64>,
+}
+
+impl Default for ControlState {
+    fn default() -> Self {
+        Self {
+            schema_version: WORKSPACE_SCHEMA_VERSION,
+            header: None,
+            workspaces: BTreeMap::new(),
+            layers: BTreeMap::new(),
+            snapshots: BTreeMap::new(),
+            leases: BTreeMap::new(),
+            journals: BTreeMap::new(),
+            allocators: BTreeMap::new(),
+        }
+    }
+}
+
+pub struct KvWorkspaceStore<B> {
+    backend: Arc<B>,
+    topology_gate: Mutex<()>,
+}
+
+impl<B> KvWorkspaceStore<B>
+where
+    B: WorkspaceKvBackend,
+{
+    pub fn new(backend: B) -> Self {
+        Self {
+            backend: Arc::new(backend),
+            topology_gate: Mutex::new(()),
+        }
+    }
+
+    pub fn from_arc(backend: Arc<B>) -> Self {
+        Self {
+            backend,
+            topology_gate: Mutex::new(()),
+        }
+    }
+
+    async fn load_control_raw(
+        &self,
+    ) -> Result<
+        (
+            Option<Vec<u8>>,
+            ControlState,
+            BTreeMap<Vec<u8>, Option<Vec<u8>>>,
+        ),
+        WorkspaceError,
+    > {
+        for _ in 0..CAS_MAX_RETRIES {
+            let raw = self.backend.get(CONTROL_KEY).await?;
+            let mut state: ControlState =
+                raw.as_deref().map(decode).transpose()?.unwrap_or_default();
+            if state.schema_version != WORKSPACE_SCHEMA_VERSION {
+                return Err(WorkspaceError::UnsupportedSchemaVersion(
+                    state.schema_version,
+                ));
+            }
+            let mut hot = BTreeMap::new();
+            self.hydrate_hot_state(&mut state, &mut hot).await?;
+            if self.backend.get(CONTROL_KEY).await? == raw {
+                return Ok((raw, state, hot));
+            }
+            tokio::task::yield_now().await;
+        }
+        Err(WorkspaceError::Busy)
+    }
+
+    async fn load_control(&self) -> Result<ControlState, WorkspaceError> {
+        Ok(self.load_control_raw().await?.1)
+    }
+
+    async fn update_control<R, F>(&self, mut operation: F) -> Result<R, WorkspaceError>
+    where
+        F: FnMut(&mut ControlState, &mut Vec<KvWrite>) -> Result<R, WorkspaceError>,
+    {
+        let _guard = self.topology_gate.lock().await;
+        for _ in 0..CAS_MAX_RETRIES {
+            let (raw, mut state, hot) = self.load_control_raw().await?;
+            let before = state.clone();
+            let mut writes = Vec::new();
+            let result = operation(&mut state, &mut writes)?;
+            append_hot_diff(&before, &state, &mut writes)?;
+            writes.push(KvWrite::Put {
+                key: CONTROL_KEY.to_vec(),
+                value: encode(&state)?,
+            });
+            let mut checks = vec![KvCheck {
+                key: CONTROL_KEY.to_vec(),
+                expected: raw,
+            }];
+            checks.extend(hot.iter().map(|(key, expected)| KvCheck {
+                key: key.clone(),
+                expected: expected.clone(),
+            }));
+            for write in &writes {
+                let key = match write {
+                    KvWrite::Put { key, .. } | KvWrite::Delete { key } => key,
+                };
+                if is_hot_key(key) && !checks.iter().any(|check| check.key == *key) {
+                    checks.push(KvCheck {
+                        key: key.clone(),
+                        expected: hot.get(key).cloned().unwrap_or(None),
+                    });
+                }
+            }
+            if self.backend.compare_and_swap(&checks, &writes).await? {
+                return Ok(result);
+            }
+            tokio::task::yield_now().await;
+        }
+        Err(WorkspaceError::Busy)
+    }
+
+    async fn hydrate_hot_state(
+        &self,
+        state: &mut ControlState,
+        raw: &mut BTreeMap<Vec<u8>, Option<Vec<u8>>>,
+    ) -> Result<(), WorkspaceError> {
+        for entry in self.backend.scan_prefix(HOT_WORKSPACE_PREFIX).await? {
+            let row: WorkspaceRecord = decode(&entry.value)?;
+            state.workspaces.insert(row.workspace_id, row);
+            raw.insert(entry.key, Some(entry.value));
+        }
+        for entry in self.backend.scan_prefix(HOT_LAYER_PREFIX).await? {
+            let row: LayerRecord = decode(&entry.value)?;
+            state.layers.insert(row.layer_id, row);
+            raw.insert(entry.key, Some(entry.value));
+        }
+        for entry in self.backend.scan_prefix(HOT_LEASE_PREFIX).await? {
+            let row: SnapshotLease = decode(&entry.value)?;
+            state.leases.insert(row.lease_id, row);
+            raw.insert(entry.key, Some(entry.value));
+        }
+        for entry in self.backend.scan_prefix(HOT_ALLOCATOR_PREFIX).await? {
+            let name = allocator_name_from_key(&entry.key)?;
+            let value: i64 = decode(&entry.value)?;
+            state.allocators.insert(name, value);
+            raw.insert(entry.key, Some(entry.value));
+        }
+        Ok(())
+    }
+
+    async fn load_hot<T: DeserializeOwned>(
+        &self,
+        key: Vec<u8>,
+    ) -> Result<(Option<Vec<u8>>, Option<T>), WorkspaceError> {
+        let raw = self.backend.get(&key).await?;
+        let value = raw.as_deref().map(decode).transpose()?;
+        Ok((raw, value))
+    }
+
+    async fn hot_mutation<R, F>(
+        &self,
+        guard: &HeadGuard,
+        mut operation: F,
+    ) -> Result<R, WorkspaceError>
+    where
+        F: FnMut(&mut LayerRecord, &mut Vec<KvWrite>) -> Result<R, WorkspaceError>,
+    {
+        let workspace_key = hot_workspace_key(guard.workspace_id);
+        let layer_key = hot_layer_key(guard.expected_head_layer_id);
+        let lease_key = hot_lease_key(guard.lease_id);
+        for _ in 0..CAS_MAX_RETRIES {
+            let keys = [workspace_key.clone(), layer_key.clone(), lease_key.clone()];
+            let (values, now) = self.backend.get_many_with_time(&keys).await?;
+            let mut values = values.into_iter();
+            let workspace_raw = values.next().flatten();
+            let layer_raw = values.next().flatten();
+            let lease_raw = values.next().flatten();
+            let workspace = workspace_raw.as_deref().map(decode).transpose()?;
+            let layer = layer_raw.as_deref().map(decode).transpose()?;
+            let lease = lease_raw.as_deref().map(decode).transpose()?;
+            let workspace =
+                workspace.ok_or(WorkspaceError::WorkspaceNotFound(guard.workspace_id))?;
+            let mut layer = layer.ok_or(WorkspaceError::Fenced)?;
+            let lease = lease.ok_or(WorkspaceError::Fenced)?;
+            checked_hot_guard(&workspace, &layer, &lease, guard, now)?;
+            let mut writes = Vec::new();
+            let result = operation(&mut layer, &mut writes)?;
+            writes.push(put(layer_key.clone(), &layer)?);
+            let checks = [
+                KvCheck {
+                    key: workspace_key.clone(),
+                    expected: workspace_raw,
+                },
+                KvCheck {
+                    key: layer_key.clone(),
+                    expected: layer_raw,
+                },
+                KvCheck {
+                    key: lease_key.clone(),
+                    expected: lease_raw,
+                },
+            ];
+            if self.backend.compare_and_swap(&checks, &writes).await? {
+                return Ok(result);
+            }
+            tokio::task::yield_now().await;
+        }
+        Err(WorkspaceError::Busy)
+    }
+
+    async fn now_ns(&self) -> Result<i64, WorkspaceError> {
+        self.backend.server_time_ns().await
+    }
+
+    async fn scan<T: DeserializeOwned>(&self, prefix: Vec<u8>) -> Result<Vec<T>, WorkspaceError> {
+        self.backend
+            .scan_prefix(&prefix)
+            .await?
+            .into_iter()
+            .map(|entry| decode(&entry.value))
+            .collect()
+    }
+
+    async fn scan_entries(&self, prefix: Vec<u8>) -> Result<Vec<KvEntry>, WorkspaceError> {
+        self.backend.scan_prefix(&prefix).await
+    }
+
+    async fn layer_delta_unchecked(
+        &self,
+        layer_id: LayerId,
+    ) -> Result<CanonicalLayerDelta, WorkspaceError> {
+        let mut delta = CanonicalLayerDelta {
+            dentries: self.scan(dentry_layer_prefix(layer_id)).await?,
+            inodes: self.scan(inode_layer_prefix(layer_id)).await?,
+            xattrs: self.scan(xattr_layer_prefix(layer_id)).await?,
+            acls: self.scan(acl_layer_prefix(layer_id)).await?,
+            extents: self.scan(extent_layer_prefix(layer_id)).await?,
+        };
+        sort_delta(&mut delta);
+        Ok(delta)
+    }
+}
+
+#[async_trait]
+impl<B> WorkspaceStore for KvWorkspaceStore<B>
+where
+    B: WorkspaceKvBackend,
+{
+    fn name(&self) -> &'static str {
+        self.backend.name()
+    }
+
+    fn capabilities(&self) -> WorkspaceStoreCapabilities {
+        WorkspaceStoreCapabilities {
+            atomic_head_switch: true,
+            durable_lease: true,
+            transactional_namespace_mutation: true,
+            transactional_rename: true,
+            watch_head_change: false,
+        }
+    }
+
+    async fn initialize_workspace_schema(&self) -> Result<(), WorkspaceError> {
+        self.update_control(|_, _| Ok(())).await
+    }
+
+    async fn load_volume_header(&self) -> Result<Option<VolumeHeader>, WorkspaceError> {
+        let state: ControlState = self
+            .backend
+            .get(CONTROL_KEY)
+            .await?
+            .as_deref()
+            .map(decode)
+            .transpose()?
+            .unwrap_or_default();
+        if state.schema_version != WORKSPACE_SCHEMA_VERSION {
+            return Err(WorkspaceError::UnsupportedSchemaVersion(
+                state.schema_version,
+            ));
+        }
+        Ok(state.header)
+    }
+
+    async fn load_workspace(&self, id: WorkspaceId) -> Result<WorkspaceRecord, WorkspaceError> {
+        self.load_hot(hot_workspace_key(id))
+            .await?
+            .1
+            .ok_or(WorkspaceError::WorkspaceNotFound(id))
+    }
+
+    async fn load_layer(&self, id: LayerId) -> Result<LayerRecord, WorkspaceError> {
+        self.load_hot(hot_layer_key(id))
+            .await?
+            .1
+            .ok_or(WorkspaceError::LayerNotFound(id))
+    }
+
+    async fn load_layer_chain(&self, head: LayerId) -> Result<Vec<LayerRecord>, WorkspaceError> {
+        let mut chain = Vec::new();
+        let mut current = Some(head);
+        while let Some(layer_id) = current {
+            if chain.len() > LAYER_CHAIN_HARD_LIMIT as usize {
+                return Err(WorkspaceError::LayerDepthLimit {
+                    depth: chain.len() as u32,
+                    hard_limit: LAYER_CHAIN_HARD_LIMIT,
+                });
+            }
+            let layer = self.load_layer(layer_id).await?;
+            current = layer.parent_layer_id;
+            chain.push(layer);
+        }
+        validate_layer_chain(head, &chain)?;
+        Ok(chain)
+    }
+
+    async fn allocate_id(&self, name: &str) -> Result<i64, WorkspaceError> {
+        if !matches!(name, "inode" | "slice" | "sealed_version") {
+            return Err(WorkspaceError::CorruptMetadata(format!(
+                "unknown workspace allocator {name}"
+            )));
+        }
+        let key = hot_allocator_key(name);
+        for _ in 0..CAS_MAX_RETRIES {
+            let (raw, value) = self.load_hot::<i64>(key.clone()).await?;
+            let current = value.unwrap_or(1);
+            let next = current
+                .checked_add(1)
+                .ok_or_else(|| WorkspaceError::CorruptMetadata("allocator overflows".into()))?;
+            let writes = [put(key.clone(), &next)?];
+            let checks = [KvCheck {
+                key: key.clone(),
+                expected: raw,
+            }];
+            if self.backend.compare_and_swap(&checks, &writes).await? {
+                return Ok(current);
+            }
+            tokio::task::yield_now().await;
+        }
+        Err(WorkspaceError::Busy)
+    }
+
+    async fn create_volume_root(
+        &self,
+        request: CreateVolumeRoot,
+    ) -> Result<WorkspaceRecord, WorkspaceError> {
+        if request.root_layer_id == request.writable_layer_id {
+            return Err(WorkspaceError::CorruptMetadata(
+                "root and writable layer IDs must differ".into(),
+            ));
+        }
+        let now = self.now_ns().await?;
+        let root_inode = InodeDelta {
+            layer_id: request.root_layer_id,
+            ino: 1,
+            state: InodeState::Present,
+            kind: 1,
+            size: 0,
+            mode: 0o755,
+            uid: 0,
+            gid: 0,
+            rdev: 0,
+            nlink: 2,
+            atime_ns: now,
+            mtime_ns: now,
+            ctime_ns: now,
+            symlink_target: None,
+            parent_hint: Some(1),
+            data_version: 1,
+            sequence: 1,
+        };
+        let digest = delta_digest(&CanonicalLayerDelta {
+            inodes: vec![root_inode.clone()],
+            ..CanonicalLayerDelta::default()
+        })?;
+        let root = root_hash([0; 32], digest);
+        let workspace = WorkspaceRecord {
+            workspace_id: request.workspace_id,
+            head_layer_id: request.writable_layer_id,
+            head_epoch: 0,
+            fork_base: Some(BaseRevision {
+                layer_id: request.root_layer_id,
+                sealed_version: 1,
+                root_hash: root,
+            }),
+            owner_id: request.owner_id.clone(),
+            state: WorkspaceState::Active,
+            created_at_ns: now,
+            updated_at_ns: now,
+        };
+        self.update_control(|state, writes| {
+            if state.header.is_some() {
+                return Err(WorkspaceError::InvalidStateTransition {
+                    from: "initialized".into(),
+                    to: "create-volume-root".into(),
+                });
+            }
+            state.layers.insert(
+                request.root_layer_id,
+                LayerRecord {
+                    layer_id: request.root_layer_id,
+                    parent_layer_id: None,
+                    state: LayerState::Sealed,
+                    schema_version: WORKSPACE_SCHEMA_VERSION,
+                    sealed_version: Some(1),
+                    delta_digest: Some(digest),
+                    root_hash: Some(root),
+                    depth: 1,
+                    owner_workspace_id: None,
+                    next_sequence: 2,
+                    owned_slice_count: 0,
+                    owned_bytes: 0,
+                    created_at_ns: now,
+                    sealed_at_ns: Some(now),
+                },
+            );
+            state.layers.insert(
+                request.writable_layer_id,
+                writable_layer(
+                    request.writable_layer_id,
+                    request.root_layer_id,
+                    2,
+                    request.workspace_id,
+                    now,
+                ),
+            );
+            state
+                .workspaces
+                .insert(request.workspace_id, workspace.clone());
+            state.allocators.insert("inode".into(), 2);
+            state.allocators.insert("slice".into(), 1);
+            state.allocators.insert("sealed_version".into(), 2);
+            state.header = Some(VolumeHeader {
+                volume_format: VOLUME_FORMAT.into(),
+                schema_version: WORKSPACE_SCHEMA_VERSION,
+                volume_id: request.volume_id,
+                created_at_ns: now,
+            });
+            writes.push(put(inode_key(&root_inode), &root_inode)?);
+            Ok(workspace.clone())
+        })
+        .await
+    }
+
+    async fn create_workspace(
+        &self,
+        request: CreateWorkspace,
+    ) -> Result<WorkspaceRecord, WorkspaceError> {
+        let now = self.now_ns().await?;
+        let base_key = hot_layer_key(request.base_revision.layer_id);
+        let workspace_key = hot_workspace_key(request.workspace_id);
+        let head_key = hot_layer_key(request.head_layer_id);
+        for _ in 0..CAS_MAX_RETRIES {
+            let (base_raw, base) = self.load_hot::<LayerRecord>(base_key.clone()).await?;
+            let base = base.ok_or(WorkspaceError::LayerNotFound(
+                request.base_revision.layer_id,
+            ))?;
+            if revision_from_layer(&base)? != request.base_revision {
+                return Err(conflict("fork base revision changed"));
+            }
+            if base.parent_layer_id.is_some() || base.depth != 1 {
+                return Err(WorkspaceError::CorruptMetadata(
+                    "workspace base revision must be a flat sealed layer".into(),
+                ));
+            }
+            let workspace = WorkspaceRecord {
+                workspace_id: request.workspace_id,
+                head_layer_id: request.head_layer_id,
+                head_epoch: 0,
+                fork_base: Some(request.base_revision.clone()),
+                owner_id: request.owner_id.clone(),
+                state: WorkspaceState::Active,
+                created_at_ns: now,
+                updated_at_ns: now,
+            };
+            let head = writable_layer(
+                request.head_layer_id,
+                request.base_revision.layer_id,
+                2,
+                request.workspace_id,
+                now,
+            );
+            let checks = [
+                KvCheck {
+                    key: base_key.clone(),
+                    expected: base_raw,
+                },
+                KvCheck {
+                    key: workspace_key.clone(),
+                    expected: None,
+                },
+                KvCheck {
+                    key: head_key.clone(),
+                    expected: None,
+                },
+            ];
+            let writes = [
+                put(workspace_key.clone(), &workspace)?,
+                put(head_key.clone(), &head)?,
+            ];
+            if self.backend.compare_and_swap(&checks, &writes).await? {
+                return Ok(workspace);
+            }
+            tokio::task::yield_now().await;
+        }
+        Err(WorkspaceError::Busy)
+    }
+
+    async fn list_workspaces(&self) -> Result<Vec<WorkspaceRecord>, WorkspaceError> {
+        let mut rows = self
+            .load_control()
+            .await?
+            .workspaces
+            .into_values()
+            .collect::<Vec<_>>();
+        rows.sort_by_key(|row| (row.created_at_ns, row.workspace_id));
+        Ok(rows)
+    }
+
+    async fn create_snapshot(
+        &self,
+        request: CreateSnapshot,
+    ) -> Result<SnapshotRecord, WorkspaceError> {
+        let now = self.now_ns().await?;
+        self.update_control(|state, _| {
+            if revision_state(state, request.revision.layer_id)? != request.revision {
+                return Err(conflict("snapshot revision changed"));
+            }
+            if state.snapshots.contains_key(&request.snapshot_id)
+                || request.name.as_ref().is_some_and(|name| {
+                    state
+                        .snapshots
+                        .values()
+                        .any(|snapshot| snapshot.name.as_ref() == Some(name))
+                })
+            {
+                return Err(conflict("snapshot ID or name already exists"));
+            }
+            let snapshot = SnapshotRecord {
+                snapshot_id: request.snapshot_id,
+                name: request.name.clone(),
+                revision: request.revision.clone(),
+                owner_id: request.owner_id.clone(),
+                created_at_ns: now,
+            };
+            state
+                .snapshots
+                .insert(request.snapshot_id, snapshot.clone());
+            Ok(snapshot)
+        })
+        .await
+    }
+
+    async fn load_snapshot(&self, id: SnapshotId) -> Result<SnapshotRecord, WorkspaceError> {
+        self.load_control()
+            .await?
+            .snapshots
+            .get(&id)
+            .cloned()
+            .ok_or_else(|| WorkspaceError::Backend(format!("snapshot not found: {id}")))
+    }
+
+    async fn list_snapshots(&self) -> Result<Vec<SnapshotRecord>, WorkspaceError> {
+        let mut rows = self
+            .load_control()
+            .await?
+            .snapshots
+            .into_values()
+            .collect::<Vec<_>>();
+        rows.sort_by_key(|row| (row.created_at_ns, row.snapshot_id));
+        Ok(rows)
+    }
+
+    async fn delete_snapshot(&self, id: SnapshotId) -> Result<(), WorkspaceError> {
+        self.update_control(|state, _| {
+            state
+                .snapshots
+                .remove(&id)
+                .map(|_| ())
+                .ok_or_else(|| WorkspaceError::Backend(format!("snapshot not found: {id}")))
+        })
+        .await
+    }
+
+    async fn acquire_lease(&self, request: AcquireLease) -> Result<SnapshotLease, WorkspaceError> {
+        if request.ttl_ns == 0 {
+            return Err(WorkspaceError::CorruptMetadata(
+                "lease TTL must be positive".into(),
+            ));
+        }
+        let now = self.now_ns().await?;
+        let expires = checked_expiry(now, request.ttl_ns)?;
+        self.update_control(|state, _| {
+            let workspace = state
+                .workspaces
+                .get(&request.workspace_id)
+                .ok_or(WorkspaceError::WorkspaceNotFound(request.workspace_id))?;
+            if workspace.state != WorkspaceState::Active {
+                return Err(WorkspaceError::Busy);
+            }
+            let head = state
+                .layers
+                .get(&workspace.head_layer_id)
+                .ok_or(WorkspaceError::LayerNotFound(workspace.head_layer_id))?;
+            if head.state != LayerState::Writable {
+                return Err(WorkspaceError::Busy);
+            }
+            let parent = head.parent_layer_id.ok_or_else(|| {
+                WorkspaceError::CorruptMetadata("writable head has no parent".into())
+            })?;
+            let base_revision = revision_state(state, parent)?;
+            for lease in state.leases.values_mut() {
+                if lease.workspace_id == request.workspace_id
+                    && lease.state == LeaseState::Active
+                    && lease.expires_at_ns <= now
+                {
+                    lease.state = LeaseState::Expired;
+                    lease.updated_at_ns = now;
+                }
+            }
+            if state.leases.contains_key(&request.lease_id)
+                || state.leases.values().any(|lease| {
+                    lease.workspace_id == request.workspace_id
+                        && lease.writable
+                        && lease.state == LeaseState::Active
+                })
+            {
+                return Err(WorkspaceError::Busy);
+            }
+            let lease = SnapshotLease {
+                lease_id: request.lease_id,
+                workspace_id: request.workspace_id,
+                base_revision,
+                holder_generation: request.holder_generation,
+                writable: true,
+                state: LeaseState::Active,
+                expires_at_ns: expires,
+                created_at_ns: now,
+                updated_at_ns: now,
+            };
+            state.leases.insert(request.lease_id, lease.clone());
+            Ok(lease)
+        })
+        .await
+    }
+
+    async fn renew_lease(&self, request: RenewLease) -> Result<SnapshotLease, WorkspaceError> {
+        if request.ttl_ns == 0 {
+            return Err(WorkspaceError::CorruptMetadata(
+                "lease TTL must be positive".into(),
+            ));
+        }
+        let now = self.now_ns().await?;
+        let expires = checked_expiry(now, request.ttl_ns)?;
+        let key = hot_lease_key(request.lease_id);
+        for _ in 0..CAS_MAX_RETRIES {
+            let (raw, lease) = self.load_hot::<SnapshotLease>(key.clone()).await?;
+            let mut lease = lease.ok_or(WorkspaceError::Fenced)?;
+            if lease.holder_generation != request.holder_generation
+                || lease.state != LeaseState::Active
+                || lease.expires_at_ns <= now
+            {
+                return Err(WorkspaceError::Fenced);
+            }
+            lease.expires_at_ns = expires;
+            lease.updated_at_ns = now;
+            let writes = [put(key.clone(), &lease)?];
+            let checks = [KvCheck {
+                key: key.clone(),
+                expected: raw,
+            }];
+            if self.backend.compare_and_swap(&checks, &writes).await? {
+                return Ok(lease);
+            }
+            tokio::task::yield_now().await;
+        }
+        Err(WorkspaceError::Busy)
+    }
+
+    async fn release_lease(&self, request: ReleaseLease) -> Result<(), WorkspaceError> {
+        let now = self.now_ns().await?;
+        self.update_control(|state, _| {
+            let lease = state
+                .leases
+                .get_mut(&request.lease_id)
+                .ok_or(WorkspaceError::Fenced)?;
+            if lease.holder_generation != request.holder_generation
+                || lease.state != LeaseState::Active
+            {
+                return Err(WorkspaceError::Fenced);
+            }
+            lease.state = LeaseState::Released;
+            lease.updated_at_ns = now;
+            Ok(())
+        })
+        .await
+    }
+
+    async fn reap_expired_leases(&self) -> Result<u64, WorkspaceError> {
+        let now = self.now_ns().await?;
+        self.update_control(|state, _| {
+            let mut count = 0_u64;
+            for lease in state.leases.values_mut() {
+                if lease.state == LeaseState::Active && lease.expires_at_ns <= now {
+                    lease.state = LeaseState::Expired;
+                    lease.updated_at_ns = now;
+                    count += 1;
+                }
+            }
+            Ok(count)
+        })
+        .await
+    }
+
+    async fn list_leases(
+        &self,
+        workspace_id: WorkspaceId,
+    ) -> Result<Vec<SnapshotLease>, WorkspaceError> {
+        let mut rows = self
+            .load_control()
+            .await?
+            .leases
+            .into_values()
+            .filter(|lease| lease.workspace_id == workspace_id)
+            .collect::<Vec<_>>();
+        rows.sort_by_key(|row| (row.created_at_ns, row.lease_id));
+        Ok(rows)
+    }
+
+    async fn get_dentry_deltas(
+        &self,
+        request: DentryQuery,
+    ) -> Result<Vec<DentryDelta>, WorkspaceError> {
+        if let Some(name) = request.name {
+            let keys = request
+                .layer_ids
+                .iter()
+                .map(|layer| dentry_identity_key(*layer, request.parent_ino, &name))
+                .collect::<Vec<_>>();
+            return self
+                .backend
+                .get_many(&keys)
+                .await?
+                .into_iter()
+                .flatten()
+                .map(|value| decode(&value))
+                .collect();
+        }
+        let mut rows = Vec::new();
+        for layer in request.layer_ids {
+            let mut found: Vec<DentryDelta> = self
+                .scan(dentry_parent_prefix(layer, request.parent_ino))
+                .await?;
+            found.sort_by(|left, right| left.name.cmp(&right.name));
+            rows.extend(found);
+        }
+        Ok(rows)
+    }
+
+    async fn get_inode_deltas(
+        &self,
+        request: InodeQuery,
+    ) -> Result<Vec<InodeDelta>, WorkspaceError> {
+        let keys = request
+            .layer_ids
+            .iter()
+            .map(|layer| inode_identity_key(*layer, request.ino))
+            .collect::<Vec<_>>();
+        self.backend
+            .get_many(&keys)
+            .await?
+            .into_iter()
+            .flatten()
+            .map(|value| decode(&value))
+            .collect()
+    }
+
+    async fn get_extent_deltas(
+        &self,
+        request: ExtentQuery,
+    ) -> Result<Vec<DataExtentDelta>, WorkspaceError> {
+        if request.range_start > request.range_end {
+            return Err(WorkspaceError::InvalidReadPlan(
+                "extent query starts after its end".into(),
+            ));
+        }
+        if request.range_start == request.range_end {
+            return Ok(Vec::new());
+        }
+        let mut rows = Vec::new();
+        for layer in request.layer_ids {
+            let mut found: Vec<DataExtentDelta> = self
+                .scan(extent_chunk_prefix(layer, request.ino, request.chunk_index))
+                .await?;
+            found.retain(|row| {
+                row.logical_offset < request.range_end
+                    && row
+                        .logical_offset
+                        .saturating_add(row.length)
+                        .gt(&request.range_start)
+            });
+            found.sort_by_key(|row| std::cmp::Reverse(row.sequence));
+            rows.extend(found);
+        }
+        Ok(rows)
+    }
+
+    async fn get_xattr_deltas(
+        &self,
+        request: XattrQuery,
+    ) -> Result<Vec<XattrDelta>, WorkspaceError> {
+        if let Some(name) = request.name {
+            let keys = request
+                .layer_ids
+                .iter()
+                .map(|layer| xattr_identity_key(*layer, request.ino, &name))
+                .collect::<Vec<_>>();
+            return self
+                .backend
+                .get_many(&keys)
+                .await?
+                .into_iter()
+                .flatten()
+                .map(|value| decode(&value))
+                .collect();
+        }
+        let mut rows = Vec::new();
+        for layer in request.layer_ids {
+            let mut found: Vec<XattrDelta> =
+                self.scan(xattr_inode_prefix(layer, request.ino)).await?;
+            found.sort_by(|left, right| left.name.cmp(&right.name));
+            rows.extend(found);
+        }
+        Ok(rows)
+    }
+
+    async fn get_acl_deltas(&self, request: AclQuery) -> Result<Vec<AclDelta>, WorkspaceError> {
+        if request.acl_type.is_some() != request.acl_id.is_some() {
+            return Err(WorkspaceError::CorruptMetadata(
+                "ACL type and ID filters must be provided together".into(),
+            ));
+        }
+        if let (Some(acl_type), Some(acl_id)) = (request.acl_type, request.acl_id) {
+            let keys = request
+                .layer_ids
+                .iter()
+                .map(|layer| acl_identity_key(*layer, request.ino, acl_type, acl_id))
+                .collect::<Vec<_>>();
+            return self
+                .backend
+                .get_many(&keys)
+                .await?
+                .into_iter()
+                .flatten()
+                .map(|value| decode(&value))
+                .collect();
+        }
+        let mut rows = Vec::new();
+        for layer in request.layer_ids {
+            let mut found: Vec<AclDelta> = self.scan(acl_inode_prefix(layer, request.ino)).await?;
+            found.sort_by_key(|row| (row.acl_type, row.acl_id));
+            rows.extend(found);
+        }
+        Ok(rows)
+    }
+
+    async fn apply_namespace_mutation(
+        &self,
+        request: NamespaceMutation,
+    ) -> Result<MutationResult, WorkspaceError> {
+        if request.dentries.is_empty() && request.inodes.is_empty() {
+            return Ok(MutationResult {
+                first_sequence: None,
+                last_sequence: None,
+            });
+        }
+        for dentry in &request.dentries {
+            if dentry.layer_id != request.guard.expected_head_layer_id {
+                return Err(WorkspaceError::Fenced);
+            }
+            dentry.validate()?;
+        }
+        if request
+            .inodes
+            .iter()
+            .any(|inode| inode.layer_id != request.guard.expected_head_layer_id)
+        {
+            return Err(WorkspaceError::Fenced);
+        }
+        let count = request
+            .dentries
+            .len()
+            .checked_add(request.inodes.len())
+            .ok_or_else(|| WorkspaceError::CorruptMetadata("mutation is too large".into()))?;
+        self.hot_mutation(&request.guard, |layer, writes| {
+            let range =
+                allocate_layer_sequences(layer, count)?.expect("non-empty mutation has a range");
+            let mut sequence = range.0;
+            for template in &request.dentries {
+                let mut row = template.clone();
+                row.sequence = sequence;
+                writes.push(put(dentry_key(&row), &row)?);
+                sequence += 1;
+            }
+            for template in &request.inodes {
+                let mut row = template.clone();
+                row.sequence = sequence;
+                writes.push(put(inode_key(&row), &row)?);
+                sequence += 1;
+            }
+            Ok(MutationResult {
+                first_sequence: Some(range.0),
+                last_sequence: Some(range.1),
+            })
+        })
+        .await
+    }
+
+    async fn apply_inode_mutation(
+        &self,
+        request: InodeMutation,
+    ) -> Result<InodeDelta, WorkspaceError> {
+        if request.inode.layer_id != request.guard.expected_head_layer_id {
+            return Err(WorkspaceError::Fenced);
+        }
+        self.hot_mutation(&request.guard, |layer, writes| {
+            let mut inode = request.inode.clone();
+            inode.sequence = allocate_layer_sequences(layer, 1)?
+                .expect("single mutation has a sequence")
+                .0;
+            writes.push(put(inode_key(&inode), &inode)?);
+            Ok(inode)
+        })
+        .await
+    }
+
+    async fn append_data_extent(
+        &self,
+        request: AppendDataExtent,
+    ) -> Result<DataExtentDelta, WorkspaceError> {
+        validate_extent_request(
+            &request.extent,
+            request.guard.expected_head_layer_id,
+            request.chunk_size,
+        )?;
+        self.hot_mutation(&request.guard, |layer, writes| {
+            let mut extent = request.extent.clone();
+            extent.sequence = allocate_layer_sequences(layer, 1)?
+                .expect("single mutation has a sequence")
+                .0;
+            if matches!(extent.kind, ExtentKind::Data { .. }) {
+                layer.owned_slice_count = layer
+                    .owned_slice_count
+                    .checked_add(1)
+                    .ok_or_else(|| WorkspaceError::Backend("owned slice count overflows".into()))?;
+                layer.owned_bytes = layer
+                    .owned_bytes
+                    .checked_add(extent.length)
+                    .ok_or_else(|| WorkspaceError::Backend("owned byte count overflows".into()))?;
+            }
+            writes.push(put(extent_key(&extent), &extent)?);
+            Ok(extent)
+        })
+        .await
+    }
+
+    async fn apply_data_mutation(
+        &self,
+        request: DataMutation,
+    ) -> Result<DataMutationResult, WorkspaceError> {
+        let head = request.guard.expected_head_layer_id;
+        if request.inode.layer_id != head
+            || request
+                .extents
+                .iter()
+                .any(|extent| extent.layer_id != head || extent.ino != request.inode.ino)
+        {
+            return Err(WorkspaceError::Fenced);
+        }
+        for extent in &request.extents {
+            validate_extent_request(extent, head, request.chunk_size)?;
+        }
+        let count = request
+            .extents
+            .len()
+            .checked_add(1)
+            .ok_or_else(|| WorkspaceError::Backend("too many data mutations".into()))?;
+        self.hot_mutation(&request.guard, |layer, writes| {
+            let first = allocate_layer_sequences(layer, count)?
+                .expect("data mutation allocates a sequence")
+                .0;
+            let mut inode = request.inode.clone();
+            inode.sequence = first;
+            writes.push(put(inode_key(&inode), &inode)?);
+
+            let mut extents = request.extents.clone();
+            let mut owned_slice_count = 0_u64;
+            let mut owned_bytes = 0_u64;
+            for (index, extent) in extents.iter_mut().enumerate() {
+                extent.sequence = first
+                    .checked_add(index as u64)
+                    .and_then(|value| value.checked_add(1))
+                    .ok_or_else(|| WorkspaceError::Backend("extent sequence overflows".into()))?;
+                if matches!(extent.kind, ExtentKind::Data { .. }) {
+                    owned_slice_count = owned_slice_count.checked_add(1).ok_or_else(|| {
+                        WorkspaceError::Backend("owned slice count overflows".into())
+                    })?;
+                    owned_bytes = owned_bytes.checked_add(extent.length).ok_or_else(|| {
+                        WorkspaceError::Backend("owned byte count overflows".into())
+                    })?;
+                }
+                writes.push(put(extent_key(extent), extent)?);
+            }
+            if owned_slice_count != 0 {
+                layer.owned_slice_count = layer
+                    .owned_slice_count
+                    .checked_add(owned_slice_count)
+                    .ok_or_else(|| WorkspaceError::Backend("owned slice count overflows".into()))?;
+                layer.owned_bytes = layer
+                    .owned_bytes
+                    .checked_add(owned_bytes)
+                    .ok_or_else(|| WorkspaceError::Backend("owned byte count overflows".into()))?;
+            }
+            Ok(DataMutationResult { inode, extents })
+        })
+        .await
+    }
+
+    async fn apply_xattr_mutation(&self, request: XattrMutation) -> Result<(), WorkspaceError> {
+        validate_value(request.xattr.op, request.xattr.value.as_deref(), "xattr")?;
+        if request.xattr.layer_id != request.guard.expected_head_layer_id
+            || request.inode.layer_id != request.guard.expected_head_layer_id
+            || request.inode.ino != request.xattr.ino
+        {
+            return Err(WorkspaceError::Fenced);
+        }
+        self.hot_mutation(&request.guard, |layer, writes| {
+            let mut xattr = request.xattr.clone();
+            let mut inode = request.inode.clone();
+            let range =
+                allocate_layer_sequences(layer, 2)?.expect("xattr mutation has a sequence range");
+            xattr.sequence = range.0;
+            inode.sequence = range.1;
+            writes.push(put(xattr_key(&xattr), &xattr)?);
+            writes.push(put(inode_key(&inode), &inode)?);
+            Ok(())
+        })
+        .await
+    }
+
+    async fn apply_acl_mutation(&self, request: AclMutation) -> Result<(), WorkspaceError> {
+        validate_value(request.acl.op, request.acl.value.as_deref(), "ACL")?;
+        if request.acl.layer_id != request.guard.expected_head_layer_id {
+            return Err(WorkspaceError::Fenced);
+        }
+        self.hot_mutation(&request.guard, |layer, writes| {
+            let mut acl = request.acl.clone();
+            acl.sequence = allocate_layer_sequences(layer, 1)?
+                .expect("single mutation has a sequence")
+                .0;
+            writes.push(put(acl_key(&acl), &acl)?);
+            Ok(())
+        })
+        .await
+    }
+
+    async fn load_layer_delta(
+        &self,
+        layer_id: LayerId,
+    ) -> Result<CanonicalLayerDelta, WorkspaceError> {
+        self.load_layer(layer_id).await?;
+        self.layer_delta_unchecked(layer_id).await
+    }
+
+    async fn begin_seal(&self, request: BeginSeal) -> Result<SealJournal, WorkspaceError> {
+        if request.new_head_layer_id == request.guard.expected_head_layer_id {
+            return Err(WorkspaceError::CorruptMetadata(
+                "seal new head must differ from old head".into(),
+            ));
+        }
+        let now = self.now_ns().await?;
+        self.update_control(|state, _| {
+            checked_guard(state, &request.guard, now)?;
+            if state.journals.contains_key(&request.journal_id) {
+                return Err(conflict("seal journal already exists"));
+            }
+            let workspace = state
+                .workspaces
+                .get_mut(&request.guard.workspace_id)
+                .ok_or(WorkspaceError::Fenced)?;
+            workspace.state = WorkspaceState::Sealing;
+            workspace.updated_at_ns = now;
+            let layer = state
+                .layers
+                .get_mut(&request.guard.expected_head_layer_id)
+                .ok_or(WorkspaceError::Fenced)?;
+            layer.state = LayerState::Sealing;
+            let journal = SealJournal {
+                journal_id: request.journal_id,
+                workspace_id: request.guard.workspace_id,
+                old_head_layer_id: request.guard.expected_head_layer_id,
+                expected_head_epoch: request.guard.expected_head_epoch,
+                phase: SealPhase::Prepare,
+                pending_bytes: 0,
+                delta_digest: None,
+                root_hash: None,
+                new_head_layer_id: Some(request.new_head_layer_id),
+                last_error: None,
+                created_at_ns: now,
+                updated_at_ns: now,
+            };
+            state.journals.insert(request.journal_id, journal.clone());
+            Ok(journal)
+        })
+        .await
+    }
+
+    async fn advance_seal(&self, request: AdvanceSeal) -> Result<SealJournal, WorkspaceError> {
+        let allowed = matches!(
+            (request.expected_phase, request.next_phase),
+            (SealPhase::Prepare, SealPhase::Quiesced)
+                | (SealPhase::Quiesced, SealPhase::DataDrained)
+                | (SealPhase::HeadSwitched, SealPhase::Completed)
+        );
+        if !allowed {
+            return Err(invalid_transition(
+                request.expected_phase,
+                request.next_phase,
+            ));
+        }
+        let now = self.now_ns().await?;
+        self.update_control(|state, _| {
+            let journal = state.journals.get_mut(&request.journal_id).ok_or_else(|| {
+                WorkspaceError::Backend(format!("seal journal not found: {}", request.journal_id))
+            })?;
+            if journal.phase != request.expected_phase {
+                return Err(invalid_transition(journal.phase, request.next_phase));
+            }
+            journal.phase = request.next_phase;
+            if let Some(bytes) = request.pending_bytes {
+                journal.pending_bytes = bytes;
+            }
+            journal.last_error = request.last_error.clone();
+            journal.updated_at_ns = now;
+            Ok(journal.clone())
+        })
+        .await
+    }
+
+    async fn hash_seal(&self, journal_id: JournalId) -> Result<SealJournal, WorkspaceError> {
+        let initial = self.load_seal_journal(journal_id).await?;
+        if initial.phase != SealPhase::DataDrained {
+            return Err(invalid_transition(initial.phase, SealPhase::Hashed));
+        }
+        let delta = self
+            .layer_delta_unchecked(initial.old_head_layer_id)
+            .await?;
+        let digest = delta_digest(&delta)?;
+        let control = self.load_control().await?;
+        let old = control
+            .layers
+            .get(&initial.old_head_layer_id)
+            .ok_or(WorkspaceError::LayerNotFound(initial.old_head_layer_id))?;
+        let parent_hash = match old.parent_layer_id {
+            Some(parent) => control
+                .layers
+                .get(&parent)
+                .and_then(|layer| layer.root_hash)
+                .ok_or_else(|| {
+                    WorkspaceError::CorruptMetadata("sealed parent has no root hash".into())
+                })?,
+            None => [0; 32],
+        };
+        let root = root_hash(parent_hash, digest);
+        let now = self.now_ns().await?;
+        self.update_control(|state, _| {
+            let journal = state.journals.get_mut(&journal_id).ok_or_else(|| {
+                WorkspaceError::Backend(format!("seal journal not found: {journal_id}"))
+            })?;
+            if journal.phase != SealPhase::DataDrained
+                || journal.old_head_layer_id != initial.old_head_layer_id
+            {
+                return Err(WorkspaceError::Fenced);
+            }
+            journal.phase = SealPhase::Hashed;
+            journal.delta_digest = Some(digest);
+            journal.root_hash = Some(root);
+            journal.updated_at_ns = now;
+            Ok(journal.clone())
+        })
+        .await
+    }
+
+    async fn commit_seal(&self, journal_id: JournalId) -> Result<SealResult, WorkspaceError> {
+        let now = self.now_ns().await?;
+        self.update_control(|state, _| {
+            let journal = state.journals.get(&journal_id).cloned().ok_or_else(|| {
+                WorkspaceError::Backend(format!("seal journal not found: {journal_id}"))
+            })?;
+            if matches!(
+                journal.phase,
+                SealPhase::Completed | SealPhase::HeadSwitched
+            ) {
+                let revision = revision_state(state, journal.old_head_layer_id)?;
+                let workspace = state
+                    .workspaces
+                    .get(&journal.workspace_id)
+                    .ok_or(WorkspaceError::WorkspaceNotFound(journal.workspace_id))?;
+                if journal.phase == SealPhase::HeadSwitched {
+                    let journal = state.journals.get_mut(&journal_id).expect("loaded journal");
+                    journal.phase = SealPhase::Completed;
+                    journal.updated_at_ns = now;
+                }
+                return Ok(SealResult {
+                    revision,
+                    new_head_layer_id: workspace.head_layer_id,
+                    head_epoch: workspace.head_epoch,
+                });
+            }
+            if journal.phase != SealPhase::Hashed {
+                return Err(invalid_transition(journal.phase, SealPhase::HeadSwitched));
+            }
+            let digest = journal.delta_digest.ok_or_else(|| {
+                WorkspaceError::CorruptMetadata("hashed journal lacks digest".into())
+            })?;
+            let root = journal.root_hash.ok_or_else(|| {
+                WorkspaceError::CorruptMetadata("hashed journal lacks root hash".into())
+            })?;
+            let new_head = journal.new_head_layer_id.ok_or_else(|| {
+                WorkspaceError::CorruptMetadata("seal journal lacks new head".into())
+            })?;
+            if state.layers.contains_key(&new_head) {
+                return Err(conflict("seal replacement head already exists"));
+            }
+            let old = state
+                .layers
+                .get(&journal.old_head_layer_id)
+                .ok_or(WorkspaceError::Fenced)?;
+            if old.state != LayerState::Sealing {
+                return Err(WorkspaceError::Fenced);
+            }
+            let new_depth = old
+                .depth
+                .checked_add(1)
+                .ok_or_else(|| WorkspaceError::CorruptMetadata("layer depth overflows".into()))?;
+            check_depth(new_depth)?;
+            let sealed_version = u64::try_from(allocate_id_state(state, "sealed_version")?)
+                .map_err(|_| WorkspaceError::CorruptMetadata("negative sealed version".into()))?;
+            let old = state
+                .layers
+                .get_mut(&journal.old_head_layer_id)
+                .expect("old layer exists");
+            old.state = LayerState::Sealed;
+            old.sealed_version = Some(sealed_version);
+            old.delta_digest = Some(digest);
+            old.root_hash = Some(root);
+            old.owner_workspace_id = None;
+            old.sealed_at_ns = Some(now);
+            state.layers.insert(
+                new_head,
+                writable_layer(
+                    new_head,
+                    journal.old_head_layer_id,
+                    new_depth,
+                    journal.workspace_id,
+                    now,
+                ),
+            );
+            let new_epoch = journal
+                .expected_head_epoch
+                .checked_add(1)
+                .ok_or_else(|| WorkspaceError::CorruptMetadata("head epoch overflows".into()))?;
+            let workspace = state
+                .workspaces
+                .get_mut(&journal.workspace_id)
+                .ok_or(WorkspaceError::Fenced)?;
+            if workspace.head_layer_id != journal.old_head_layer_id
+                || workspace.head_epoch != journal.expected_head_epoch
+                || workspace.state != WorkspaceState::Sealing
+            {
+                return Err(WorkspaceError::Fenced);
+            }
+            workspace.head_layer_id = new_head;
+            workspace.head_epoch = new_epoch;
+            workspace.state = WorkspaceState::Active;
+            workspace.updated_at_ns = now;
+            let revision = BaseRevision {
+                layer_id: journal.old_head_layer_id,
+                sealed_version,
+                root_hash: root,
+            };
+            for lease in state.leases.values_mut() {
+                if lease.workspace_id == journal.workspace_id && lease.state == LeaseState::Active {
+                    lease.base_revision = revision.clone();
+                    lease.updated_at_ns = now;
+                }
+            }
+            let journal = state.journals.get_mut(&journal_id).expect("loaded journal");
+            journal.phase = SealPhase::Completed;
+            journal.updated_at_ns = now;
+            Ok(SealResult {
+                revision,
+                new_head_layer_id: new_head,
+                head_epoch: new_epoch,
+            })
+        })
+        .await
+    }
+
+    async fn abort_recoverable_seal(&self, request: AbortSeal) -> Result<(), WorkspaceError> {
+        let now = self.now_ns().await?;
+        self.update_control(|state, _| {
+            let journal = state
+                .journals
+                .get(&request.journal_id)
+                .cloned()
+                .ok_or_else(|| {
+                    WorkspaceError::Backend(format!(
+                        "seal journal not found: {}",
+                        request.journal_id
+                    ))
+                })?;
+            if !matches!(
+                journal.phase,
+                SealPhase::Prepare | SealPhase::Quiesced | SealPhase::DataDrained
+            ) {
+                return Err(invalid_transition(journal.phase, SealPhase::Aborted));
+            }
+            if let Some(layer) = state.layers.get_mut(&journal.old_head_layer_id)
+                && layer.state == LayerState::Sealing
+            {
+                layer.state = LayerState::Writable;
+            }
+            if let Some(workspace) = state.workspaces.get_mut(&journal.workspace_id)
+                && workspace.head_layer_id == journal.old_head_layer_id
+                && workspace.head_epoch == journal.expected_head_epoch
+            {
+                workspace.state = WorkspaceState::Active;
+                workspace.updated_at_ns = now;
+            }
+            let journal = state
+                .journals
+                .get_mut(&request.journal_id)
+                .expect("loaded journal");
+            journal.phase = SealPhase::Aborted;
+            journal.last_error = Some(request.reason.clone());
+            journal.updated_at_ns = now;
+            Ok(())
+        })
+        .await
+    }
+
+    async fn load_seal_journal(
+        &self,
+        journal_id: JournalId,
+    ) -> Result<SealJournal, WorkspaceError> {
+        self.load_control()
+            .await?
+            .journals
+            .get(&journal_id)
+            .cloned()
+            .ok_or_else(|| WorkspaceError::Backend(format!("seal journal not found: {journal_id}")))
+    }
+
+    async fn list_incomplete_seal_journals(&self) -> Result<Vec<SealJournal>, WorkspaceError> {
+        let mut rows = self
+            .load_control()
+            .await?
+            .journals
+            .into_values()
+            .filter(|journal| !matches!(journal.phase, SealPhase::Completed | SealPhase::Aborted))
+            .collect::<Vec<_>>();
+        rows.sort_by_key(|journal| journal.created_at_ns);
+        Ok(rows)
+    }
+
+    async fn fast_forward_commit(
+        &self,
+        request: FastForwardCommit,
+    ) -> Result<CommitResult, WorkspaceError> {
+        let now = self.now_ns().await?;
+        self.update_control(|state, _| {
+            if revision_state(state, request.source_revision.layer_id)? != request.source_revision {
+                return Err(commit_conflict("source revision changed"));
+            }
+            let target = state
+                .workspaces
+                .get(&request.target_workspace_id)
+                .cloned()
+                .ok_or(WorkspaceError::WorkspaceNotFound(
+                    request.target_workspace_id,
+                ))?;
+            if target.head_layer_id != request.target_expected_head_layer_id
+                || target.head_epoch != request.target_expected_head_epoch
+                || target.state != WorkspaceState::Active
+                || target.fork_base.as_ref() != Some(&request.source_fork_base)
+            {
+                return Err(commit_conflict("target revision changed"));
+            }
+            let target_head = state
+                .layers
+                .get(&target.head_layer_id)
+                .cloned()
+                .ok_or_else(|| commit_conflict("target head is not writable"))?;
+            if target_head.state != LayerState::Writable
+                || target_head.owner_workspace_id != Some(target.workspace_id)
+                || target_head.next_sequence != 1
+            {
+                return Err(commit_conflict("target writable head is not empty"));
+            }
+            let parent = target_head
+                .parent_layer_id
+                .ok_or_else(|| commit_conflict("target head has no base"))?;
+            if revision_state(state, parent)? != request.source_fork_base {
+                return Err(commit_conflict("target base revision changed"));
+            }
+            if state.leases.values().any(|lease| {
+                lease.workspace_id == target.workspace_id
+                    && lease.writable
+                    && lease.state == LeaseState::Active
+                    && lease.expires_at_ns > now
+            }) {
+                return Err(commit_conflict("target has an active writable lease"));
+            }
+            if state.layers.contains_key(&request.new_head_layer_id) {
+                return Err(commit_conflict("replacement head already exists"));
+            }
+            let source_depth = state
+                .layers
+                .get(&request.source_revision.layer_id)
+                .ok_or(WorkspaceError::LayerNotFound(
+                    request.source_revision.layer_id,
+                ))?
+                .depth;
+            let depth = source_depth
+                .checked_add(1)
+                .ok_or_else(|| WorkspaceError::CorruptMetadata("layer depth overflows".into()))?;
+            check_depth(depth)?;
+            state.layers.insert(
+                request.new_head_layer_id,
+                writable_layer(
+                    request.new_head_layer_id,
+                    request.source_revision.layer_id,
+                    depth,
+                    target.workspace_id,
+                    now,
+                ),
+            );
+            let epoch = target
+                .head_epoch
+                .checked_add(1)
+                .ok_or_else(|| WorkspaceError::CorruptMetadata("head epoch overflows".into()))?;
+            let workspace = state
+                .workspaces
+                .get_mut(&target.workspace_id)
+                .expect("target workspace exists");
+            workspace.head_layer_id = request.new_head_layer_id;
+            workspace.head_epoch = epoch;
+            workspace.fork_base = Some(request.source_revision.clone());
+            workspace.updated_at_ns = now;
+            let old_head = state
+                .layers
+                .get_mut(&target.head_layer_id)
+                .expect("target head exists");
+            old_head.state = LayerState::Deleting;
+            old_head.owner_workspace_id = None;
+            Ok(CommitResult {
+                revision: request.source_revision.clone(),
+                target_head_layer_id: request.new_head_layer_id,
+                target_head_epoch: epoch,
+            })
+        })
+        .await
+    }
+
+    async fn mark_workspace_deleting(&self, request: MarkDeleting) -> Result<(), WorkspaceError> {
+        let now = self.now_ns().await?;
+        self.update_control(|state, _| {
+            let active = state.leases.values().any(|lease| {
+                lease.workspace_id == request.workspace_id
+                    && lease.state == LeaseState::Active
+                    && lease.expires_at_ns > now
+            });
+            if active && !request.force_fence_lease {
+                return Err(WorkspaceError::Busy);
+            }
+            if request.force_fence_lease {
+                for lease in state.leases.values_mut() {
+                    if lease.workspace_id == request.workspace_id
+                        && lease.state == LeaseState::Active
+                    {
+                        lease.state = LeaseState::Released;
+                        lease.updated_at_ns = now;
+                    }
+                }
+            }
+            let workspace = state
+                .workspaces
+                .get_mut(&request.workspace_id)
+                .ok_or(WorkspaceError::WorkspaceNotFound(request.workspace_id))?;
+            if workspace.state != WorkspaceState::Active {
+                return Err(WorkspaceError::WorkspaceNotFound(request.workspace_id));
+            }
+            workspace.state = WorkspaceState::Deleting;
+            workspace.updated_at_ns = now;
+            let head = workspace.head_layer_id;
+            if let Some(layer) = state.layers.get_mut(&head)
+                && layer.state == LayerState::Writable
+            {
+                layer.state = LayerState::Deleting;
+                layer.owner_workspace_id = None;
+            }
+            Ok(())
+        })
+        .await
+    }
+
+    async fn record_orphan_slice(&self, request: RecordOrphanSlice) -> Result<(), WorkspaceError> {
+        if request.slice_end == 0 {
+            return Err(WorkspaceError::CorruptMetadata(
+                "orphan slice length must be non-zero".into(),
+            ));
+        }
+        let now = self.now_ns().await?;
+        let extent = DataExtentDelta::data(
+            request.orphan_layer_id,
+            1,
+            0,
+            0,
+            request.slice_end,
+            request.slice_id,
+            0,
+            1,
+        );
+        self.update_control(|state, writes| {
+            if state.layers.contains_key(&request.orphan_layer_id) {
+                return Err(conflict("orphan layer already exists"));
+            }
+            state.layers.insert(
+                request.orphan_layer_id,
+                LayerRecord {
+                    layer_id: request.orphan_layer_id,
+                    parent_layer_id: None,
+                    state: LayerState::Deleting,
+                    schema_version: WORKSPACE_SCHEMA_VERSION,
+                    sealed_version: None,
+                    delta_digest: None,
+                    root_hash: None,
+                    depth: 1,
+                    owner_workspace_id: None,
+                    next_sequence: 2,
+                    owned_slice_count: 1,
+                    owned_bytes: request.slice_end,
+                    created_at_ns: now,
+                    sealed_at_ns: None,
+                },
+            );
+            writes.push(put(extent_key(&extent), &extent)?);
+            Ok(())
+        })
+        .await
+    }
+
+    async fn gc_snapshot(
+        &self,
+        now_ns: i64,
+        lease_grace_ns: u64,
+    ) -> Result<GcSnapshot, WorkspaceError> {
+        let state = self.load_control().await?;
+        let lease_cutoff = now_ns.saturating_sub(u64_to_i64(lease_grace_ns, "lease grace")?);
+        let mut roots = BTreeSet::new();
+        for workspace in state.workspaces.values() {
+            if workspace.state != WorkspaceState::Deleting {
+                roots.insert(workspace.head_layer_id);
+            }
+        }
+        for lease in state.leases.values() {
+            if matches!(lease.state, LeaseState::Active | LeaseState::Releasing)
+                && lease.expires_at_ns > lease_cutoff
+            {
+                roots.insert(lease.base_revision.layer_id);
+            }
+        }
+        roots.extend(
+            state
+                .snapshots
+                .values()
+                .map(|snapshot| snapshot.revision.layer_id),
+        );
+        for journal in state.journals.values() {
+            if !matches!(journal.phase, SealPhase::Completed | SealPhase::Aborted) {
+                roots.insert(journal.old_head_layer_id);
+                if let Some(head) = journal.new_head_layer_id {
+                    roots.insert(head);
+                }
+            }
+        }
+        let mut layers = state.layers.into_values().collect::<Vec<_>>();
+        layers.sort_by_key(|layer| (layer.created_at_ns, layer.layer_id));
+        let extents: Vec<DataExtentDelta> = self.scan(b"delta/extent/".to_vec()).await?;
+        let mut slice_references = Vec::new();
+        for extent in extents {
+            if let ExtentKind::Data {
+                slice_id,
+                slice_offset,
+            } = extent.kind
+            {
+                slice_references.push(SliceReference {
+                    layer_id: extent.layer_id,
+                    slice_id,
+                    slice_end: slice_offset.checked_add(extent.length).ok_or_else(|| {
+                        WorkspaceError::CorruptMetadata("slice reference overflows".into())
+                    })?,
+                });
+            }
+        }
+        Ok(GcSnapshot {
+            root_layers: roots.into_iter().collect(),
+            layers,
+            slice_references,
+        })
+    }
+
+    async fn delete_layer_metadata(
+        &self,
+        request: DeleteLayerMetadata,
+    ) -> Result<(), WorkspaceError> {
+        if request.layer_ids.is_empty() {
+            return Ok(());
+        }
+        self.update_control(|state, _| {
+            let lease_cutoff = request
+                .now_ns
+                .saturating_sub(u64_to_i64(request.lease_grace_ns, "lease grace")?);
+            let reachable = reachable_layers(state, lease_cutoff);
+            if request
+                .layer_ids
+                .iter()
+                .any(|layer| reachable.contains(layer))
+            {
+                return Err(WorkspaceError::Busy);
+            }
+            for layer_id in &request.layer_ids {
+                if let Some(layer) = state.layers.get_mut(layer_id) {
+                    layer.state = LayerState::Deleting;
+                    layer.owner_workspace_id = None;
+                }
+            }
+            Ok(())
+        })
+        .await
+    }
+
+    async fn finalize_layer_metadata_deletion(
+        &self,
+        layer_ids: Vec<LayerId>,
+    ) -> Result<(), WorkspaceError> {
+        let mut entries = BTreeMap::<LayerId, Vec<Vec<u8>>>::new();
+        for layer_id in &layer_ids {
+            let mut keys = Vec::new();
+            for prefix in [
+                dentry_layer_prefix(*layer_id),
+                inode_layer_prefix(*layer_id),
+                xattr_layer_prefix(*layer_id),
+                acl_layer_prefix(*layer_id),
+                extent_layer_prefix(*layer_id),
+            ] {
+                keys.extend(
+                    self.scan_entries(prefix)
+                        .await?
+                        .into_iter()
+                        .map(|entry| entry.key),
+                );
+            }
+            entries.insert(*layer_id, keys);
+        }
+        self.update_control(|state, writes| {
+            for layer_id in &layer_ids {
+                if state
+                    .layers
+                    .get(layer_id)
+                    .is_some_and(|layer| layer.state != LayerState::Deleting)
+                {
+                    return Err(WorkspaceError::Busy);
+                }
+            }
+            for layer_id in &layer_ids {
+                state.layers.remove(layer_id);
+                if let Some(keys) = entries.get(layer_id) {
+                    writes.extend(keys.iter().cloned().map(|key| KvWrite::Delete { key }));
+                }
+            }
+            Ok(())
+        })
+        .await
+    }
+
+    async fn install_compaction(
+        &self,
+        request: InstallCompaction,
+    ) -> Result<CompactionResult, WorkspaceError> {
+        if request.compacted_layer_id == request.replacement_head_layer_id {
+            return Err(WorkspaceError::CorruptMetadata(
+                "compacted and replacement head IDs must differ".into(),
+            ));
+        }
+        for layer_id in request
+            .delta
+            .dentries
+            .iter()
+            .map(|row| row.layer_id)
+            .chain(request.delta.inodes.iter().map(|row| row.layer_id))
+            .chain(request.delta.xattrs.iter().map(|row| row.layer_id))
+            .chain(request.delta.acls.iter().map(|row| row.layer_id))
+            .chain(request.delta.extents.iter().map(|row| row.layer_id))
+        {
+            if layer_id != request.compacted_layer_id {
+                return Err(WorkspaceError::CorruptMetadata(
+                    "compaction delta contains a foreign layer ID".into(),
+                ));
+            }
+        }
+        let digest = delta_digest(&request.delta)?;
+        let root = root_hash([0; 32], digest);
+        let next_sequence = request
+            .delta
+            .dentries
+            .iter()
+            .map(|row| row.sequence)
+            .chain(request.delta.inodes.iter().map(|row| row.sequence))
+            .chain(request.delta.xattrs.iter().map(|row| row.sequence))
+            .chain(request.delta.acls.iter().map(|row| row.sequence))
+            .chain(request.delta.extents.iter().map(|row| row.sequence))
+            .max()
+            .unwrap_or(0)
+            .checked_add(1)
+            .ok_or_else(|| WorkspaceError::CorruptMetadata("sequence overflows".into()))?;
+        let now = self.now_ns().await?;
+        self.update_control(|state, writes| {
+            let workspace = state
+                .workspaces
+                .get(&request.workspace_id)
+                .cloned()
+                .ok_or(WorkspaceError::WorkspaceNotFound(request.workspace_id))?;
+            if workspace.head_layer_id != request.expected_head_layer_id
+                || workspace.head_epoch != request.expected_head_epoch
+                || workspace.state != WorkspaceState::Active
+            {
+                return Err(WorkspaceError::Fenced);
+            }
+            let head = state
+                .layers
+                .get(&request.expected_head_layer_id)
+                .ok_or(WorkspaceError::Fenced)?;
+            if head.state != LayerState::Writable
+                || head.owner_workspace_id != Some(request.workspace_id)
+                || head.parent_layer_id != Some(request.expected_parent_layer_id)
+                || head.next_sequence != 1
+            {
+                return Err(WorkspaceError::Fenced);
+            }
+            if state.layers.contains_key(&request.compacted_layer_id)
+                || state
+                    .layers
+                    .contains_key(&request.replacement_head_layer_id)
+            {
+                return Err(conflict("compaction output layer already exists"));
+            }
+            let sealed_version = u64::try_from(allocate_id_state(state, "sealed_version")?)
+                .map_err(|_| WorkspaceError::CorruptMetadata("negative sealed version".into()))?;
+            state.layers.insert(
+                request.compacted_layer_id,
+                LayerRecord {
+                    layer_id: request.compacted_layer_id,
+                    parent_layer_id: None,
+                    state: LayerState::Sealed,
+                    schema_version: WORKSPACE_SCHEMA_VERSION,
+                    sealed_version: Some(sealed_version),
+                    delta_digest: Some(digest),
+                    root_hash: Some(root),
+                    depth: 1,
+                    owner_workspace_id: None,
+                    next_sequence,
+                    owned_slice_count: 0,
+                    owned_bytes: 0,
+                    created_at_ns: now,
+                    sealed_at_ns: Some(now),
+                },
+            );
+            state.layers.insert(
+                request.replacement_head_layer_id,
+                writable_layer(
+                    request.replacement_head_layer_id,
+                    request.compacted_layer_id,
+                    2,
+                    request.workspace_id,
+                    now,
+                ),
+            );
+            let epoch = workspace
+                .head_epoch
+                .checked_add(1)
+                .ok_or_else(|| WorkspaceError::CorruptMetadata("head epoch overflows".into()))?;
+            let workspace = state
+                .workspaces
+                .get_mut(&request.workspace_id)
+                .expect("workspace exists");
+            workspace.head_layer_id = request.replacement_head_layer_id;
+            workspace.head_epoch = epoch;
+            workspace.fork_base = Some(BaseRevision {
+                layer_id: request.compacted_layer_id,
+                sealed_version,
+                root_hash: root,
+            });
+            workspace.updated_at_ns = now;
+            let revision = workspace
+                .fork_base
+                .clone()
+                .expect("compaction installs a fork base");
+            for lease in state.leases.values_mut() {
+                if lease.workspace_id == request.workspace_id && lease.state == LeaseState::Active {
+                    lease.base_revision = revision.clone();
+                    lease.updated_at_ns = now;
+                }
+            }
+            let old_head = state
+                .layers
+                .get_mut(&request.expected_head_layer_id)
+                .expect("head exists");
+            old_head.state = LayerState::Deleting;
+            old_head.owner_workspace_id = None;
+
+            for row in &request.delta.dentries {
+                writes.push(put(dentry_key(row), row)?);
+            }
+            for row in &request.delta.inodes {
+                writes.push(put(inode_key(row), row)?);
+            }
+            for row in &request.delta.xattrs {
+                writes.push(put(xattr_key(row), row)?);
+            }
+            for row in &request.delta.acls {
+                writes.push(put(acl_key(row), row)?);
+            }
+            for row in &request.delta.extents {
+                writes.push(put(extent_key(row), row)?);
+            }
+            Ok(CompactionResult {
+                revision: BaseRevision {
+                    layer_id: request.compacted_layer_id,
+                    sealed_version,
+                    root_hash: root,
+                },
+                replacement_head_layer_id: request.replacement_head_layer_id,
+                head_epoch: epoch,
+            })
+        })
+        .await
+    }
+}
+
+fn encode<T: Serialize>(value: &T) -> Result<Vec<u8>, WorkspaceError> {
+    let payload = bincode::serialize(value)
+        .map_err(|error| WorkspaceError::Backend(format!("encode workspace record: {error}")))?;
+    let mut bytes = Vec::with_capacity(ENVELOPE_MAGIC.len() + payload.len());
+    bytes.extend_from_slice(ENVELOPE_MAGIC);
+    bytes.extend_from_slice(&payload);
+    Ok(bytes)
+}
+
+fn decode<T: DeserializeOwned>(bytes: &[u8]) -> Result<T, WorkspaceError> {
+    let payload = bytes.strip_prefix(ENVELOPE_MAGIC).ok_or_else(|| {
+        WorkspaceError::CorruptMetadata("workspace KV record has invalid envelope".into())
+    })?;
+    bincode::deserialize(payload).map_err(|error| {
+        WorkspaceError::CorruptMetadata(format!("decode workspace record: {error}"))
+    })
+}
+
+fn put<T: Serialize>(key: Vec<u8>, value: &T) -> Result<KvWrite, WorkspaceError> {
+    Ok(KvWrite::Put {
+        key,
+        value: encode(value)?,
+    })
+}
+
+fn hot_workspace_key(id: WorkspaceId) -> Vec<u8> {
+    format!("hot/workspace/{id}").into_bytes()
+}
+
+fn hot_layer_key(id: LayerId) -> Vec<u8> {
+    format!("hot/layer/{id}").into_bytes()
+}
+
+fn hot_lease_key(id: LeaseId) -> Vec<u8> {
+    format!("hot/lease/{id}").into_bytes()
+}
+
+fn hot_allocator_key(name: &str) -> Vec<u8> {
+    format!("hot/allocator/{name}").into_bytes()
+}
+
+fn is_hot_key(key: &[u8]) -> bool {
+    key.starts_with(HOT_WORKSPACE_PREFIX)
+        || key.starts_with(HOT_LAYER_PREFIX)
+        || key.starts_with(HOT_LEASE_PREFIX)
+        || key.starts_with(HOT_ALLOCATOR_PREFIX)
+}
+
+fn allocator_name_from_key(key: &[u8]) -> Result<String, WorkspaceError> {
+    let name = key.strip_prefix(HOT_ALLOCATOR_PREFIX).ok_or_else(|| {
+        WorkspaceError::CorruptMetadata("invalid hot allocator key prefix".into())
+    })?;
+    String::from_utf8(name.to_vec())
+        .map_err(|_| WorkspaceError::CorruptMetadata("invalid hot allocator key".into()))
+}
+
+fn append_hot_diff(
+    before: &ControlState,
+    after: &ControlState,
+    writes: &mut Vec<KvWrite>,
+) -> Result<(), WorkspaceError> {
+    append_map_diff(&before.workspaces, &after.workspaces, writes, |id| {
+        hot_workspace_key(*id)
+    })?;
+    append_map_diff(&before.layers, &after.layers, writes, |id| {
+        hot_layer_key(*id)
+    })?;
+    append_map_diff(&before.leases, &after.leases, writes, |id| {
+        hot_lease_key(*id)
+    })?;
+    append_map_diff(&before.allocators, &after.allocators, writes, |name| {
+        hot_allocator_key(name)
+    })?;
+    Ok(())
+}
+
+fn append_map_diff<K, V, F>(
+    before: &BTreeMap<K, V>,
+    after: &BTreeMap<K, V>,
+    writes: &mut Vec<KvWrite>,
+    key: F,
+) -> Result<(), WorkspaceError>
+where
+    K: Ord,
+    V: PartialEq + Serialize,
+    F: Fn(&K) -> Vec<u8>,
+{
+    for (id, value) in after {
+        if before.get(id) != Some(value) {
+            writes.push(put(key(id), value)?);
+        }
+    }
+    for id in before.keys() {
+        if !after.contains_key(id) {
+            writes.push(KvWrite::Delete { key: key(id) });
+        }
+    }
+    Ok(())
+}
+
+fn checked_hot_guard(
+    workspace: &WorkspaceRecord,
+    layer: &LayerRecord,
+    lease: &SnapshotLease,
+    guard: &HeadGuard,
+    now: i64,
+) -> Result<(), WorkspaceError> {
+    if workspace.workspace_id != guard.workspace_id
+        || workspace.state != WorkspaceState::Active
+        || workspace.head_layer_id != guard.expected_head_layer_id
+        || workspace.head_epoch != guard.expected_head_epoch
+        || layer.layer_id != guard.expected_head_layer_id
+        || layer.state != LayerState::Writable
+        || layer.owner_workspace_id != Some(guard.workspace_id)
+        || lease.lease_id != guard.lease_id
+        || lease.workspace_id != guard.workspace_id
+        || lease.state != LeaseState::Active
+        || !lease.writable
+        || lease.holder_generation != guard.holder_generation
+        || lease.expires_at_ns <= now
+    {
+        return Err(WorkspaceError::Fenced);
+    }
+    Ok(())
+}
+
+fn allocate_layer_sequences(
+    layer: &mut LayerRecord,
+    count: usize,
+) -> Result<Option<(u64, u64)>, WorkspaceError> {
+    if count == 0 {
+        return Ok(None);
+    }
+    let count = u64::try_from(count)
+        .map_err(|_| WorkspaceError::CorruptMetadata("sequence count overflows".into()))?;
+    let first = layer.next_sequence;
+    let next = first
+        .checked_add(count)
+        .ok_or_else(|| WorkspaceError::CorruptMetadata("sequence overflows".into()))?;
+    layer.next_sequence = next;
+    Ok(Some((first, next - 1)))
+}
+
+fn writable_layer(
+    layer_id: LayerId,
+    parent_layer_id: LayerId,
+    depth: u32,
+    workspace_id: WorkspaceId,
+    now: i64,
+) -> LayerRecord {
+    LayerRecord {
+        layer_id,
+        parent_layer_id: Some(parent_layer_id),
+        state: LayerState::Writable,
+        schema_version: WORKSPACE_SCHEMA_VERSION,
+        sealed_version: None,
+        delta_digest: None,
+        root_hash: None,
+        depth,
+        owner_workspace_id: Some(workspace_id),
+        next_sequence: 1,
+        owned_slice_count: 0,
+        owned_bytes: 0,
+        created_at_ns: now,
+        sealed_at_ns: None,
+    }
+}
+
+fn revision_state(state: &ControlState, layer_id: LayerId) -> Result<BaseRevision, WorkspaceError> {
+    let layer = state
+        .layers
+        .get(&layer_id)
+        .ok_or(WorkspaceError::LayerNotFound(layer_id))?;
+    revision_from_layer(layer)
+}
+
+fn revision_from_layer(layer: &LayerRecord) -> Result<BaseRevision, WorkspaceError> {
+    if layer.state != LayerState::Sealed {
+        return Err(WorkspaceError::LayerNotFound(layer.layer_id));
+    }
+    Ok(BaseRevision {
+        layer_id: layer.layer_id,
+        sealed_version: layer
+            .sealed_version
+            .ok_or_else(|| WorkspaceError::CorruptMetadata("sealed layer has no version".into()))?,
+        root_hash: layer.root_hash.ok_or_else(|| {
+            WorkspaceError::CorruptMetadata("sealed layer has no root hash".into())
+        })?,
+    })
+}
+
+fn checked_guard(state: &ControlState, guard: &HeadGuard, now: i64) -> Result<(), WorkspaceError> {
+    let Some(workspace) = state.workspaces.get(&guard.workspace_id) else {
+        return Err(WorkspaceError::Fenced);
+    };
+    let Some(layer) = state.layers.get(&workspace.head_layer_id) else {
+        return Err(WorkspaceError::Fenced);
+    };
+    let Some(lease) = state.leases.get(&guard.lease_id) else {
+        return Err(WorkspaceError::Fenced);
+    };
+    if workspace.state != WorkspaceState::Active
+        || workspace.head_layer_id != guard.expected_head_layer_id
+        || workspace.head_epoch != guard.expected_head_epoch
+        || layer.state != LayerState::Writable
+        || layer.owner_workspace_id != Some(guard.workspace_id)
+        || lease.workspace_id != guard.workspace_id
+        || lease.state != LeaseState::Active
+        || !lease.writable
+        || lease.holder_generation != guard.holder_generation
+        || lease.expires_at_ns <= now
+    {
+        return Err(WorkspaceError::Fenced);
+    }
+    Ok(())
+}
+
+fn allocate_id_state(state: &mut ControlState, name: &str) -> Result<i64, WorkspaceError> {
+    let next = state.allocators.get_mut(name).ok_or_else(|| {
+        WorkspaceError::CorruptMetadata(format!("workspace allocator {name} is missing"))
+    })?;
+    if *next == i64::MAX {
+        return Err(WorkspaceError::CorruptMetadata(format!(
+            "workspace allocator {name} is exhausted"
+        )));
+    }
+    let allocated = *next;
+    *next += 1;
+    Ok(allocated)
+}
+
+fn checked_expiry(now: i64, ttl_ns: u64) -> Result<i64, WorkspaceError> {
+    now.checked_add(u64_to_i64(ttl_ns, "lease TTL")?)
+        .ok_or_else(|| WorkspaceError::CorruptMetadata("lease expiry overflows".into()))
+}
+
+fn check_depth(depth: u32) -> Result<(), WorkspaceError> {
+    if depth > LAYER_CHAIN_HARD_LIMIT {
+        return Err(WorkspaceError::LayerDepthLimit {
+            depth,
+            hard_limit: LAYER_CHAIN_HARD_LIMIT,
+        });
+    }
+    Ok(())
+}
+
+fn validate_extent_request(
+    extent: &DataExtentDelta,
+    head: LayerId,
+    chunk_size: u64,
+) -> Result<(), WorkspaceError> {
+    if extent.layer_id != head {
+        return Err(WorkspaceError::Fenced);
+    }
+    extent.validate()?;
+    let end = extent
+        .logical_offset
+        .checked_add(extent.length)
+        .ok_or_else(|| WorkspaceError::CorruptMetadata("extent range overflows".into()))?;
+    if end > chunk_size {
+        return Err(WorkspaceError::CorruptMetadata(format!(
+            "extent end {end} exceeds chunk size {chunk_size}"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_value(op: ValueOp, value: Option<&[u8]>, kind: &str) -> Result<(), WorkspaceError> {
+    match (op, value) {
+        (ValueOp::Put, Some(_)) | (ValueOp::Whiteout, None) => Ok(()),
+        _ => Err(WorkspaceError::CorruptMetadata(format!(
+            "{kind} op/payload mismatch"
+        ))),
+    }
+}
+
+fn invalid_transition(from: SealPhase, to: SealPhase) -> WorkspaceError {
+    WorkspaceError::InvalidStateTransition {
+        from: format!("{from:?}"),
+        to: format!("{to:?}"),
+    }
+}
+
+fn conflict(reason: &str) -> WorkspaceError {
+    WorkspaceError::Conflict(ConflictDetail {
+        path: Vec::new(),
+        reason: reason.into(),
+    })
+}
+
+fn commit_conflict(reason: &str) -> WorkspaceError {
+    conflict(reason)
+}
+
+fn u64_to_i64(value: u64, field: &str) -> Result<i64, WorkspaceError> {
+    i64::try_from(value)
+        .map_err(|_| WorkspaceError::CorruptMetadata(format!("{field} exceeds i64 range")))
+}
+
+fn reachable_layers(state: &ControlState, lease_cutoff: i64) -> HashSet<LayerId> {
+    let mut pending = Vec::new();
+    pending.extend(
+        state
+            .workspaces
+            .values()
+            .filter(|workspace| workspace.state != WorkspaceState::Deleting)
+            .map(|workspace| workspace.head_layer_id),
+    );
+    pending.extend(
+        state
+            .snapshots
+            .values()
+            .map(|snapshot| snapshot.revision.layer_id),
+    );
+    pending.extend(
+        state
+            .leases
+            .values()
+            .filter(|lease| {
+                matches!(lease.state, LeaseState::Active | LeaseState::Releasing)
+                    && lease.expires_at_ns > lease_cutoff
+            })
+            .map(|lease| lease.base_revision.layer_id),
+    );
+    for journal in state.journals.values() {
+        if !matches!(journal.phase, SealPhase::Completed | SealPhase::Aborted) {
+            pending.push(journal.old_head_layer_id);
+            pending.extend(journal.new_head_layer_id);
+        }
+    }
+    let mut reachable = HashSet::new();
+    while let Some(layer_id) = pending.pop() {
+        if !reachable.insert(layer_id) {
+            continue;
+        }
+        if let Some(parent) = state
+            .layers
+            .get(&layer_id)
+            .and_then(|layer| layer.parent_layer_id)
+        {
+            pending.push(parent);
+        }
+    }
+    reachable
+}
+
+fn sort_delta(delta: &mut CanonicalLayerDelta) {
+    delta
+        .dentries
+        .sort_by(|left, right| (left.parent_ino, &left.name).cmp(&(right.parent_ino, &right.name)));
+    delta.inodes.sort_by_key(|row| row.ino);
+    delta
+        .xattrs
+        .sort_by(|left, right| (left.ino, &left.name).cmp(&(right.ino, &right.name)));
+    delta
+        .acls
+        .sort_by_key(|row| (row.ino, row.acl_type, row.acl_id));
+    delta
+        .extents
+        .sort_by_key(|row| (row.ino, row.chunk_index, row.sequence));
+}
+
+fn id_component(id: LayerId) -> String {
+    id.to_string()
+}
+
+fn ino_component(ino: i64) -> String {
+    format!("{:016x}", (ino as u64) ^ (1_u64 << 63))
+}
+
+fn u64_component(value: u64) -> String {
+    format!("{value:016x}")
+}
+
+fn dentry_layer_prefix(layer: LayerId) -> Vec<u8> {
+    format!("delta/dentry/{}/", id_component(layer)).into_bytes()
+}
+
+fn dentry_parent_prefix(layer: LayerId, parent_ino: i64) -> Vec<u8> {
+    format!(
+        "delta/dentry/{}/{}/",
+        id_component(layer),
+        ino_component(parent_ino)
+    )
+    .into_bytes()
+}
+
+fn dentry_key(row: &DentryDelta) -> Vec<u8> {
+    dentry_identity_key(row.layer_id, row.parent_ino, &row.name)
+}
+
+fn dentry_identity_key(layer: LayerId, parent_ino: i64, name: &[u8]) -> Vec<u8> {
+    let mut key = dentry_parent_prefix(layer, parent_ino);
+    key.extend_from_slice(hex::encode(name).as_bytes());
+    key
+}
+
+fn inode_layer_prefix(layer: LayerId) -> Vec<u8> {
+    format!("delta/inode/{}/", id_component(layer)).into_bytes()
+}
+
+fn inode_identity_key(layer: LayerId, ino: i64) -> Vec<u8> {
+    format!("delta/inode/{}/{}", id_component(layer), ino_component(ino)).into_bytes()
+}
+
+fn inode_key(row: &InodeDelta) -> Vec<u8> {
+    inode_identity_key(row.layer_id, row.ino)
+}
+
+fn xattr_layer_prefix(layer: LayerId) -> Vec<u8> {
+    format!("delta/xattr/{}/", id_component(layer)).into_bytes()
+}
+
+fn xattr_inode_prefix(layer: LayerId, ino: i64) -> Vec<u8> {
+    format!(
+        "delta/xattr/{}/{}/",
+        id_component(layer),
+        ino_component(ino)
+    )
+    .into_bytes()
+}
+
+fn xattr_key(row: &XattrDelta) -> Vec<u8> {
+    xattr_identity_key(row.layer_id, row.ino, &row.name)
+}
+
+fn xattr_identity_key(layer: LayerId, ino: i64, name: &[u8]) -> Vec<u8> {
+    let mut key = xattr_inode_prefix(layer, ino);
+    key.extend_from_slice(hex::encode(name).as_bytes());
+    key
+}
+
+fn acl_layer_prefix(layer: LayerId) -> Vec<u8> {
+    format!("delta/acl/{}/", id_component(layer)).into_bytes()
+}
+
+fn acl_inode_prefix(layer: LayerId, ino: i64) -> Vec<u8> {
+    format!("delta/acl/{}/{}/", id_component(layer), ino_component(ino)).into_bytes()
+}
+
+fn acl_key(row: &AclDelta) -> Vec<u8> {
+    acl_identity_key(row.layer_id, row.ino, row.acl_type, row.acl_id)
+}
+
+fn acl_identity_key(layer: LayerId, ino: i64, acl_type: u8, acl_id: i64) -> Vec<u8> {
+    let mut key = acl_inode_prefix(layer, ino);
+    key.extend_from_slice(format!("{acl_type:02x}/{}", ino_component(acl_id)).as_bytes());
+    key
+}
+
+fn extent_layer_prefix(layer: LayerId) -> Vec<u8> {
+    format!("delta/extent/{}/", id_component(layer)).into_bytes()
+}
+
+fn extent_chunk_prefix(layer: LayerId, ino: i64, chunk_index: u64) -> Vec<u8> {
+    format!(
+        "delta/extent/{}/{}/{}/",
+        id_component(layer),
+        ino_component(ino),
+        u64_component(chunk_index)
+    )
+    .into_bytes()
+}
+
+fn extent_key(row: &DataExtentDelta) -> Vec<u8> {
+    let mut key = extent_chunk_prefix(row.layer_id, row.ino, row.chunk_index);
+    key.extend_from_slice(u64_component(row.sequence).as_bytes());
+    key
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use async_trait::async_trait;
+    use tokio::sync::{Barrier, Mutex};
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::workspace_overlay::catalog::{
+        AcquireLease, AdvanceSeal, AppendDataExtent, BeginSeal, CreateVolumeRoot, CreateWorkspace,
+        DentryQuery, HeadGuard, NamespaceMutation, WorkspaceStore,
+    };
+    use crate::workspace_overlay::ids::{JournalId, LeaseId};
+    use crate::workspace_overlay::stores::redis::RedisWorkspaceBackend;
+    use crate::workspace_overlay::stores::tikv::TiKvWorkspaceBackend;
+
+    #[derive(Clone, Default)]
+    struct MemoryBackend {
+        records: Arc<Mutex<BTreeMap<Vec<u8>, Vec<u8>>>>,
+        cas_checks: Arc<Mutex<Vec<Vec<Vec<u8>>>>>,
+        scans: Arc<AtomicU64>,
+    }
+
+    #[async_trait]
+    impl WorkspaceKvBackend for MemoryBackend {
+        fn name(&self) -> &'static str {
+            "workspace-memory-test"
+        }
+
+        async fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, WorkspaceError> {
+            Ok(self.records.lock().await.get(key).cloned())
+        }
+
+        async fn scan_prefix(&self, prefix: &[u8]) -> Result<Vec<KvEntry>, WorkspaceError> {
+            self.scans.fetch_add(1, Ordering::Relaxed);
+            Ok(self
+                .records
+                .lock()
+                .await
+                .range(prefix.to_vec()..)
+                .take_while(|(key, _)| key.starts_with(prefix))
+                .map(|(key, value)| KvEntry {
+                    key: key.clone(),
+                    value: value.clone(),
+                })
+                .collect())
+        }
+
+        async fn compare_and_swap(
+            &self,
+            checks: &[KvCheck],
+            writes: &[KvWrite],
+        ) -> Result<bool, WorkspaceError> {
+            self.cas_checks
+                .lock()
+                .await
+                .push(checks.iter().map(|check| check.key.clone()).collect());
+            let mut records = self.records.lock().await;
+            if checks
+                .iter()
+                .any(|check| records.get(&check.key) != check.expected.as_ref())
+            {
+                return Ok(false);
+            }
+            for write in writes {
+                match write {
+                    KvWrite::Put { key, value } => {
+                        records.insert(key.clone(), value.clone());
+                    }
+                    KvWrite::Delete { key } => {
+                        records.remove(key);
+                    }
+                }
+            }
+            Ok(true)
+        }
+
+        async fn server_time_ns(&self) -> Result<i64, WorkspaceError> {
+            let duration = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map_err(|error| WorkspaceError::Backend(error.to_string()))?;
+            i64::try_from(duration.as_nanos())
+                .map_err(|_| WorkspaceError::Backend("test clock overflow".into()))
+        }
+    }
+
+    fn id(value: u128) -> Uuid {
+        Uuid::from_u128(value)
+    }
+
+    fn create_request(offset: u128) -> CreateVolumeRoot {
+        CreateVolumeRoot {
+            volume_id: id(offset + 1),
+            workspace_id: WorkspaceId::from_uuid(id(offset + 2)),
+            root_layer_id: LayerId::from_uuid(id(offset + 3)),
+            writable_layer_id: LayerId::from_uuid(id(offset + 4)),
+            owner_id: Some("kv-contract".into()),
+        }
+    }
+
+    async fn initialized() -> (
+        KvWorkspaceStore<MemoryBackend>,
+        WorkspaceRecord,
+        SnapshotLease,
+        HeadGuard,
+    ) {
+        let store = KvWorkspaceStore::new(MemoryBackend::default());
+        store.initialize_workspace_schema().await.unwrap();
+        let workspace = store.create_volume_root(create_request(0)).await.unwrap();
+        let lease = store
+            .acquire_lease(AcquireLease {
+                workspace_id: workspace.workspace_id,
+                lease_id: LeaseId::from_uuid(id(5)),
+                holder_generation: 1,
+                ttl_ns: 120_000_000_000,
+            })
+            .await
+            .unwrap();
+        let guard = HeadGuard {
+            workspace_id: workspace.workspace_id,
+            expected_head_layer_id: workspace.head_layer_id,
+            expected_head_epoch: workspace.head_epoch,
+            lease_id: lease.lease_id,
+            holder_generation: lease.holder_generation,
+        };
+        (store, workspace, lease, guard)
+    }
+
+    #[tokio::test]
+    async fn named_lookup_and_layer_pair_loading_never_scan() {
+        let (store, workspace, _lease, guard) = initialized().await;
+        store
+            .apply_namespace_mutation(NamespaceMutation {
+                guard,
+                dentries: vec![DentryDelta::put(
+                    workspace.head_layer_id,
+                    1,
+                    b"point-lookup".to_vec(),
+                    2,
+                    0,
+                    0,
+                )],
+                inodes: Vec::new(),
+            })
+            .await
+            .unwrap();
+
+        store.backend.scans.store(0, Ordering::Relaxed);
+        let chain = store
+            .load_layer_chain(workspace.head_layer_id)
+            .await
+            .unwrap();
+        let rows = store
+            .get_dentry_deltas(DentryQuery {
+                layer_ids: chain.iter().map(|layer| layer.layer_id).collect(),
+                parent_ino: 1,
+                name: Some(b"point-lookup".to_vec()),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(store.backend.scans.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn kv_catalog_round_trips_mutations_and_full_seal() {
+        let (store, workspace, _lease, guard) = initialized().await;
+        let mutation = store
+            .apply_namespace_mutation(NamespaceMutation {
+                guard: guard.clone(),
+                dentries: vec![DentryDelta::put(
+                    workspace.head_layer_id,
+                    1,
+                    b"agent.txt".to_vec(),
+                    2,
+                    1,
+                    0,
+                )],
+                inodes: Vec::new(),
+            })
+            .await
+            .unwrap();
+        assert_eq!(mutation.first_sequence, Some(1));
+        let extent = store
+            .append_data_extent(AppendDataExtent {
+                guard: guard.clone(),
+                extent: DataExtentDelta::data(workspace.head_layer_id, 2, 0, 0, 4096, 99, 0, 0),
+                chunk_size: 64 * 1024 * 1024,
+            })
+            .await
+            .unwrap();
+        assert_eq!(extent.sequence, 2);
+        let rows = store
+            .get_dentry_deltas(DentryQuery {
+                layer_ids: vec![workspace.head_layer_id],
+                parent_ino: 1,
+                name: None,
+            })
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+
+        let journal = store
+            .begin_seal(BeginSeal {
+                guard,
+                journal_id: JournalId::from_uuid(id(6)),
+                new_head_layer_id: LayerId::from_uuid(id(7)),
+            })
+            .await
+            .unwrap();
+        store
+            .advance_seal(AdvanceSeal {
+                journal_id: journal.journal_id,
+                expected_phase: SealPhase::Prepare,
+                next_phase: SealPhase::Quiesced,
+                pending_bytes: None,
+                last_error: None,
+            })
+            .await
+            .unwrap();
+        store
+            .advance_seal(AdvanceSeal {
+                journal_id: journal.journal_id,
+                expected_phase: SealPhase::Quiesced,
+                next_phase: SealPhase::DataDrained,
+                pending_bytes: Some(0),
+                last_error: None,
+            })
+            .await
+            .unwrap();
+        store.hash_seal(journal.journal_id).await.unwrap();
+        let sealed = store.commit_seal(journal.journal_id).await.unwrap();
+        assert_eq!(sealed.revision.layer_id, workspace.head_layer_id);
+        assert_eq!(sealed.head_epoch, 1);
+        assert_eq!(
+            store
+                .load_layer_delta(sealed.revision.layer_id)
+                .await
+                .unwrap()
+                .extents
+                .len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn independent_kv_store_instances_use_backend_cas() {
+        let backend = MemoryBackend::default();
+        let probe = backend.clone();
+        let store_a = Arc::new(KvWorkspaceStore::new(backend.clone()));
+        let store_b = Arc::new(KvWorkspaceStore::new(backend));
+        store_a.initialize_workspace_schema().await.unwrap();
+        let first = store_a
+            .create_volume_root(create_request(100))
+            .await
+            .unwrap();
+        let root = store_a
+            .load_layer_chain(first.head_layer_id)
+            .await
+            .unwrap()
+            .pop()
+            .unwrap();
+        let base = BaseRevision {
+            layer_id: root.layer_id,
+            sealed_version: root.sealed_version.unwrap(),
+            root_hash: root.root_hash.unwrap(),
+        };
+        let second = store_b
+            .create_workspace(CreateWorkspace {
+                workspace_id: WorkspaceId::from_uuid(id(110)),
+                head_layer_id: LayerId::from_uuid(id(111)),
+                base_revision: base,
+                owner_id: None,
+            })
+            .await
+            .unwrap();
+        let lease_a = store_a
+            .acquire_lease(AcquireLease {
+                workspace_id: first.workspace_id,
+                lease_id: LeaseId::from_uuid(id(112)),
+                holder_generation: 1,
+                ttl_ns: 120_000_000_000,
+            })
+            .await
+            .unwrap();
+        let lease_b = store_b
+            .acquire_lease(AcquireLease {
+                workspace_id: second.workspace_id,
+                lease_id: LeaseId::from_uuid(id(113)),
+                holder_generation: 1,
+                ttl_ns: 120_000_000_000,
+            })
+            .await
+            .unwrap();
+        probe.cas_checks.lock().await.clear();
+        let first_head = first.head_layer_id;
+        let second_head = second.head_layer_id;
+        let barrier = Arc::new(Barrier::new(2));
+        let writers = [
+            (
+                Arc::clone(&store_a),
+                first,
+                lease_a,
+                Arc::clone(&barrier),
+                b'a',
+            ),
+            (Arc::clone(&store_b), second, lease_b, barrier, b'b'),
+        ]
+        .into_iter()
+        .map(|(store, workspace, lease, barrier, tag)| {
+            tokio::spawn(async move {
+                barrier.wait().await;
+                let guard = HeadGuard {
+                    workspace_id: workspace.workspace_id,
+                    expected_head_layer_id: workspace.head_layer_id,
+                    expected_head_epoch: workspace.head_epoch,
+                    lease_id: lease.lease_id,
+                    holder_generation: lease.holder_generation,
+                };
+                for index in 0..32_i64 {
+                    store
+                        .apply_namespace_mutation(NamespaceMutation {
+                            guard: guard.clone(),
+                            dentries: vec![DentryDelta::put(
+                                workspace.head_layer_id,
+                                1,
+                                format!("{}-{index}", tag as char).into_bytes(),
+                                1_000 + index,
+                                1,
+                                0,
+                            )],
+                            inodes: Vec::new(),
+                        })
+                        .await?;
+                }
+                Ok::<(), WorkspaceError>(())
+            })
+        })
+        .collect::<Vec<_>>();
+        for writer in writers {
+            writer.await.unwrap().unwrap();
+        }
+        let checks = probe.cas_checks.lock().await.clone();
+        assert_eq!(checks.len(), 64);
+        assert!(checks.iter().all(|keys| {
+            keys.len() == 3
+                && !keys.iter().any(|key| key.as_slice() == CONTROL_KEY)
+                && keys.iter().any(|key| key.starts_with(HOT_WORKSPACE_PREFIX))
+                && keys.iter().any(|key| key.starts_with(HOT_LAYER_PREFIX))
+                && keys.iter().any(|key| key.starts_with(HOT_LEASE_PREFIX))
+        }));
+        assert_eq!(
+            store_a.load_layer(first_head).await.unwrap().next_sequence,
+            33
+        );
+        assert_eq!(
+            store_b.load_layer(second_head).await.unwrap().next_sequence,
+            33
+        );
+    }
+
+    #[tokio::test]
+    async fn lease_heartbeat_and_allocators_do_not_cas_control() {
+        let backend = MemoryBackend::default();
+        let store = KvWorkspaceStore::new(backend.clone());
+        store.initialize_workspace_schema().await.unwrap();
+        let workspace = store.create_volume_root(create_request(200)).await.unwrap();
+        let lease = store
+            .acquire_lease(AcquireLease {
+                workspace_id: workspace.workspace_id,
+                lease_id: LeaseId::from_uuid(id(205)),
+                holder_generation: 9,
+                ttl_ns: 120_000_000_000,
+            })
+            .await
+            .unwrap();
+        backend.cas_checks.lock().await.clear();
+
+        store
+            .renew_lease(RenewLease {
+                lease_id: lease.lease_id,
+                holder_generation: lease.holder_generation,
+                ttl_ns: 120_000_000_000,
+            })
+            .await
+            .unwrap();
+        assert_eq!(store.allocate_id("inode").await.unwrap(), 2);
+        assert_eq!(store.allocate_id("slice").await.unwrap(), 1);
+
+        let checks = backend.cas_checks.lock().await.clone();
+        assert_eq!(checks.len(), 3);
+        assert!(checks.iter().all(|keys| {
+            keys.len() == 1 && keys[0].as_slice() != CONTROL_KEY && is_hot_key(&keys[0])
+        }));
+        assert!(checks[0][0].starts_with(HOT_LEASE_PREFIX));
+        assert!(
+            checks[1..]
+                .iter()
+                .all(|keys| keys[0].starts_with(HOT_ALLOCATOR_PREFIX))
+        );
+    }
+
+    async fn remote_backend_contract<B>(
+        store_a: Arc<KvWorkspaceStore<B>>,
+        store_b: Arc<KvWorkspaceStore<B>>,
+    ) where
+        B: WorkspaceKvBackend,
+    {
+        store_a.initialize_workspace_schema().await.unwrap();
+        let request = CreateVolumeRoot {
+            volume_id: Uuid::now_v7(),
+            workspace_id: WorkspaceId::new(),
+            root_layer_id: LayerId::new(),
+            writable_layer_id: LayerId::new(),
+            owner_id: Some("remote-contract".into()),
+        };
+        let workspace = store_a.create_volume_root(request).await.unwrap();
+        assert_eq!(
+            store_b
+                .load_workspace(workspace.workspace_id)
+                .await
+                .unwrap(),
+            workspace
+        );
+        let lease = store_a
+            .acquire_lease(AcquireLease {
+                workspace_id: workspace.workspace_id,
+                lease_id: LeaseId::new(),
+                holder_generation: 77,
+                ttl_ns: 120_000_000_000,
+            })
+            .await
+            .unwrap();
+        let guard = HeadGuard {
+            workspace_id: workspace.workspace_id,
+            expected_head_layer_id: workspace.head_layer_id,
+            expected_head_epoch: workspace.head_epoch,
+            lease_id: lease.lease_id,
+            holder_generation: lease.holder_generation,
+        };
+        let barrier = Arc::new(Barrier::new(2));
+        let writers = [Arc::clone(&store_a), Arc::clone(&store_b)]
+            .into_iter()
+            .enumerate()
+            .map(|(writer, store)| {
+                let barrier = Arc::clone(&barrier);
+                let guard = guard.clone();
+                let workspace = workspace.clone();
+                tokio::spawn(async move {
+                    barrier.wait().await;
+                    for index in 0..32_i64 {
+                        store
+                            .apply_namespace_mutation(NamespaceMutation {
+                                guard: guard.clone(),
+                                dentries: vec![DentryDelta::put(
+                                    workspace.head_layer_id,
+                                    1,
+                                    format!("writer-{writer}-{index}").into_bytes(),
+                                    2_000 + writer as i64 * 100 + index,
+                                    1,
+                                    0,
+                                )],
+                                inodes: Vec::new(),
+                            })
+                            .await?;
+                    }
+                    Ok::<(), WorkspaceError>(())
+                })
+            })
+            .collect::<Vec<_>>();
+        for writer in writers {
+            writer.await.unwrap().unwrap();
+        }
+        let rows = store_a
+            .get_dentry_deltas(DentryQuery {
+                layer_ids: vec![workspace.head_layer_id],
+                parent_ino: 1,
+                name: None,
+            })
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 64);
+        let mut sequences = rows.into_iter().map(|row| row.sequence).collect::<Vec<_>>();
+        sequences.sort_unstable();
+        assert_eq!(sequences, (1..=64).collect::<Vec<_>>());
+        assert_eq!(
+            store_b
+                .load_layer(workspace.head_layer_id)
+                .await
+                .unwrap()
+                .next_sequence,
+            65
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires BREWFS_TEST_REDIS_URL"]
+    async fn redis_backend_passes_distributed_catalog_contract() {
+        let url = std::env::var("BREWFS_TEST_REDIS_URL")
+            .expect("BREWFS_TEST_REDIS_URL must point at an isolated Redis");
+        let namespace = format!("test{}", Uuid::now_v7().simple());
+        let backend_a = RedisWorkspaceBackend::connect(&url, &namespace)
+            .await
+            .unwrap();
+        let backend_b = RedisWorkspaceBackend::connect(&url, &namespace)
+            .await
+            .unwrap();
+        remote_backend_contract(
+            Arc::new(KvWorkspaceStore::new(backend_a)),
+            Arc::new(KvWorkspaceStore::new(backend_b)),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    #[ignore = "requires BREWFS_TEST_TIKV_PD_ENDPOINTS"]
+    async fn tikv_backend_passes_distributed_catalog_contract() {
+        let endpoints = std::env::var("BREWFS_TEST_TIKV_PD_ENDPOINTS")
+            .expect("BREWFS_TEST_TIKV_PD_ENDPOINTS must list TiKV PD endpoints")
+            .split(',')
+            .map(str::to_owned)
+            .collect::<Vec<_>>();
+        let namespace = format!("test{}", Uuid::now_v7().simple());
+        let backend_a = TiKvWorkspaceBackend::connect(endpoints.clone(), &namespace)
+            .await
+            .unwrap();
+        let backend_b = TiKvWorkspaceBackend::connect(endpoints, &namespace)
+            .await
+            .unwrap();
+        remote_backend_contract(
+            Arc::new(KvWorkspaceStore::new(backend_a)),
+            Arc::new(KvWorkspaceStore::new(backend_b)),
+        )
+        .await;
+    }
+}

--- a/src/workspace_overlay/stores/mod.rs
+++ b/src/workspace_overlay/stores/mod.rs
@@ -1,0 +1,8 @@
+pub mod database;
+pub mod kv_backend;
+pub mod kv_store;
+pub mod redis;
+pub mod tikv;
+
+#[cfg(test)]
+mod tests;

--- a/src/workspace_overlay/stores/redis.rs
+++ b/src/workspace_overlay/stores/redis.rs
@@ -1,0 +1,324 @@
+//! Redis transactional substrate for the workspace catalog.
+
+use async_trait::async_trait;
+use redis::aio::ConnectionManager;
+
+use super::kv_backend::{KvCheck, KvEntry, KvWrite, WorkspaceKvBackend};
+use crate::workspace_overlay::error::WorkspaceError;
+
+const CAS_LUA: &str = r#"
+local check_count = tonumber(ARGV[1])
+local cursor = 2
+for index = 1, check_count do
+    local expected_present = ARGV[cursor]
+    local expected = ARGV[cursor + 1]
+    cursor = cursor + 2
+    local current = redis.call('GET', KEYS[index])
+    if expected_present == '0' then
+        if current then return 0 end
+    elseif current ~= expected then
+        return 0
+    end
+end
+
+local write_count = tonumber(ARGV[cursor])
+cursor = cursor + 1
+local index_key = KEYS[check_count + write_count + 1]
+for index = 1, write_count do
+    local operation = ARGV[cursor]
+    local value = ARGV[cursor + 1]
+    cursor = cursor + 2
+    local key = KEYS[check_count + index]
+    if operation == 'put' then
+        redis.call('SET', key, value)
+        redis.call('ZADD', index_key, 0, key)
+    else
+        redis.call('DEL', key)
+        redis.call('ZREM', index_key, key)
+    end
+end
+return 1
+"#;
+
+const KEY_INDEX: &[u8] = b"__index/keys";
+const KEY_INDEX_READY: &[u8] = b"__index/ready";
+const INDEX_BATCH_SIZE: usize = 1024;
+
+#[derive(Clone)]
+pub struct RedisWorkspaceBackend {
+    connection: ConnectionManager,
+    prefix: Vec<u8>,
+}
+
+impl RedisWorkspaceBackend {
+    pub async fn connect(url: &str, namespace: &str) -> Result<Self, WorkspaceError> {
+        validate_namespace(namespace)?;
+        let client = redis::Client::open(url).map_err(backend)?;
+        let connection = ConnectionManager::new(client).await.map_err(backend)?;
+        // The hash tag keeps every catalog key in one Redis Cluster slot, which
+        // is required for the multi-key Lua transactions below.
+        let prefix = format!("{{brewfs-ws-v1}}:{namespace}:ws:v1/").into_bytes();
+        let backend = Self { connection, prefix };
+        backend.ensure_key_index().await?;
+        Ok(backend)
+    }
+
+    fn scoped(&self, key: &[u8]) -> Vec<u8> {
+        let mut scoped = Vec::with_capacity(self.prefix.len() + key.len());
+        scoped.extend_from_slice(&self.prefix);
+        scoped.extend_from_slice(key);
+        scoped
+    }
+
+    async fn ensure_key_index(&self) -> Result<(), WorkspaceError> {
+        let marker = self.scoped(KEY_INDEX_READY);
+        let index = self.scoped(KEY_INDEX);
+        let mut connection = self.connection.clone();
+        let ready: Option<Vec<u8>> = redis::cmd("GET")
+            .arg(&marker)
+            .query_async(&mut connection)
+            .await
+            .map_err(backend)?;
+        if ready.is_some() {
+            return Ok(());
+        }
+
+        // This is a one-time migration for catalogs created before the
+        // lexicographic index existed. Normal prefix reads never use SCAN.
+        let mut pattern = self.prefix.clone();
+        pattern.push(b'*');
+        let mut cursor = 0_u64;
+        loop {
+            let (next, mut keys): (u64, Vec<Vec<u8>>) = redis::cmd("SCAN")
+                .arg(cursor)
+                .arg("MATCH")
+                .arg(&pattern)
+                .arg("COUNT")
+                .arg(INDEX_BATCH_SIZE)
+                .query_async(&mut connection)
+                .await
+                .map_err(backend)?;
+            keys.retain(|key| key != &index && key != &marker);
+            if !keys.is_empty() {
+                redis::cmd("ZADD")
+                    .arg(&index)
+                    .arg(0_i64)
+                    .arg(keys)
+                    .query_async::<()>(&mut connection)
+                    .await
+                    .map_err(backend)?;
+            }
+            if next == 0 {
+                break;
+            }
+            cursor = next;
+        }
+        redis::cmd("SET")
+            .arg(marker)
+            .arg(1_u8)
+            .query_async::<()>(&mut connection)
+            .await
+            .map_err(backend)
+    }
+}
+
+#[async_trait]
+impl WorkspaceKvBackend for RedisWorkspaceBackend {
+    fn name(&self) -> &'static str {
+        "workspace-redis"
+    }
+
+    async fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, WorkspaceError> {
+        let mut connection = self.connection.clone();
+        redis::cmd("GET")
+            .arg(self.scoped(key))
+            .query_async(&mut connection)
+            .await
+            .map_err(backend)
+    }
+
+    async fn get_many(&self, keys: &[Vec<u8>]) -> Result<Vec<Option<Vec<u8>>>, WorkspaceError> {
+        if keys.is_empty() {
+            return Ok(Vec::new());
+        }
+        let scoped = keys.iter().map(|key| self.scoped(key)).collect::<Vec<_>>();
+        let mut connection = self.connection.clone();
+        redis::cmd("MGET")
+            .arg(scoped)
+            .query_async(&mut connection)
+            .await
+            .map_err(backend)
+    }
+
+    async fn get_many_with_time(
+        &self,
+        keys: &[Vec<u8>],
+    ) -> Result<(Vec<Option<Vec<u8>>>, i64), WorkspaceError> {
+        let scoped = keys.iter().map(|key| self.scoped(key)).collect::<Vec<_>>();
+        let mut connection = self.connection.clone();
+        let ((seconds, micros), values): ((i64, i64), Vec<Option<Vec<u8>>>) = redis::pipe()
+            .cmd("TIME")
+            .cmd("MGET")
+            .arg(scoped)
+            .query_async(&mut connection)
+            .await
+            .map_err(backend)?;
+        let now = redis_time_ns(seconds, micros)?;
+        Ok((values, now))
+    }
+
+    async fn scan_prefix(&self, prefix: &[u8]) -> Result<Vec<KvEntry>, WorkspaceError> {
+        let mut connection = self.connection.clone();
+        let scoped_prefix = self.scoped(prefix);
+        let mut minimum = Vec::with_capacity(scoped_prefix.len() + 1);
+        minimum.push(b'[');
+        minimum.extend_from_slice(&scoped_prefix);
+        let maximum = match prefix_range_end(&scoped_prefix) {
+            Some(upper) => {
+                let mut bound = Vec::with_capacity(upper.len() + 1);
+                bound.push(b'(');
+                bound.extend_from_slice(&upper);
+                bound
+            }
+            None => b"+".to_vec(),
+        };
+        let index = self.scoped(KEY_INDEX);
+        let mut entries = Vec::new();
+        loop {
+            let keys: Vec<Vec<u8>> = redis::cmd("ZRANGEBYLEX")
+                .arg(&index)
+                .arg(&minimum)
+                .arg(&maximum)
+                .arg("LIMIT")
+                .arg(0_u8)
+                .arg(INDEX_BATCH_SIZE)
+                .query_async(&mut connection)
+                .await
+                .map_err(backend)?;
+            if keys.is_empty() {
+                break;
+            }
+            let batch: Vec<Option<Vec<u8>>> = redis::cmd("MGET")
+                .arg(&keys)
+                .query_async(&mut connection)
+                .await
+                .map_err(backend)?;
+            for (key, value) in keys.iter().zip(batch) {
+                if let Some(value) = value {
+                    let logical = key.strip_prefix(self.prefix.as_slice()).ok_or_else(|| {
+                        WorkspaceError::Backend(
+                            "Redis workspace index returned an out-of-namespace key".into(),
+                        )
+                    })?;
+                    entries.push(KvEntry {
+                        key: logical.to_vec(),
+                        value,
+                    });
+                }
+            }
+            let Some(last) = keys.last() else {
+                break;
+            };
+            minimum.clear();
+            minimum.push(b'(');
+            minimum.extend_from_slice(last);
+            if keys.len() < INDEX_BATCH_SIZE {
+                break;
+            }
+        }
+        Ok(entries)
+    }
+
+    async fn compare_and_swap(
+        &self,
+        checks: &[KvCheck],
+        writes: &[KvWrite],
+    ) -> Result<bool, WorkspaceError> {
+        let script = redis::Script::new(CAS_LUA);
+        let mut invocation = script.prepare_invoke();
+        for check in checks {
+            invocation.key(self.scoped(&check.key));
+        }
+        for write in writes {
+            let key = match write {
+                KvWrite::Put { key, .. } | KvWrite::Delete { key } => key,
+            };
+            invocation.key(self.scoped(key));
+        }
+        invocation.key(self.scoped(KEY_INDEX));
+        invocation.arg(checks.len());
+        for check in checks {
+            match &check.expected {
+                Some(expected) => {
+                    invocation.arg(1_u8).arg(expected);
+                }
+                None => {
+                    invocation.arg(0_u8).arg(Vec::<u8>::new());
+                }
+            }
+        }
+        invocation.arg(writes.len());
+        for write in writes {
+            match write {
+                KvWrite::Put { value, .. } => {
+                    invocation.arg("put").arg(value);
+                }
+                KvWrite::Delete { .. } => {
+                    invocation.arg("delete").arg(Vec::<u8>::new());
+                }
+            }
+        }
+        let mut connection = self.connection.clone();
+        let result: i64 = invocation
+            .invoke_async(&mut connection)
+            .await
+            .map_err(backend)?;
+        Ok(result == 1)
+    }
+
+    async fn server_time_ns(&self) -> Result<i64, WorkspaceError> {
+        let mut connection = self.connection.clone();
+        let (seconds, micros): (i64, i64) = redis::cmd("TIME")
+            .query_async(&mut connection)
+            .await
+            .map_err(backend)?;
+        redis_time_ns(seconds, micros)
+    }
+}
+
+fn prefix_range_end(prefix: &[u8]) -> Option<Vec<u8>> {
+    let mut upper = prefix.to_vec();
+    for index in (0..upper.len()).rev() {
+        if upper[index] != u8::MAX {
+            upper[index] += 1;
+            upper.truncate(index + 1);
+            return Some(upper);
+        }
+    }
+    None
+}
+
+fn redis_time_ns(seconds: i64, micros: i64) -> Result<i64, WorkspaceError> {
+    seconds
+        .checked_mul(1_000_000_000)
+        .and_then(|value| value.checked_add(micros.saturating_mul(1_000)))
+        .ok_or_else(|| WorkspaceError::Backend("Redis TIME overflows i64 nanos".into()))
+}
+
+fn validate_namespace(namespace: &str) -> Result<(), WorkspaceError> {
+    if namespace.is_empty()
+        || !namespace
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+    {
+        return Err(WorkspaceError::Backend(
+            "Redis workspace namespace must contain only ASCII letters, digits, '-', '_' or '.'"
+                .into(),
+        ));
+    }
+    Ok(())
+}
+
+fn backend(error: impl std::fmt::Display) -> WorkspaceError {
+    WorkspaceError::Backend(format!("Redis workspace catalog: {error}"))
+}

--- a/src/workspace_overlay/stores/tests.rs
+++ b/src/workspace_overlay/stores/tests.rs
@@ -1,0 +1,571 @@
+use std::sync::Arc;
+
+use tokio::sync::Barrier;
+use uuid::Uuid;
+
+use crate::workspace_overlay::catalog::{
+    AcquireLease, AppendDataExtent, CreateVolumeRoot, CreateWorkspace, DentryQuery, ExtentQuery,
+    HeadGuard, InodeQuery, NamespaceMutation, RecordOrphanSlice, ReleaseLease, RenewLease,
+    WorkspaceStore, XattrMutation, XattrQuery,
+};
+use crate::workspace_overlay::error::WorkspaceError;
+use crate::workspace_overlay::ids::{LayerId, LeaseId, WorkspaceId};
+use crate::workspace_overlay::model::{
+    BaseRevision, DataExtentDelta, DentryDelta, ExtentKind, LayerState, ValueOp, XattrDelta,
+};
+
+use super::database::{SqliteWorkspaceStore, StoreFailpoint};
+
+fn id(value: u128) -> Uuid {
+    Uuid::from_u128(value)
+}
+
+fn create_request() -> CreateVolumeRoot {
+    CreateVolumeRoot {
+        volume_id: id(1),
+        workspace_id: WorkspaceId::from_uuid(id(2)),
+        root_layer_id: LayerId::from_uuid(id(3)),
+        writable_layer_id: LayerId::from_uuid(id(4)),
+        owner_id: Some("test-owner".into()),
+    }
+}
+
+async fn initialized_store() -> SqliteWorkspaceStore {
+    let store = SqliteWorkspaceStore::connect("sqlite::memory:")
+        .await
+        .unwrap();
+    store.initialize_workspace_schema().await.unwrap();
+    store
+}
+
+#[tokio::test]
+async fn schema_initialization_is_idempotent_and_does_not_create_a_marker() {
+    let store = initialized_store().await;
+    store.initialize_workspace_schema().await.unwrap();
+    let names = store.schema_table_names().await.unwrap();
+    assert_eq!(names.len(), 12);
+    assert!(names.iter().all(|name| name.starts_with("ws_v1_")));
+    assert_eq!(store.load_volume_header().await.unwrap(), None);
+}
+
+#[tokio::test]
+async fn volume_root_creation_is_atomic_and_builds_a_valid_two_layer_chain() {
+    let store = initialized_store().await;
+    let request = create_request();
+    let workspace = store.create_volume_root(request.clone()).await.unwrap();
+    assert_eq!(workspace.workspace_id, request.workspace_id);
+    assert_eq!(workspace.head_layer_id, request.writable_layer_id);
+
+    let header = store.load_volume_header().await.unwrap().unwrap();
+    assert_eq!(header.volume_id, request.volume_id);
+    assert_eq!(header.volume_format, "workspace-v1");
+    assert_eq!(header.schema_version, 1);
+
+    let chain = store
+        .load_layer_chain(request.writable_layer_id)
+        .await
+        .unwrap();
+    assert_eq!(chain.len(), 2);
+    assert_eq!(chain[0].state, LayerState::Writable);
+    assert_eq!(chain[1].state, LayerState::Sealed);
+    assert_eq!(chain[1].sealed_version, Some(1));
+    assert!(chain[1].delta_digest.is_some());
+    assert!(chain[1].root_hash.is_some());
+}
+
+#[tokio::test]
+async fn head_guard_fences_stale_epoch_and_generation_without_partial_writes() {
+    let store = initialized_store().await;
+    let request = create_request();
+    let workspace = store.create_volume_root(request.clone()).await.unwrap();
+    let lease = store
+        .acquire_lease(AcquireLease {
+            workspace_id: workspace.workspace_id,
+            lease_id: LeaseId::from_uuid(id(5)),
+            holder_generation: 7,
+            ttl_ns: 30_000_000_000,
+        })
+        .await
+        .unwrap();
+    let guard = HeadGuard {
+        workspace_id: workspace.workspace_id,
+        expected_head_layer_id: workspace.head_layer_id,
+        expected_head_epoch: workspace.head_epoch,
+        lease_id: lease.lease_id,
+        holder_generation: lease.holder_generation,
+    };
+
+    store
+        .apply_namespace_mutation(NamespaceMutation {
+            guard: guard.clone(),
+            dentries: vec![DentryDelta::put(
+                workspace.head_layer_id,
+                1,
+                b"ok".to_vec(),
+                2,
+                1,
+                0,
+            )],
+            inodes: Vec::new(),
+        })
+        .await
+        .unwrap();
+
+    let mut stale = guard;
+    stale.expected_head_epoch += 1;
+    let error = store
+        .apply_namespace_mutation(NamespaceMutation {
+            guard: stale,
+            dentries: vec![DentryDelta::put(
+                workspace.head_layer_id,
+                1,
+                b"fenced".to_vec(),
+                3,
+                1,
+                0,
+            )],
+            inodes: Vec::new(),
+        })
+        .await
+        .unwrap_err();
+    assert!(matches!(error, WorkspaceError::Fenced));
+
+    let rows = store
+        .get_dentry_deltas(DentryQuery {
+            layer_ids: vec![workspace.head_layer_id],
+            parent_ino: 1,
+            name: None,
+        })
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].name, b"ok");
+    assert_eq!(rows[0].sequence, 1);
+}
+
+#[tokio::test]
+async fn injected_failure_before_commit_rolls_back_the_entire_namespace_mutation() {
+    let store = initialized_store().await;
+    let request = create_request();
+    let workspace = store.create_volume_root(request).await.unwrap();
+    let lease = store
+        .acquire_lease(AcquireLease {
+            workspace_id: workspace.workspace_id,
+            lease_id: LeaseId::from_uuid(id(6)),
+            holder_generation: 1,
+            ttl_ns: 30_000_000_000,
+        })
+        .await
+        .unwrap();
+    store.set_failpoint(StoreFailpoint::BeforeCommit);
+
+    let result = store
+        .apply_namespace_mutation(NamespaceMutation {
+            guard: HeadGuard {
+                workspace_id: workspace.workspace_id,
+                expected_head_layer_id: workspace.head_layer_id,
+                expected_head_epoch: workspace.head_epoch,
+                lease_id: lease.lease_id,
+                holder_generation: lease.holder_generation,
+            },
+            dentries: vec![DentryDelta::put(
+                workspace.head_layer_id,
+                1,
+                b"rolled-back".to_vec(),
+                2,
+                1,
+                0,
+            )],
+            inodes: Vec::new(),
+        })
+        .await;
+    assert!(result.is_err());
+    store.set_failpoint(StoreFailpoint::Disabled);
+
+    let rows = store
+        .get_dentry_deltas(DentryQuery {
+            layer_ids: vec![workspace.head_layer_id],
+            parent_ino: 1,
+            name: Some(b"rolled-back".to_vec()),
+        })
+        .await
+        .unwrap();
+    assert!(rows.is_empty());
+}
+
+#[tokio::test]
+async fn lease_singleton_renewal_and_release_are_generation_fenced() {
+    let store = initialized_store().await;
+    let workspace = store.create_volume_root(create_request()).await.unwrap();
+    let lease = store
+        .acquire_lease(AcquireLease {
+            workspace_id: workspace.workspace_id,
+            lease_id: LeaseId::from_uuid(id(7)),
+            holder_generation: 4,
+            ttl_ns: 30_000_000_000,
+        })
+        .await
+        .unwrap();
+    let duplicate = store
+        .acquire_lease(AcquireLease {
+            workspace_id: workspace.workspace_id,
+            lease_id: LeaseId::from_uuid(id(8)),
+            holder_generation: 5,
+            ttl_ns: 30_000_000_000,
+        })
+        .await
+        .unwrap_err();
+    assert!(matches!(duplicate, WorkspaceError::Busy));
+
+    let stale = store
+        .renew_lease(RenewLease {
+            lease_id: lease.lease_id,
+            holder_generation: 99,
+            ttl_ns: 30_000_000_000,
+        })
+        .await
+        .unwrap_err();
+    assert!(matches!(stale, WorkspaceError::Fenced));
+    let renewed = store
+        .renew_lease(RenewLease {
+            lease_id: lease.lease_id,
+            holder_generation: lease.holder_generation,
+            ttl_ns: 60_000_000_000,
+        })
+        .await
+        .unwrap();
+    assert!(renewed.expires_at_ns > lease.expires_at_ns);
+
+    store
+        .release_lease(ReleaseLease {
+            lease_id: lease.lease_id,
+            holder_generation: lease.holder_generation,
+        })
+        .await
+        .unwrap();
+    store
+        .acquire_lease(AcquireLease {
+            workspace_id: workspace.workspace_id,
+            lease_id: LeaseId::from_uuid(id(8)),
+            holder_generation: 5,
+            ttl_ns: 30_000_000_000,
+        })
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn expired_lease_is_reaped_before_a_new_generation_mounts() {
+    let store = initialized_store().await;
+    let workspace = store.create_volume_root(create_request()).await.unwrap();
+    let expired = store
+        .acquire_lease(AcquireLease {
+            workspace_id: workspace.workspace_id,
+            lease_id: LeaseId::from_uuid(id(70)),
+            holder_generation: 1,
+            ttl_ns: 1,
+        })
+        .await
+        .unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+
+    let replacement = store
+        .acquire_lease(AcquireLease {
+            workspace_id: workspace.workspace_id,
+            lease_id: LeaseId::from_uuid(id(71)),
+            holder_generation: 2,
+            ttl_ns: 30_000_000_000,
+        })
+        .await
+        .unwrap();
+    assert_eq!(replacement.holder_generation, 2);
+    assert!(matches!(
+        store
+            .renew_lease(RenewLease {
+                lease_id: expired.lease_id,
+                holder_generation: expired.holder_generation,
+                ttl_ns: 30_000_000_000,
+            })
+            .await,
+        Err(WorkspaceError::Fenced)
+    ));
+    let leases = store.list_leases(workspace.workspace_id).await.unwrap();
+    assert!(leases.iter().any(|lease| {
+        lease.lease_id == expired.lease_id
+            && lease.state == crate::workspace_overlay::model::LeaseState::Expired
+    }));
+}
+
+#[tokio::test]
+async fn uploaded_orphan_is_persisted_as_an_unreachable_gc_layer() {
+    let store = initialized_store().await;
+    store.create_volume_root(create_request()).await.unwrap();
+    let orphan_layer_id = LayerId::from_uuid(id(72));
+    store
+        .record_orphan_slice(RecordOrphanSlice {
+            orphan_layer_id,
+            slice_id: 9001,
+            slice_end: 8193,
+        })
+        .await
+        .unwrap();
+
+    let layer = store.load_layer(orphan_layer_id).await.unwrap();
+    assert_eq!(layer.state, LayerState::Deleting);
+    assert_eq!(layer.parent_layer_id, None);
+    assert_eq!(layer.owned_slice_count, 1);
+    assert_eq!(layer.owned_bytes, 8193);
+    let snapshot = store.gc_snapshot(i64::MAX, 0).await.unwrap();
+    assert!(!snapshot.root_layers.contains(&orphan_layer_id));
+    assert!(snapshot.slice_references.iter().any(|reference| {
+        reference.layer_id == orphan_layer_id
+            && reference.slice_id == 9001
+            && reference.slice_end == 8193
+    }));
+}
+
+#[tokio::test]
+async fn guarded_extent_and_xattr_mutations_round_trip_with_store_sequences() {
+    let store = initialized_store().await;
+    let workspace = store.create_volume_root(create_request()).await.unwrap();
+    let lease = store
+        .acquire_lease(AcquireLease {
+            workspace_id: workspace.workspace_id,
+            lease_id: LeaseId::from_uuid(id(9)),
+            holder_generation: 1,
+            ttl_ns: 30_000_000_000,
+        })
+        .await
+        .unwrap();
+    let guard = HeadGuard {
+        workspace_id: workspace.workspace_id,
+        expected_head_layer_id: workspace.head_layer_id,
+        expected_head_epoch: workspace.head_epoch,
+        lease_id: lease.lease_id,
+        holder_generation: lease.holder_generation,
+    };
+
+    let written = store
+        .append_data_extent(AppendDataExtent {
+            guard: guard.clone(),
+            extent: DataExtentDelta::data(workspace.head_layer_id, 2, 0, 4096, 8192, 100, 32, 0),
+            chunk_size: 64 * 1024 * 1024,
+        })
+        .await
+        .unwrap();
+    assert_eq!(written.sequence, 1);
+    let extents = store
+        .get_extent_deltas(ExtentQuery {
+            layer_ids: vec![workspace.head_layer_id],
+            ino: 2,
+            chunk_index: 0,
+            range_start: 0,
+            range_end: 16 * 1024,
+        })
+        .await
+        .unwrap();
+    assert_eq!(extents, vec![written]);
+    assert_eq!(
+        extents[0].kind,
+        ExtentKind::Data {
+            slice_id: 100,
+            slice_offset: 32
+        }
+    );
+
+    let base_layer = store
+        .load_layer_chain(workspace.head_layer_id)
+        .await
+        .unwrap()[1]
+        .layer_id;
+    let mut inode = store
+        .get_inode_deltas(InodeQuery {
+            layer_ids: vec![base_layer],
+            ino: 1,
+        })
+        .await
+        .unwrap()
+        .into_iter()
+        .next()
+        .unwrap();
+    inode.layer_id = workspace.head_layer_id;
+
+    store
+        .apply_xattr_mutation(XattrMutation {
+            guard,
+            inode,
+            xattr: XattrDelta {
+                layer_id: workspace.head_layer_id,
+                ino: 1,
+                name: b"user.agent".to_vec(),
+                op: ValueOp::Put,
+                value: Some(b"private".to_vec()),
+                sequence: 0,
+            },
+        })
+        .await
+        .unwrap();
+    let xattrs = store
+        .get_xattr_deltas(XattrQuery {
+            layer_ids: vec![workspace.head_layer_id],
+            ino: 1,
+            name: Some(b"user.agent".to_vec()),
+        })
+        .await
+        .unwrap();
+    assert_eq!(xattrs.len(), 1);
+    assert_eq!(xattrs[0].sequence, 2);
+    assert_eq!(xattrs[0].value.as_deref(), Some(b"private".as_slice()));
+}
+
+#[tokio::test]
+async fn workspace_allocators_are_monotonic_and_reject_unknown_names() {
+    let store = initialized_store().await;
+    store.create_volume_root(create_request()).await.unwrap();
+    assert_eq!(store.allocate_id("inode").await.unwrap(), 2);
+    assert_eq!(store.allocate_id("inode").await.unwrap(), 3);
+    assert_eq!(store.allocate_id("slice").await.unwrap(), 1);
+    assert_eq!(store.allocate_id("sealed_version").await.unwrap(), 2);
+    assert!(store.allocate_id("unknown").await.is_err());
+}
+
+#[tokio::test]
+async fn independent_store_instances_serialize_concurrent_workspace_writers() {
+    let directory = tempfile::tempdir().unwrap();
+    let database = directory.path().join("workspace-catalog.sqlite");
+    let url = format!("sqlite://{}", database.display());
+    let store_a = Arc::new(SqliteWorkspaceStore::connect(&url).await.unwrap());
+    store_a.initialize_workspace_schema().await.unwrap();
+    assert_eq!(store_a.journal_mode().await.unwrap(), "wal");
+    let first = store_a.create_volume_root(create_request()).await.unwrap();
+    let root = store_a
+        .load_layer_chain(first.head_layer_id)
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|layer| layer.parent_layer_id.is_none())
+        .unwrap();
+    let base_revision = BaseRevision {
+        layer_id: root.layer_id,
+        sealed_version: root.sealed_version.unwrap(),
+        root_hash: root.root_hash.unwrap(),
+    };
+
+    // A second connection has its own in-process gate, just like a separate
+    // BrewFS mount process. SQLite therefore has to coordinate these writers.
+    let store_b = Arc::new(SqliteWorkspaceStore::connect(&url).await.unwrap());
+    assert_eq!(store_b.journal_mode().await.unwrap(), "wal");
+    let second = store_b
+        .create_workspace(CreateWorkspace {
+            workspace_id: WorkspaceId::from_uuid(id(80)),
+            head_layer_id: LayerId::from_uuid(id(81)),
+            base_revision,
+            owner_id: Some("second-writer".into()),
+        })
+        .await
+        .unwrap();
+    let first_lease = store_a
+        .acquire_lease(AcquireLease {
+            workspace_id: first.workspace_id,
+            lease_id: LeaseId::from_uuid(id(82)),
+            holder_generation: 1,
+            ttl_ns: 120_000_000_000,
+        })
+        .await
+        .unwrap();
+    let second_lease = store_b
+        .acquire_lease(AcquireLease {
+            workspace_id: second.workspace_id,
+            lease_id: LeaseId::from_uuid(id(83)),
+            holder_generation: 1,
+            ttl_ns: 120_000_000_000,
+        })
+        .await
+        .unwrap();
+    let first_guard = HeadGuard {
+        workspace_id: first.workspace_id,
+        expected_head_layer_id: first.head_layer_id,
+        expected_head_epoch: first.head_epoch,
+        lease_id: first_lease.lease_id,
+        holder_generation: first_lease.holder_generation,
+    };
+    let second_guard = HeadGuard {
+        workspace_id: second.workspace_id,
+        expected_head_layer_id: second.head_layer_id,
+        expected_head_epoch: second.head_epoch,
+        lease_id: second_lease.lease_id,
+        holder_generation: second_lease.holder_generation,
+    };
+
+    const MUTATIONS: u64 = 64;
+    let barrier = Arc::new(Barrier::new(2));
+    let writer_a = {
+        let store = Arc::clone(&store_a);
+        let barrier = Arc::clone(&barrier);
+        tokio::spawn(async move {
+            barrier.wait().await;
+            for index in 0..MUTATIONS {
+                store
+                    .apply_namespace_mutation(NamespaceMutation {
+                        guard: first_guard.clone(),
+                        dentries: vec![DentryDelta::put(
+                            first.head_layer_id,
+                            1,
+                            format!("writer-a-{index}").into_bytes(),
+                            1_000 + index as i64,
+                            1,
+                            0,
+                        )],
+                        inodes: Vec::new(),
+                    })
+                    .await?;
+            }
+            Ok::<(), WorkspaceError>(())
+        })
+    };
+    let writer_b = {
+        let store = Arc::clone(&store_b);
+        let barrier = Arc::clone(&barrier);
+        tokio::spawn(async move {
+            barrier.wait().await;
+            for index in 0..MUTATIONS {
+                store
+                    .apply_namespace_mutation(NamespaceMutation {
+                        guard: second_guard.clone(),
+                        dentries: vec![DentryDelta::put(
+                            second.head_layer_id,
+                            1,
+                            format!("writer-b-{index}").into_bytes(),
+                            2_000 + index as i64,
+                            1,
+                            0,
+                        )],
+                        inodes: Vec::new(),
+                    })
+                    .await?;
+            }
+            Ok::<(), WorkspaceError>(())
+        })
+    };
+    writer_a.await.unwrap().unwrap();
+    writer_b.await.unwrap().unwrap();
+
+    let first_rows = store_a
+        .get_dentry_deltas(DentryQuery {
+            layer_ids: vec![first.head_layer_id],
+            parent_ino: 1,
+            name: None,
+        })
+        .await
+        .unwrap();
+    let second_rows = store_b
+        .get_dentry_deltas(DentryQuery {
+            layer_ids: vec![second.head_layer_id],
+            parent_ino: 1,
+            name: None,
+        })
+        .await
+        .unwrap();
+    assert_eq!(first_rows.len(), MUTATIONS as usize);
+    assert_eq!(second_rows.len(), MUTATIONS as usize);
+}

--- a/src/workspace_overlay/stores/tikv.rs
+++ b/src/workspace_overlay/stores/tikv.rs
@@ -1,0 +1,302 @@
+//! TiKV transactional substrate for the workspace catalog.
+
+use std::collections::BTreeMap;
+use std::ops::Bound;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use rand::{RngCore, rng};
+use tikv_client::{BoundRange, CheckLevel, Key, KvPair, TransactionClient, TransactionOptions};
+
+use super::kv_backend::{KvCheck, KvEntry, KvWrite, WorkspaceKvBackend};
+use crate::workspace_overlay::error::WorkspaceError;
+
+const SCAN_BATCH_LIMIT: u32 = 1024;
+const TXN_MAX_RETRIES: usize = 10;
+
+#[derive(Clone)]
+pub struct TiKvWorkspaceBackend {
+    client: TransactionClient,
+    prefix: Vec<u8>,
+}
+
+impl TiKvWorkspaceBackend {
+    pub async fn connect(
+        pd_endpoints: Vec<String>,
+        namespace: &str,
+    ) -> Result<Self, WorkspaceError> {
+        if pd_endpoints.is_empty() {
+            return Err(WorkspaceError::Backend(
+                "TiKV workspace catalog requires at least one PD endpoint".into(),
+            ));
+        }
+        validate_namespace(namespace)?;
+        let client = TransactionClient::new(pd_endpoints)
+            .await
+            .map_err(backend)?;
+        let prefix = format!("{namespace}/ws:v1/").into_bytes();
+        Ok(Self { client, prefix })
+    }
+
+    fn scoped(&self, key: &[u8]) -> Vec<u8> {
+        let mut scoped = Vec::with_capacity(self.prefix.len() + key.len());
+        scoped.extend_from_slice(&self.prefix);
+        scoped.extend_from_slice(key);
+        scoped
+    }
+
+    async fn retry_delay(attempt: usize) {
+        let bound = ((attempt + 1) * (attempt + 1)).max(1) as u64;
+        let jitter = rng().next_u64() % bound;
+        tokio::time::sleep(Duration::from_millis(20 + jitter)).await;
+    }
+}
+
+#[async_trait]
+impl WorkspaceKvBackend for TiKvWorkspaceBackend {
+    fn name(&self) -> &'static str {
+        "workspace-tikv"
+    }
+
+    async fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, WorkspaceError> {
+        let options = TransactionOptions::new_optimistic().drop_check(CheckLevel::Warn);
+        let mut transaction = self
+            .client
+            .begin_with_options(options)
+            .await
+            .map_err(backend)?;
+        let value = transaction.get(self.scoped(key)).await.map_err(backend)?;
+        if let Err(error) = transaction.rollback().await {
+            log::debug!("TiKV workspace get rollback failed: {error}");
+        }
+        Ok(value)
+    }
+
+    async fn get_many(&self, keys: &[Vec<u8>]) -> Result<Vec<Option<Vec<u8>>>, WorkspaceError> {
+        Ok(self.get_many_with_time(keys).await?.0)
+    }
+
+    async fn get_many_with_time(
+        &self,
+        keys: &[Vec<u8>],
+    ) -> Result<(Vec<Option<Vec<u8>>>, i64), WorkspaceError> {
+        if keys.is_empty() {
+            return Ok((Vec::new(), self.server_time_ns().await?));
+        }
+        let options = TransactionOptions::new_optimistic().drop_check(CheckLevel::Warn);
+        let mut transaction = self
+            .client
+            .begin_with_options(options)
+            .await
+            .map_err(backend)?;
+        let now = pd_physical_ms_to_ns(transaction.start_timestamp().physical)?;
+        let scoped = keys.iter().map(|key| self.scoped(key)).collect::<Vec<_>>();
+        let found = transaction
+            .batch_get(scoped.clone())
+            .await
+            .map_err(backend)?
+            .map(|pair| {
+                let key: Vec<u8> = pair.key().clone().into();
+                (key, pair.value().to_vec())
+            })
+            .collect::<BTreeMap<_, _>>();
+        if let Err(error) = transaction.rollback().await {
+            log::debug!("TiKV workspace batch get rollback failed: {error}");
+        }
+        Ok((
+            scoped.iter().map(|key| found.get(key).cloned()).collect(),
+            now,
+        ))
+    }
+
+    async fn scan_prefix(&self, prefix: &[u8]) -> Result<Vec<KvEntry>, WorkspaceError> {
+        let options = TransactionOptions::new_optimistic().drop_check(CheckLevel::Warn);
+        let mut transaction = self
+            .client
+            .begin_with_options(options)
+            .await
+            .map_err(backend)?;
+        let scoped_prefix = self.scoped(prefix);
+        let upper = prefix_range_end(&scoped_prefix)
+            .map(Key::from)
+            .map(Bound::Excluded)
+            .unwrap_or(Bound::Unbounded);
+        let mut lower = Bound::Included(Key::from(scoped_prefix));
+        let mut entries = Vec::new();
+
+        loop {
+            let range = BoundRange::new(lower.clone(), upper.clone());
+            let batch: Vec<KvPair> = transaction
+                .scan(range, SCAN_BATCH_LIMIT)
+                .await
+                .map_err(backend)?
+                .collect();
+            let batch_len = batch.len();
+            if batch_len == 0 {
+                break;
+            }
+            for pair in batch {
+                let last_key: Vec<u8> = pair.key().clone().into();
+                lower = Bound::Excluded(Key::from(last_key.clone()));
+                let logical = last_key
+                    .strip_prefix(self.prefix.as_slice())
+                    .ok_or_else(|| {
+                        WorkspaceError::Backend(
+                            "TiKV workspace scan returned an out-of-namespace key".into(),
+                        )
+                    })?;
+                entries.push(KvEntry {
+                    key: logical.to_vec(),
+                    value: pair.value().to_vec(),
+                });
+            }
+            if batch_len < SCAN_BATCH_LIMIT as usize {
+                break;
+            }
+        }
+
+        if let Err(error) = transaction.rollback().await {
+            log::debug!("TiKV workspace scan rollback failed: {error}");
+        }
+        Ok(entries)
+    }
+
+    async fn compare_and_swap(
+        &self,
+        checks: &[KvCheck],
+        writes: &[KvWrite],
+    ) -> Result<bool, WorkspaceError> {
+        'attempt: for attempt in 0..TXN_MAX_RETRIES {
+            let options = TransactionOptions::new_pessimistic().drop_check(CheckLevel::Warn);
+            let mut transaction = self
+                .client
+                .begin_with_options(options)
+                .await
+                .map_err(backend)?;
+
+            let mut matched = true;
+            for check in checks {
+                let current = match transaction.get_for_update(self.scoped(&check.key)).await {
+                    Ok(current) => current,
+                    Err(error) => {
+                        let retryable = is_retryable(&error.to_string());
+                        if let Err(rollback_error) = transaction.rollback().await {
+                            log::debug!(
+                                "TiKV workspace CAS check rollback failed: {rollback_error}"
+                            );
+                        }
+                        if retryable && attempt + 1 < TXN_MAX_RETRIES {
+                            Self::retry_delay(attempt).await;
+                            continue 'attempt;
+                        }
+                        return Err(backend(error));
+                    }
+                };
+                if current.as_deref() != check.expected.as_deref() {
+                    matched = false;
+                    break;
+                }
+            }
+            if !matched {
+                if let Err(error) = transaction.rollback().await {
+                    log::debug!("TiKV workspace CAS mismatch rollback failed: {error}");
+                }
+                return Ok(false);
+            }
+
+            for write in writes {
+                let result = match write {
+                    KvWrite::Put { key, value } => {
+                        transaction.put(self.scoped(key), value.clone()).await
+                    }
+                    KvWrite::Delete { key } => transaction.delete(self.scoped(key)).await,
+                };
+                if let Err(error) = result {
+                    let retryable = is_retryable(&error.to_string());
+                    if let Err(rollback_error) = transaction.rollback().await {
+                        log::debug!("TiKV workspace CAS rollback failed: {rollback_error}");
+                    }
+                    if retryable && attempt + 1 < TXN_MAX_RETRIES {
+                        Self::retry_delay(attempt).await;
+                        continue 'attempt;
+                    }
+                    return Err(backend(error));
+                }
+            }
+
+            match transaction.commit().await {
+                Ok(_) => return Ok(true),
+                Err(error) if is_retryable(&error.to_string()) && attempt + 1 < TXN_MAX_RETRIES => {
+                    Self::retry_delay(attempt).await;
+                }
+                Err(error) => return Err(backend(error)),
+            }
+        }
+        Err(WorkspaceError::Backend(
+            "TiKV workspace catalog exhausted transaction retries".into(),
+        ))
+    }
+
+    async fn server_time_ns(&self) -> Result<i64, WorkspaceError> {
+        let timestamp = self.client.current_timestamp().await.map_err(backend)?;
+        pd_physical_ms_to_ns(timestamp.physical)
+    }
+}
+
+fn pd_physical_ms_to_ns(physical_ms: i64) -> Result<i64, WorkspaceError> {
+    physical_ms
+        .checked_mul(1_000_000)
+        .ok_or_else(|| WorkspaceError::Backend("PD TSO physical time overflows nanoseconds".into()))
+}
+
+fn validate_namespace(namespace: &str) -> Result<(), WorkspaceError> {
+    if namespace.is_empty()
+        || !namespace
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+    {
+        return Err(WorkspaceError::Backend(
+            "TiKV workspace namespace must contain only ASCII letters, digits, '-', '_' or '.'"
+                .into(),
+        ));
+    }
+    Ok(())
+}
+
+fn prefix_range_end(prefix: &[u8]) -> Option<Vec<u8>> {
+    let mut end = prefix.to_vec();
+    for index in (0..end.len()).rev() {
+        if end[index] != 0xff {
+            end[index] += 1;
+            end.truncate(index + 1);
+            return Some(end);
+        }
+    }
+    None
+}
+
+fn is_retryable(message: &str) -> bool {
+    let message = message.to_ascii_lowercase();
+    message.contains("write conflict")
+        || message.contains("pessimisticlock")
+        || message.contains("lock conflict")
+        || message.contains("txnlock")
+}
+
+fn backend(error: impl std::fmt::Display) -> WorkspaceError {
+    WorkspaceError::Backend(format!("TiKV workspace catalog: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::pd_physical_ms_to_ns;
+
+    #[test]
+    fn pd_tso_physical_milliseconds_are_converted_to_nanoseconds() {
+        assert_eq!(
+            pd_physical_ms_to_ns(1_725_000_000_123).unwrap(),
+            1_725_000_000_123_000_000
+        );
+        assert!(pd_physical_ms_to_ns(i64::MAX).is_err());
+    }
+}

--- a/tests/workspace_overlay_resolver.rs
+++ b/tests/workspace_overlay_resolver.rs
@@ -1,0 +1,311 @@
+#![cfg(feature = "workspace-overlay")]
+
+use std::ops::Range;
+
+use brewfs::workspace_overlay::digest::{CanonicalLayerDelta, canonical_delta_bytes, delta_digest};
+use brewfs::workspace_overlay::ids::{LayerId, WorkspaceId};
+use brewfs::workspace_overlay::model::{
+    DataExtentDelta, DentryDelta, ExtentKind, InodeDelta, InodeState, LayerRecord, LayerState,
+    ValueOp, XattrDelta,
+};
+use brewfs::workspace_overlay::resolver::{
+    resolve_dentry, resolve_directory, resolve_extents, resolve_inode, resolve_xattr,
+    validate_layer_chain,
+};
+use uuid::Uuid;
+
+fn layer_id(value: u128) -> LayerId {
+    LayerId::from_uuid(Uuid::from_u128(value))
+}
+
+fn workspace_id(value: u128) -> WorkspaceId {
+    WorkspaceId::from_uuid(Uuid::from_u128(value))
+}
+
+fn layer(id: u128, parent: Option<u128>, state: LayerState, depth: u32) -> LayerRecord {
+    LayerRecord {
+        layer_id: layer_id(id),
+        parent_layer_id: parent.map(layer_id),
+        state,
+        schema_version: 1,
+        sealed_version: (state == LayerState::Sealed).then_some(id as u64),
+        delta_digest: (state == LayerState::Sealed).then_some([id as u8; 32]),
+        root_hash: (state == LayerState::Sealed).then_some([(id + 1) as u8; 32]),
+        depth,
+        owner_workspace_id: (state == LayerState::Writable).then_some(workspace_id(99)),
+        next_sequence: 1,
+        owned_slice_count: 0,
+        owned_bytes: 0,
+        created_at_ns: 0,
+        sealed_at_ns: (state == LayerState::Sealed).then_some(0),
+    }
+}
+
+fn chain() -> Vec<LayerRecord> {
+    vec![
+        layer(2, Some(1), LayerState::Writable, 2),
+        layer(1, None, LayerState::Sealed, 1),
+    ]
+}
+
+#[test]
+fn layer_chain_rejects_cycles_depth_mismatch_and_unsealed_parents() {
+    validate_layer_chain(layer_id(2), &chain()).unwrap();
+
+    let mut cyclic = chain();
+    cyclic[1].parent_layer_id = Some(layer_id(2));
+    assert!(validate_layer_chain(layer_id(2), &cyclic).is_err());
+
+    let mut wrong_depth = chain();
+    wrong_depth[0].depth = 3;
+    assert!(validate_layer_chain(layer_id(2), &wrong_depth).is_err());
+
+    let mut writable_parent = chain();
+    writable_parent[1].state = LayerState::Writable;
+    assert!(validate_layer_chain(layer_id(2), &writable_parent).is_err());
+}
+
+#[test]
+fn dentry_whiteout_hides_lower_entry_and_recreate_wins() {
+    let layers = chain();
+    let lower = DentryDelta::put(layer_id(1), 1, b"tool".to_vec(), 10, 1, 1);
+    let whiteout = DentryDelta::whiteout(layer_id(2), 1, b"tool".to_vec(), 2);
+
+    assert_eq!(
+        resolve_dentry(&layers, &[lower.clone(), whiteout.clone()], 1, b"tool").unwrap(),
+        None
+    );
+
+    let recreated = DentryDelta::put(layer_id(2), 1, b"tool".to_vec(), 11, 1, 3);
+    let resolved = resolve_dentry(&layers, &[lower, whiteout, recreated], 1, b"tool")
+        .unwrap()
+        .unwrap();
+    assert_eq!(resolved.ino, 11);
+    assert_eq!(resolved.layer_id, layer_id(2));
+}
+
+#[test]
+fn readdir_is_newest_wins_filters_whiteouts_and_sorts_raw_names() {
+    let layers = chain();
+    let deltas = vec![
+        DentryDelta::put(layer_id(1), 1, b"z".to_vec(), 20, 1, 1),
+        DentryDelta::put(layer_id(1), 1, b"a".to_vec(), 21, 1, 2),
+        DentryDelta::whiteout(layer_id(2), 1, b"z".to_vec(), 3),
+        DentryDelta::put(layer_id(2), 1, b"m".to_vec(), 22, 1, 4),
+    ];
+
+    let entries = resolve_directory(&layers, &deltas, 1).unwrap();
+    let names: Vec<&[u8]> = entries.iter().map(|entry| entry.name.as_slice()).collect();
+    assert_eq!(names, vec![b"a".as_slice(), b"m".as_slice()]);
+}
+
+#[test]
+fn extent_resolution_handles_data_hole_data_and_clipped_slice_offsets() {
+    let layers = chain();
+    let extents = vec![
+        DataExtentDelta::data(layer_id(1), 7, 0, 0, 100, 1000, 10, 1),
+        DataExtentDelta::hole(layer_id(2), 7, 0, 20, 60, 1),
+        DataExtentDelta::data(layer_id(2), 7, 0, 40, 20, 2000, 5, 2),
+    ];
+
+    let plan = resolve_extents(&layers, &extents, 7, 0, Range { start: 0, end: 100 }).unwrap();
+    assert_eq!(plan.len(), 5);
+    assert_eq!(plan[0].logical_offset, 0);
+    assert_eq!(plan[0].length, 20);
+    assert_eq!(
+        plan[0].kind,
+        ExtentKind::Data {
+            slice_id: 1000,
+            slice_offset: 10
+        }
+    );
+    assert_eq!(plan[1].kind, ExtentKind::Hole);
+    assert_eq!((plan[1].logical_offset, plan[1].length), (20, 20));
+    assert_eq!(
+        plan[2].kind,
+        ExtentKind::Data {
+            slice_id: 2000,
+            slice_offset: 5
+        }
+    );
+    assert_eq!((plan[2].logical_offset, plan[2].length), (40, 20));
+    assert_eq!(plan[3].kind, ExtentKind::Hole);
+    assert_eq!((plan[3].logical_offset, plan[3].length), (60, 20));
+    assert_eq!(
+        plan[4].kind,
+        ExtentKind::Data {
+            slice_id: 1000,
+            slice_offset: 90
+        }
+    );
+    assert_eq!((plan[4].logical_offset, plan[4].length), (80, 20));
+}
+
+#[test]
+fn uncovered_ranges_are_zero_and_invalid_extents_fail_closed() {
+    let layers = chain();
+    let plan = resolve_extents(&layers, &[], 7, 0, 4..12).unwrap();
+    assert_eq!(plan.len(), 1);
+    assert_eq!(plan[0].kind, ExtentKind::Hole);
+    assert_eq!((plan[0].logical_offset, plan[0].length), (4, 8));
+
+    let zero_length = DataExtentDelta::data(layer_id(2), 7, 0, 0, 0, 1, 0, 1);
+    assert!(resolve_extents(&layers, &[zero_length], 7, 0, 0..8).is_err());
+
+    let overflow = DataExtentDelta::data(layer_id(2), 7, 0, u64::MAX, 2, 1, 0, 1);
+    assert!(resolve_extents(&layers, &[overflow], 7, 0, 0..8).is_err());
+}
+
+#[test]
+fn empty_delta_canonical_bytes_are_a_stable_golden_fixture() {
+    let empty = CanonicalLayerDelta::default();
+    let bytes = canonical_delta_bytes(&empty).unwrap();
+    let mut expected = b"BWSDELTA".to_vec();
+    expected.extend_from_slice(&1_u32.to_be_bytes());
+    for table in 1_u8..=5 {
+        expected.push(table);
+        expected.extend_from_slice(&0_u64.to_be_bytes());
+    }
+    assert_eq!(bytes, expected);
+    assert_eq!(
+        hex::encode(delta_digest(&empty).unwrap()),
+        "a5b54177cc3b11d6d7dde476bf74b5c0f4bdff165e3fc08252ba851e684f3c1b"
+    );
+}
+
+#[test]
+fn canonical_encoding_is_independent_of_input_row_order() {
+    let a = DentryDelta::put(layer_id(1), 1, b"a".to_vec(), 2, 1, 1);
+    let b = DentryDelta::whiteout(layer_id(1), 1, b"b".to_vec(), 2);
+    let left = CanonicalLayerDelta {
+        dentries: vec![b.clone(), a.clone()],
+        ..CanonicalLayerDelta::default()
+    };
+    let right = CanonicalLayerDelta {
+        dentries: vec![a, b],
+        ..CanonicalLayerDelta::default()
+    };
+
+    assert_eq!(
+        canonical_delta_bytes(&left).unwrap(),
+        canonical_delta_bytes(&right).unwrap()
+    );
+}
+
+#[test]
+fn inode_delete_and_xattr_whiteout_stop_lower_lookup() {
+    let layers = chain();
+    let mut lower_inode = inode(layer_id(1), 42, InodeState::Present, 1);
+    lower_inode.size = 123;
+    let deleted_inode = inode(layer_id(2), 42, InodeState::Deleted, 2);
+    assert_eq!(
+        resolve_inode(&layers, &[lower_inode, deleted_inode], 42).unwrap(),
+        None
+    );
+
+    let lower_xattr = XattrDelta {
+        layer_id: layer_id(1),
+        ino: 42,
+        name: b"user.agent".to_vec(),
+        op: ValueOp::Put,
+        value: Some(b"shared".to_vec()),
+        sequence: 1,
+    };
+    let whiteout = XattrDelta {
+        layer_id: layer_id(2),
+        ino: 42,
+        name: b"user.agent".to_vec(),
+        op: ValueOp::Whiteout,
+        value: None,
+        sequence: 2,
+    };
+    assert_eq!(
+        resolve_xattr(&layers, &[lower_xattr, whiteout], 42, b"user.agent").unwrap(),
+        None
+    );
+}
+
+#[test]
+fn randomized_extent_operations_match_a_byte_array_oracle() {
+    const WIDTH: usize = 64;
+    for seed in 1_u64..=128 {
+        let layers = chain();
+        let mut extents = vec![DataExtentDelta::data(
+            layer_id(1),
+            7,
+            0,
+            0,
+            WIDTH as u64,
+            1,
+            0,
+            1,
+        )];
+        let mut oracle = [1_u8; WIDTH];
+        let mut random = seed;
+        for sequence in 1_u64..=32 {
+            random = random
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            let start = (random as usize) % WIDTH;
+            random = random.rotate_left(17);
+            let length = 1 + (random as usize) % (WIDTH - start);
+            if random & 1 == 0 {
+                extents.push(DataExtentDelta::hole(
+                    layer_id(2),
+                    7,
+                    0,
+                    start as u64,
+                    length as u64,
+                    sequence,
+                ));
+                oracle[start..start + length].fill(0);
+            } else {
+                let byte = (sequence as u8).wrapping_add(1);
+                extents.push(DataExtentDelta::data(
+                    layer_id(2),
+                    7,
+                    0,
+                    start as u64,
+                    length as u64,
+                    byte as u64,
+                    0,
+                    sequence,
+                ));
+                oracle[start..start + length].fill(byte);
+            }
+        }
+
+        let plan = resolve_extents(&layers, &extents, 7, 0, 0..WIDTH as u64).unwrap();
+        let mut actual = [0_u8; WIDTH];
+        for extent in plan {
+            let range =
+                extent.logical_offset as usize..(extent.logical_offset + extent.length) as usize;
+            if let ExtentKind::Data { slice_id, .. } = extent.kind {
+                actual[range].fill(slice_id as u8);
+            }
+        }
+        assert_eq!(actual, oracle, "seed {seed}");
+    }
+}
+
+fn inode(layer_id: LayerId, ino: i64, state: InodeState, sequence: u64) -> InodeDelta {
+    InodeDelta {
+        layer_id,
+        ino,
+        state,
+        kind: 1,
+        size: 0,
+        mode: 0o644,
+        uid: 1000,
+        gid: 1000,
+        rdev: 0,
+        nlink: 1,
+        atime_ns: 0,
+        mtime_ns: 0,
+        ctime_ns: 0,
+        symlink_target: None,
+        parent_hint: Some(1),
+        data_version: 1,
+        sequence,
+    }
+}


### PR DESCRIPTION
## Summary



- retain the opt-in workspace-overlay implementation and Redis/TiKV/SQLite backends
- synchronize open/close lifecycle transitions and reject stale cached opens
- avoid leaking VFS handles when a concurrently deleted inode can no longer be opened
- return explicit `NotSupported` for workspace `statfs` until atomic usage counters exist
- run bounded Redis/TiKV workspace control-plane smoke coverage on PR and push branches while keeping full xfstests/LTP manual

## Review follow-up

This addresses: the open/close race, fabricated zero `statfs` accounting, and skipped PR/push CI coverage.

## Validation
- `cargo +1.97.1 fmt --all -- --check`
- 8 targeted workspace-overlay/VFS open, close, stale-open, and unsupported-`statfs` regressions passed
- workflow and shell syntax checks passed