### PR TITLE
fix(meta): make Redis slice-cache validation configurable

### DIFF
--- a/doc/operations/configuration.md
+++ b/doc/operations/configuration.md
@@ -149,6 +149,7 @@ meta:
   open_file_cache_ttl_ms: 30000
   open_file_cache_capacity: 65536
   allow_write_open_cache: false
+  slice_version_check_interval_ms: 1000
 
 cache:
   root: /var/cache/brewfs
@@ -275,6 +276,7 @@ export AWS_EC2_METADATA_DISABLED=true
 | `meta.open_file_cache_ttl_ms` | 关闭 | 只读 open 文件属性缓存 TTL，单位 ms。 |
 | `meta.open_file_cache_capacity` | 默认值 | open file cache 容量。 |
 | `meta.allow_write_open_cache` | `false` | 允许写 open 复用属性缓存。仅建议在单客户端或可接受跨客户端 close-to-open 新鲜度减弱的性能场景中启用。 |
+| `meta.slice_version_check_interval_ms` | `1000` | Redis slice-list 缓存的后端版本复检间隔。远端 compact/write 最多可在该窗口内暂未被当前客户端看到；设为 `0` 会在每次缓存命中时复检。与复检重叠的变更可能在下一次复检时可见。 |
 
 示例：
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -328,6 +328,7 @@ pub struct MetaFileConfig {
     pub open_file_cache_ttl_ms: Option<u64>,
     pub open_file_cache_capacity: Option<u64>,
     pub allow_write_open_cache: Option<bool>,
+    pub slice_version_check_interval_ms: Option<u64>,
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
@@ -414,6 +415,7 @@ pub struct MountConfig {
     pub meta_open_file_cache_ttl_ms: Option<u64>,
     pub meta_open_file_cache_capacity: Option<u64>,
     pub meta_allow_write_open_cache: bool,
+    pub meta_slice_version_check_interval_ms: Option<u64>,
     pub chunk_size: u64,
     pub block_size: u32,
     pub fuse_workers: usize,
@@ -516,6 +518,7 @@ impl MountConfig {
             meta_open_file_cache_ttl_ms: meta_cfg.open_file_cache_ttl_ms,
             meta_open_file_cache_capacity: meta_cfg.open_file_cache_capacity,
             meta_allow_write_open_cache: meta_cfg.allow_write_open_cache.unwrap_or(false),
+            meta_slice_version_check_interval_ms: meta_cfg.slice_version_check_interval_ms,
             chunk_size: args
                 .chunk_size
                 .or(layout_cfg.chunk_size)
@@ -918,6 +921,7 @@ meta:
   open_file_cache_ttl_ms: 1000
   open_file_cache_capacity: 65536
   allow_write_open_cache: true
+  slice_version_check_interval_ms: 250
 "#,
         )
         .unwrap();
@@ -928,6 +932,7 @@ meta:
         assert_eq!(config.meta_open_file_cache_ttl_ms, Some(1000));
         assert_eq!(config.meta_open_file_cache_capacity, Some(65536));
         assert!(config.meta_allow_write_open_cache);
+        assert_eq!(config.meta_slice_version_check_interval_ms, Some(250));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -643,6 +643,9 @@ where
         meta_config.options.open_file_cache.capacity = capacity;
     }
     meta_config.options.open_file_cache.allow_write = args.meta_allow_write_open_cache;
+    if let Some(interval_ms) = args.meta_slice_version_check_interval_ms {
+        meta_config.options.slice_version_check_interval = Duration::from_millis(interval_ms);
+    }
     meta_config.compact = args.compact.clone();
 
     tracing::info!("mount startup meta client create begin");

--- a/src/meta/client/cache.rs
+++ b/src/meta/client/cache.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crate::chunk::SliceDesc;
 use crate::meta::entities::etcd::EtcdEntryInfo;
@@ -16,6 +16,13 @@ use tracing::debug;
 /// Type alias for children map to reduce complexity
 /// BTreeMap provides ordered iteration for consistent ls output
 pub(crate) type ChildrenMap = BTreeMap<String, i64>;
+
+#[derive(Clone)]
+pub(crate) struct CachedSlices {
+    pub(crate) version: Option<u64>,
+    pub(crate) slices: Vec<SliceDesc>,
+    pub(crate) validated_at: Instant,
+}
 
 #[derive(Clone)]
 pub(crate) enum ChildrenState {
@@ -56,8 +63,8 @@ pub(crate) struct InodeEntry {
     pub(crate) children: Arc<RwLock<ChildrenState>>,
     /// Monotonic generation for child map mutations to detect stale readdir snapshots.
     pub(crate) children_generation: Arc<AtomicU64>,
-    /// Cache slice metadata per chunk index
-    pub(crate) slices: DashMap<u64, Vec<SliceDesc>>,
+    /// Cache slice metadata per chunk index, with an optional backend version token.
+    pub(crate) slices: DashMap<u64, CachedSlices>,
 }
 
 impl Clone for InodeEntry {
@@ -358,8 +365,8 @@ impl InodeCache {
             // after truncate: invalidate_inode clears the cache, insert_node
             // recreates it with an empty slices map, and post-truncate writes
             // would otherwise seed a partial entry that shadows the full list.
-            if let Some(mut slices) = node.slices.get_mut(&chunk_index) {
-                slices.push(desc);
+            if let Some(mut cached) = node.slices.get_mut(&chunk_index) {
+                cached.slices.push(desc);
             }
         }
     }
@@ -368,8 +375,8 @@ impl InodeCache {
     pub(crate) async fn replace_slices(&self, inode: i64, chunk_index: u64, desc: &[SliceDesc]) {
         if let Some(node) = self.ttl_manager.get(&inode).await {
             // Same rationale as append_slice: only update an existing entry.
-            if let Some(mut slices) = node.slices.get_mut(&chunk_index) {
-                *slices = desc.to_owned();
+            if let Some(mut cached) = node.slices.get_mut(&chunk_index) {
+                cached.slices = desc.to_owned();
             }
         }
     }
@@ -378,18 +385,63 @@ impl InodeCache {
         &self,
         inode: i64,
         chunk_index: u64,
+        version: Option<u64>,
         desc: &[SliceDesc],
     ) -> Option<Vec<SliceDesc>> {
         let node = self.ttl_manager.get(&inode).await?;
         let entry = node.slices.entry(chunk_index);
         Some(match entry {
-            Entry::Occupied(entry) => entry.get().clone(),
+            Entry::Occupied(entry) => entry.get().slices.clone(),
             Entry::Vacant(entry) => {
-                let cached = desc.to_owned();
+                let slices = desc.to_owned();
+                let cached = CachedSlices {
+                    version,
+                    slices,
+                    validated_at: Instant::now(),
+                };
                 entry.insert(cached.clone());
-                cached
+                cached.slices
             }
         })
+    }
+
+    pub(crate) async fn get_cached_slices(
+        &self,
+        inode: i64,
+        chunk_index: u64,
+    ) -> Option<CachedSlices> {
+        let node = self.ttl_manager.get(&inode).await?;
+        node.slices.get(&chunk_index).map(|entry| entry.clone())
+    }
+
+    pub(crate) async fn touch_slices_validation(
+        &self,
+        inode: i64,
+        chunk_index: u64,
+        expected_version: u64,
+    ) {
+        if let Some(node) = self.ttl_manager.get(&inode).await
+            && let Some(mut cached) = node.slices.get_mut(&chunk_index)
+            && cached.version == Some(expected_version)
+        {
+            cached.validated_at = Instant::now();
+        }
+    }
+
+    pub(crate) async fn invalidate_slices_if_version(
+        &self,
+        inode: i64,
+        chunk_index: u64,
+        expected_version: u64,
+    ) {
+        let Some(node) = self.ttl_manager.get(&inode).await else {
+            return;
+        };
+        if let Entry::Occupied(entry) = node.slices.entry(chunk_index)
+            && entry.get().version == Some(expected_version)
+        {
+            entry.remove();
+        }
     }
 
     pub(crate) async fn invalidate_slices(&self, inode: i64, chunk_index: u64) {
@@ -404,7 +456,7 @@ impl InodeCache {
         // Use entry api to ensure consistency, it will lock the bucket.
         let entry = node.slices.entry(chunk_index);
         match entry {
-            Entry::Occupied(entry) => entry.get().clone().into(),
+            Entry::Occupied(entry) => entry.get().slices.clone().into(),
             Entry::Vacant(_) => None,
         }
     }

--- a/src/meta/client/mod.rs
+++ b/src/meta/client/mod.rs
@@ -51,6 +51,7 @@ use path_trie::PathTrie;
 use session::{SessionInfo, SessionManager};
 
 const ROOT_INODE: i64 = 1;
+const DEFAULT_SLICE_VERSION_CHECK_INTERVAL: Duration = Duration::from_secs(1);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OpenFileCacheConfig {
@@ -107,6 +108,11 @@ pub struct MetaClientOptions {
     /// to readonly opens; close may seed the final attr for a later readonly
     /// open without allowing write opens to skip their fresh stat.
     pub open_file_cache: OpenFileCacheConfig,
+    /// Maximum time a versioned slice-list cache hit may skip backend
+    /// revalidation. A remote mutation can therefore remain invisible for up
+    /// to this interval. `Duration::ZERO` revalidates every cache hit.
+    /// Mutations that overlap a validation may be observed by the next check.
+    pub slice_version_check_interval: Duration,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -287,6 +293,7 @@ impl Default for MetaClientOptions {
             max_symlinks: 40,
             batch_prefetch: BatchPrefetchConfig::default(),
             open_file_cache: OpenFileCacheConfig::default(),
+            slice_version_check_interval: DEFAULT_SLICE_VERSION_CHECK_INTERVAL,
         }
     }
 }
@@ -3066,9 +3073,9 @@ impl<T: MetaStore + ?Sized + 'static> MetaLayer for MetaClient<T> {
     )]
     async fn get_slices(&self, chunk_id: u64) -> Result<Vec<SliceDesc>, MetaError> {
         let (inode, chunk_index) = extract_ino_and_chunk_index(chunk_id);
-        if let Some(slices) = self
+        if let Some(cached) = self
             .inode_cache
-            .get_slices(inode, chunk_index)
+            .get_cached_slices(inode, chunk_index)
             .instrument(tracing::trace_span!(
                 "get_slices.cache_lookup",
                 inode,
@@ -3076,21 +3083,42 @@ impl<T: MetaStore + ?Sized + 'static> MetaLayer for MetaClient<T> {
             ))
             .await
         {
-            tracing::Span::current().record("cache_hit", true);
-            tracing::Span::current().record("slice_count", slices.len());
-            self.metrics.record_get_slices_cache_hit();
-            return Ok(slices);
+            if let Some(cached_version) = cached.version
+                && cached.validated_at.elapsed() >= self.options.slice_version_check_interval
+            {
+                let store_version = self
+                    .store
+                    .get_chunk_version(chunk_id)
+                    .instrument(tracing::trace_span!("get_slices.version_check", chunk_id))
+                    .await?;
+                if store_version == Some(cached_version) {
+                    self.inode_cache
+                        .touch_slices_validation(inode, chunk_index, cached_version)
+                        .await;
+                } else {
+                    self.inode_cache
+                        .invalidate_slices_if_version(inode, chunk_index, cached_version)
+                        .await;
+                }
+            }
+
+            if let Some(slices) = self.inode_cache.get_slices(inode, chunk_index).await {
+                tracing::Span::current().record("cache_hit", true);
+                tracing::Span::current().record("slice_count", slices.len());
+                self.metrics.record_get_slices_cache_hit();
+                return Ok(slices);
+            }
         }
         tracing::Span::current().record("cache_hit", false);
         self.metrics.record_get_slices_cache_miss();
-        let slices = self
+        let (version, slices) = self
             .store
-            .get_slices(chunk_id)
+            .get_slices_with_version(chunk_id)
             .instrument(tracing::trace_span!("get_slices.store", chunk_id))
             .await?;
         let cached = self
             .inode_cache
-            .cache_slices_if_absent(inode, chunk_index, &slices)
+            .cache_slices_if_absent(inode, chunk_index, version, &slices)
             .await
             .unwrap_or(slices);
         tracing::Span::current().record("slice_count", cached.len());
@@ -3928,7 +3956,7 @@ mod tests {
         }];
         client
             .inode_cache
-            .cache_slices_if_absent(ino, chunk_index, &cached_slices)
+            .cache_slices_if_absent(ino, chunk_index, None, &cached_slices)
             .await;
         assert!(
             client

--- a/src/meta/store.rs
+++ b/src/meta/store.rs
@@ -810,6 +810,21 @@ pub trait MetaStore: Send + Sync {
 
     async fn get_slices(&self, chunk_id: u64) -> Result<Vec<SliceDesc>, MetaError>;
 
+    /// Fetch slices with an opaque version token when the backend supports it.
+    /// Backends returning `None` retain explicit local-invalidation semantics.
+    async fn get_slices_with_version(
+        &self,
+        chunk_id: u64,
+    ) -> Result<(Option<u64>, Vec<SliceDesc>), MetaError> {
+        Ok((None, self.get_slices(chunk_id).await?))
+    }
+
+    /// Fetch the current opaque chunk version, or `None` when unsupported.
+    async fn get_chunk_version(&self, chunk_id: u64) -> Result<Option<u64>, MetaError> {
+        let _ = chunk_id;
+        Ok(None)
+    }
+
     /// Return all distinct chunk IDs that have at least one slice.
     /// Used by the compaction scheduler to discover compaction candidates.
     async fn list_chunk_ids(&self, limit: usize) -> Result<Vec<u64>, MetaError> {

--- a/src/meta/stores/redis/mod.rs
+++ b/src/meta/stores/redis/mod.rs
@@ -3283,6 +3283,62 @@ impl MetaStore for RedisMetaStore {
 
     #[tracing::instrument(
         level = "trace",
+        skip(self),
+        fields(chunk_id, slice_count = tracing::field::Empty)
+    )]
+    async fn get_slices_with_version(
+        &self,
+        chunk_id: u64,
+    ) -> Result<(Option<u64>, Vec<SliceDesc>), MetaError> {
+        let chunk_key = self.chunk_key(chunk_id);
+        let version_key = self.chunk_version_key(chunk_id);
+        let mut conn = self.conn.clone();
+        let mut pipe = redis::pipe();
+        pipe.atomic()
+            .cmd("GET")
+            .arg(&version_key)
+            .cmd("LRANGE")
+            .arg(&chunk_key)
+            .arg(0)
+            .arg(-1);
+        let (version, raw): (Option<u64>, Vec<Vec<u8>>) = pipe
+            .query_async(&mut conn)
+            .instrument(tracing::trace_span!(
+                "get_slices_with_version.redis_transaction",
+                chunk_id
+            ))
+            .await
+            .map_err(redis_err)?;
+
+        let mut slices = Vec::with_capacity(raw.len());
+        for entry in raw {
+            slices.push(crate::meta::serialization::deserialize_meta(&entry)?);
+        }
+        tracing::Span::current().record("slice_count", slices.len());
+
+        // Redis supports version validation even before the first mutation.
+        // Version zero keeps an empty cached list distinguishable from a
+        // backend that does not support version tokens at all.
+        Ok((Some(version.unwrap_or(0)), slices))
+    }
+
+    #[tracing::instrument(level = "trace", skip(self), fields(chunk_id))]
+    async fn get_chunk_version(&self, chunk_id: u64) -> Result<Option<u64>, MetaError> {
+        let mut conn = self.conn.clone();
+        let version: Option<u64> = redis::cmd("GET")
+            .arg(self.chunk_version_key(chunk_id))
+            .query_async(&mut conn)
+            .instrument(tracing::trace_span!(
+                "get_chunk_version.redis_get",
+                chunk_id
+            ))
+            .await
+            .map_err(redis_err)?;
+        Ok(Some(version.unwrap_or(0)))
+    }
+
+    #[tracing::instrument(
+        level = "trace",
         skip(self, slice),
         fields(chunk_id, slice_id = slice.slice_id, offset = slice.offset, len = slice.length)
     )]

--- a/src/meta/stores/redis/tests.rs
+++ b/src/meta/stores/redis/tests.rs
@@ -1,4 +1,4 @@
-use crate::meta::client::MetaClient;
+use crate::meta::client::{MetaClient, MetaClientOptions};
 use crate::meta::config::Config;
 use crate::meta::config::{
     CacheCapacity, CacheConfig, CacheTtl, ClientOptions, CompactConfig, DatabaseConfig,
@@ -2217,6 +2217,96 @@ async fn test_file_full_lifecycle_flow() {
     assert!(
         deleted.contains(&ino),
         "file should be in deleted set after unlink"
+    );
+}
+
+#[serial]
+#[tokio::test]
+#[ignore]
+async fn get_slices_cache_detects_remote_compact_via_version_token() {
+    let store = Arc::new(new_test_store().await);
+    let root = store.root_ino();
+    let client = MetaClient::with_options(
+        store.clone(),
+        CacheCapacity {
+            inode: 100,
+            path: 100,
+        },
+        CacheTtl::for_redis(),
+        MetaClientOptions {
+            slice_version_check_interval: Duration::ZERO,
+            ..MetaClientOptions::default()
+        },
+    );
+
+    let ino = client
+        .create_file(root, "slice_version.txt".to_string())
+        .await
+        .unwrap();
+    let chunk_id = crate::vfs::chunk_id_for(ino, 0).unwrap();
+    let old_slice = crate::chunk::SliceDesc {
+        slice_id: 201,
+        chunk_id,
+        offset: 0,
+        length: 4096,
+    };
+    client.append_slice(chunk_id, old_slice).await.unwrap();
+    assert_eq!(client.get_slices(chunk_id).await.unwrap(), vec![old_slice]);
+
+    let new_slice = crate::chunk::SliceDesc {
+        slice_id: 202,
+        chunk_id,
+        offset: 0,
+        length: 8192,
+    };
+    store
+        .replace_slices_for_compact_with_version(chunk_id, &[new_slice], &[], &[old_slice])
+        .await
+        .unwrap();
+    assert_eq!(
+        client.get_slices(chunk_id).await.unwrap(),
+        vec![new_slice],
+        "a client must not keep serving slices replaced by a remote compaction"
+    );
+}
+
+#[serial]
+#[tokio::test]
+#[ignore]
+async fn get_slices_cache_detects_first_remote_append_after_empty_read() {
+    let store = Arc::new(new_test_store().await);
+    let root = store.root_ino();
+    let client = MetaClient::with_options(
+        store.clone(),
+        CacheCapacity {
+            inode: 100,
+            path: 100,
+        },
+        CacheTtl::for_redis(),
+        MetaClientOptions {
+            slice_version_check_interval: Duration::ZERO,
+            ..MetaClientOptions::default()
+        },
+    );
+
+    let ino = client
+        .create_file(root, "empty_slice_version.txt".to_string())
+        .await
+        .unwrap();
+    let chunk_id = crate::vfs::chunk_id_for(ino, 0).unwrap();
+    assert!(client.get_slices(chunk_id).await.unwrap().is_empty());
+
+    let remote_slice = crate::chunk::SliceDesc {
+        slice_id: 301,
+        chunk_id,
+        offset: 0,
+        length: 4096,
+    };
+    store.append_slice(chunk_id, remote_slice).await.unwrap();
+    assert_eq!(
+        client.get_slices(chunk_id).await.unwrap(),
+        vec![remote_slice],
+        "a cached empty chunk must observe the first remote append"
     );
 }
 

--- a/src/vfs/fs/mod.rs
+++ b/src/vfs/fs/mod.rs
@@ -846,7 +846,6 @@ where
         }
 
         let meta_store = meta_client.store();
-        let is_database_store = meta_store.name() == "database";
 
         let mut worker = CompactionWorker::with_config(
             meta_store,
@@ -856,15 +855,13 @@ where
             config.compact_config.lock_ttl.clone(),
         );
 
-        if is_database_store {
-            let client = Arc::clone(meta_client);
-            worker = worker.with_compaction_hook(Arc::new(move |chunk_id| {
-                let client = Arc::clone(&client);
-                tokio::spawn(async move {
-                    client.invalidate_chunk_slices(chunk_id).await;
-                });
-            }));
-        }
+        let client = Arc::clone(meta_client);
+        worker = worker.with_compaction_hook(Arc::new(move |chunk_id| {
+            let client = Arc::clone(&client);
+            tokio::spawn(async move {
+                client.invalidate_chunk_slices(chunk_id).await;
+            });
+        }));
         let (compaction_handle, gc_handle) = worker.start(config.compaction, config.gc);
 
         Some(VfsBackgroundTasks {


### PR DESCRIPTION
## Summary



- retain version-token validation for Redis slice-cache entries
- document bounded eventual consistency instead of a linearizable read-after-compaction guarantee
- add `meta.slice_version_check_interval_ms`, defaulting to 1000 ms
- allow `0` to validate every cache hit
- use deterministic zero-interval validation in Redis regressions

## Validation

- `get_slices_cache_detects_remote_compact_via_version_token` passed against local Redis 8.10.1
- `get_slices_cache_detects_first_remote_append_after_empty_read` passed against local Redis 8.10.1
- targeted mount/configuration parsing test passed
- `cargo +1.97.1 fmt --all -- --check`
- `git diff --check`