### PR TITLE
fix(meta/redis): make compact GC atomic and reject cluster mode

### DIFF
--- a/doc/operations/configuration.md
+++ b/doc/operations/configuration.md
@@ -268,7 +268,7 @@ export AWS_EC2_METADATA_DISABLED=true
 |---|---:|---|
 | `meta.backend` | `sqlx` | `sqlx`、`redis`、`etcd` 或 `tikv`。 |
 | `meta.sqlx.url` | `sqlite::memory:` | SQLite 或 PostgreSQL URL。 |
-| `meta.redis.url` | 无 | Redis URL；`backend=redis` 时必须显式配置。 |
+| `meta.redis.url` | 无 | 单一 Redis endpoint URL；`backend=redis` 时必须显式配置。当前元数据后端依赖跨 key Lua 原子事务，不支持 Redis Cluster。 |
 | `meta.etcd.urls` | `[]` | Etcd endpoint 列表。 |
 | `meta.tikv.pd_endpoints` | `[]` | TiKV PD endpoint 列表。 |
 | `meta.tikv.namespace` | `brewfs` | TiKV key namespace。 |

--- a/src/meta/stores/redis/mod.rs
+++ b/src/meta/stores/redis/mod.rs
@@ -39,6 +39,8 @@ use tracing::{Instrument, error, info};
 use uuid::Uuid;
 
 const ROOT_INODE: i64 = 1;
+const REDIS_CLUSTER_PROBE_KEY_A: &str = "c{brewfs-cluster-probe-a}";
+const REDIS_CLUSTER_PROBE_KEY_B: &str = "ds_{brewfs-cluster-probe-b}";
 const COUNTER_INODE_KEY: &str = "nextinode";
 const COUNTER_SLICE_KEY: &str = "nextchunk";
 const NODE_KEY_PREFIX: &str = "i";
@@ -84,6 +86,127 @@ const CHUNK_CAS_LUA: &str = r#"
         redis.call('SET', KEYS[2], new_ver)
     else
         redis.call('DEL', KEYS[2])
+    end
+
+    return 1
+"#;
+
+// Atomically replace a compacted chunk and create the delayed-GC ledger for
+// every removed slice. Redis does not roll back earlier writes when a Lua
+// script hits a runtime error, so all fallible type checks and delayed-ID
+// allocation happen before the chunk list is changed.
+// KEYS: chunk list, chunk version, delayed counter, delayed index,
+// uncommitted pending index, uncommitted orphan index.
+// ARGV: expected version, new version, delayed key prefix, chunk id,
+// timestamp, delayed count, uncommitted key prefix, new-slice count,
+// delayed (sid, offset, size) triples, new slice IDs, serialized final slices.
+const CHUNK_COMPACT_LUA: &str = r#"
+    local expected = tonumber(ARGV[1])
+    local new_ver = tonumber(ARGV[2])
+    local prefix = ARGV[3]
+    local cid = ARGV[4]
+    local now = ARGV[5]
+    local n = tonumber(ARGV[6])
+    local uc_prefix = ARGV[7]
+    local new_count = tonumber(ARGV[8])
+
+    if expected == nil or new_ver == nil or n == nil or new_count == nil
+        or n < 0 or n % 1 ~= 0 or new_count < 0 or new_count % 1 ~= 0 then
+        return redis.error_reply('invalid compact arguments')
+    end
+    if #ARGV < 8 + 3 * n + new_count then
+        return redis.error_reply('missing compact arguments')
+    end
+
+    local current = redis.call('GET', KEYS[2])
+    local current_ver = 0
+    if current then
+        current_ver = tonumber(current)
+        if current_ver == nil then
+            return redis.error_reply('invalid chunk version value')
+        end
+    end
+    if current_ver ~= expected then
+        return 0
+    end
+
+    local function key_type(key)
+        local reply = redis.call('TYPE', key)
+        if type(reply) == 'table' then
+            return reply.ok
+        end
+        return reply
+    end
+
+    local first_id = 0
+    if n > 0 then
+        local counter_type = key_type(KEYS[3])
+        if counter_type ~= 'none' and counter_type ~= 'string' then
+            return redis.error_reply('invalid delayed counter type')
+        end
+        local index_type = key_type(KEYS[4])
+        if index_type ~= 'none' and index_type ~= 'zset' then
+            return redis.error_reply('invalid delayed index type')
+        end
+
+        local allocation = redis.pcall('INCRBY', KEYS[3], n)
+        if type(allocation) == 'table' and allocation.err then
+            return redis.error_reply(allocation.err)
+        end
+        first_id = allocation - n + 1
+
+        -- A collision indicates a corrupt/out-of-sync counter. Reject it
+        -- before touching the chunk; consuming an ID range is harmless.
+        for i = 0, n - 1 do
+            local ds_key = prefix .. (first_id + i)
+            if key_type(ds_key) ~= 'none' then
+                return redis.error_reply('delayed id collision')
+            end
+        end
+    end
+
+    if new_count > 0 then
+        local pending_type = key_type(KEYS[5])
+        if pending_type ~= 'none' and pending_type ~= 'zset' then
+            return redis.error_reply('invalid uncommitted pending index type')
+        end
+        local orphan_type = key_type(KEYS[6])
+        if orphan_type ~= 'none' and orphan_type ~= 'zset' then
+            return redis.error_reply('invalid uncommitted orphan index type')
+        end
+    end
+
+    local new_id_start = 9 + 3 * n
+    local data_start = new_id_start + new_count
+    redis.call('DEL', KEYS[1])
+    for i = data_start, #ARGV do
+        redis.call('RPUSH', KEYS[1], ARGV[i])
+    end
+    if new_ver > 0 then
+        redis.call('SET', KEYS[2], new_ver)
+    else
+        redis.call('DEL', KEYS[2])
+    end
+
+    for i = 0, n - 1 do
+        local delayed_id = first_id + i
+        local ds_key = prefix .. delayed_id
+        local base = 9 + 3 * i
+        redis.call('HSET', ds_key,
+            'sid', ARGV[base],
+            'off', ARGV[base + 1],
+            'sz', ARGV[base + 2],
+            'st', 'pending',
+            'ca', now,
+            'cid', cid)
+        redis.call('ZADD', KEYS[4], now, delayed_id)
+    end
+
+    for i = 0, new_count - 1 do
+        local slice_id = ARGV[new_id_start + i]
+        redis.call('DEL', uc_prefix .. slice_id)
+        redis.call('ZREM', KEYS[5], slice_id)
+        redis.call('ZREM', KEYS[6], slice_id)
     end
 
     return 1
@@ -1305,6 +1428,10 @@ struct LuaResponse {
 }
 
 /// Minimal Redis-backed meta store.
+///
+/// This backend requires standalone Redis command semantics. Redis Cluster is
+/// not supported because filesystem transitions use atomic Lua scripts across
+/// multiple metadata keys, including keys allocated dynamically by a script.
 pub struct RedisMetaStore {
     conn: ConnectionManager,
     _config: Config,
@@ -1323,6 +1450,39 @@ pub struct RedisMetaStore {
 }
 
 impl RedisMetaStore {
+    async fn verify_standalone_redis(conn: &mut ConnectionManager) -> Result<(), MetaError> {
+        // The backend requires EVAL and cross-key atomicity in normal operation.
+        // Probe that exact capability with two deliberately different hash tags;
+        // Redis Cluster rejects the request with CROSSSLOT before running the
+        // side-effect-free script. Other errors are also fatal because the real
+        // metadata scripts would be unusable for the same connection.
+        let probe: i32 = redis::cmd("EVAL")
+            .arg("return 1")
+            .arg(2)
+            .arg(REDIS_CLUSTER_PROBE_KEY_A)
+            .arg(REDIS_CLUSTER_PROBE_KEY_B)
+            .query_async(conn)
+            .await
+            .map_err(|err| {
+                if err.to_string().to_ascii_uppercase().contains("CROSSSLOT") {
+                    MetaError::Config(
+                        "Redis Cluster is not supported by the metadata backend; use a standalone Redis endpoint"
+                            .to_string(),
+                    )
+                } else {
+                    MetaError::Config(format!(
+                        "Redis standalone capability probe failed: {err}"
+                    ))
+                }
+            })?;
+        if probe != 1 {
+            return Err(MetaError::Config(
+                "Redis standalone capability probe returned an unexpected result".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
     async fn resolve_redis_url(url: &str) -> Result<String, MetaError> {
         let Some((scheme, rest)) = url.split_once("://") else {
             return Ok(url.to_string());
@@ -1448,11 +1608,12 @@ impl RedisMetaStore {
                         "Failed to parse Redis URL {resolved_url} (from {url}): {e}"
                     ))
                 })?;
-                let cm = ConnectionManager::new(client).await.map_err(|e| {
+                let mut cm = ConnectionManager::new(client).await.map_err(|e| {
                     MetaError::Config(format!(
                         "Failed to connect to Redis backend using {resolved_url}: {e}"
                     ))
                 })?;
+                Self::verify_standalone_redis(&mut cm).await?;
                 info!("redis connection established");
                 Ok(cm)
             }
@@ -3479,8 +3640,22 @@ impl MetaStore for RedisMetaStore {
 
         let chunk_key = self.chunk_key(chunk_id);
         let version_key = self.chunk_version_key(chunk_id);
-        let script = redis::Script::new(CHUNK_CAS_LUA);
+        let script = redis::Script::new(CHUNK_COMPACT_LUA);
         let _txn_guard = Self::local_lock_for_key(&chunk_key).lock().await;
+        let delayed_args: Vec<String> = delayed_slices
+            .iter()
+            .flat_map(|(slice_id, offset, size)| {
+                [
+                    slice_id.to_string(),
+                    offset.to_string(),
+                    u64::from(*size).to_string(),
+                ]
+            })
+            .collect();
+        let new_slice_ids: Vec<String> = new_slices
+            .iter()
+            .map(|slice| slice.slice_id.to_string())
+            .collect();
 
         for _ in 0..COMPACT_RETRY_LIMIT {
             let mut conn = self.conn.clone();
@@ -3515,12 +3690,25 @@ impl MetaStore for RedisMetaStore {
 
             let new_version = current_version + 1;
 
-            // Atomic CAS via Lua: replace list iff version still matches.
+            // The chunk swap and delayed-GC ledger are one script. All script
+            // errors that can be preflighted occur before the chunk changes.
             let ok: i32 = script
                 .key(&chunk_key)
                 .key(&version_key)
+                .key(DELAYED_COUNTER_KEY)
+                .key(DELAYED_INDEX_KEY)
+                .key(UNCOMMITTED_PENDING_INDEX_KEY)
+                .key(UNCOMMITTED_ORPHAN_INDEX_KEY)
                 .arg(current_version)
                 .arg(new_version)
+                .arg(DELAYED_KEY_PREFIX)
+                .arg(chunk_id)
+                .arg(Utc::now().timestamp())
+                .arg(delayed_slices.len())
+                .arg(UNCOMMITTED_KEY_PREFIX)
+                .arg(new_slice_ids.len())
+                .arg(&delayed_args)
+                .arg(&new_slice_ids)
                 .arg(&final_data)
                 .invoke_async(&mut conn)
                 .await
@@ -3528,38 +3716,6 @@ impl MetaStore for RedisMetaStore {
 
             if ok == 0 {
                 continue;
-            }
-
-            // CAS succeeded — create delayed records for removed slices.
-            if !delayed_slices.is_empty() {
-                let n = delayed_slices.len() as i64;
-                let last_id: i64 = redis::cmd("INCRBY")
-                    .arg(DELAYED_COUNTER_KEY)
-                    .arg(n)
-                    .query_async(&mut conn)
-                    .await
-                    .map_err(redis_err)?;
-                let first_id = last_id - n + 1;
-                let now = Utc::now().timestamp();
-
-                let mut pipe = redis::pipe();
-                pipe.atomic();
-                for (i, (slice_id, offset, size)) in delayed_slices.iter().enumerate() {
-                    let delayed_id = first_id + i as i64;
-                    let ds_key = self.delayed_key(delayed_id);
-                    pipe.hset(&ds_key, "sid", slice_id.to_string());
-                    pipe.hset(&ds_key, "off", offset.to_string());
-                    pipe.hset(&ds_key, "sz", u64::from(*size).to_string());
-                    pipe.hset(&ds_key, "st", "pending");
-                    pipe.hset(&ds_key, "ca", now.to_string());
-                    pipe.hset(&ds_key, "cid", chunk_id.to_string());
-                    pipe.cmd("ZADD")
-                        .arg(DELAYED_INDEX_KEY)
-                        .arg(now)
-                        .arg(delayed_id)
-                        .ignore();
-                }
-                pipe.query_async::<()>(&mut conn).await.map_err(redis_err)?;
             }
 
             return Ok(());
@@ -3597,8 +3753,22 @@ impl MetaStore for RedisMetaStore {
 
         let chunk_key = self.chunk_key(chunk_id);
         let version_key = self.chunk_version_key(chunk_id);
-        let script = redis::Script::new(CHUNK_CAS_LUA);
+        let script = redis::Script::new(CHUNK_COMPACT_LUA);
         let _txn_guard = Self::local_lock_for_key(&chunk_key).lock().await;
+        let delayed_args: Vec<String> = delayed_slices
+            .iter()
+            .flat_map(|(slice_id, offset, size)| {
+                [
+                    slice_id.to_string(),
+                    offset.to_string(),
+                    u64::from(*size).to_string(),
+                ]
+            })
+            .collect();
+        let new_slice_ids: Vec<String> = new_slices
+            .iter()
+            .map(|slice| slice.slice_id.to_string())
+            .collect();
 
         for _ in 0..COMPACT_RETRY_LIMIT {
             let mut conn = self.conn.clone();
@@ -3673,12 +3843,25 @@ impl MetaStore for RedisMetaStore {
                 final_data.push(crate::meta::serialization::serialize_meta(slice)?);
             }
 
-            // Atomic CAS via Lua: replace list iff version still matches.
+            // Commit the replacement, delayed-GC records, and uncommitted
+            // cleanup as one metadata transition.
             let ok: i32 = script
                 .key(&chunk_key)
                 .key(&version_key)
+                .key(DELAYED_COUNTER_KEY)
+                .key(DELAYED_INDEX_KEY)
+                .key(UNCOMMITTED_PENDING_INDEX_KEY)
+                .key(UNCOMMITTED_ORPHAN_INDEX_KEY)
                 .arg(current_version)
                 .arg(new_version)
+                .arg(DELAYED_KEY_PREFIX)
+                .arg(chunk_id)
+                .arg(Utc::now().timestamp())
+                .arg(delayed_slices.len())
+                .arg(UNCOMMITTED_KEY_PREFIX)
+                .arg(new_slice_ids.len())
+                .arg(&delayed_args)
+                .arg(&new_slice_ids)
                 .arg(&final_data)
                 .invoke_async(&mut conn)
                 .await
@@ -3686,72 +3869,6 @@ impl MetaStore for RedisMetaStore {
 
             if ok == 0 {
                 continue;
-            }
-
-            // CAS succeeded — create delayed records and clean up uncommitted entries.
-            if !delayed_slices.is_empty() {
-                let n = delayed_slices.len() as i64;
-                let last_id: i64 = redis::cmd("INCRBY")
-                    .arg(DELAYED_COUNTER_KEY)
-                    .arg(n)
-                    .query_async(&mut conn)
-                    .await
-                    .map_err(redis_err)?;
-                let first_id = last_id - n + 1;
-                let now = Utc::now().timestamp();
-
-                let mut pipe = redis::pipe();
-                pipe.atomic();
-                for (i, (slice_id, offset, size)) in delayed_slices.iter().enumerate() {
-                    let delayed_id = first_id + i as i64;
-                    let ds_key = self.delayed_key(delayed_id);
-                    pipe.hset(&ds_key, "sid", slice_id.to_string());
-                    pipe.hset(&ds_key, "off", offset.to_string());
-                    pipe.hset(&ds_key, "sz", u64::from(*size).to_string());
-                    pipe.hset(&ds_key, "st", "pending");
-                    pipe.hset(&ds_key, "ca", now.to_string());
-                    pipe.hset(&ds_key, "cid", chunk_id.to_string());
-                    pipe.cmd("ZADD")
-                        .arg(DELAYED_INDEX_KEY)
-                        .arg(now)
-                        .arg(delayed_id)
-                        .ignore();
-                }
-                // Clean up uncommitted records for new slices
-                for slice in new_slices {
-                    let uc_key = self.uncommitted_key(slice.slice_id);
-                    pipe.cmd("DEL").arg(&uc_key).ignore();
-                    pipe.cmd("ZREM")
-                        .arg(UNCOMMITTED_PENDING_INDEX_KEY)
-                        .arg(slice.slice_id.to_string())
-                        .ignore();
-                    pipe.cmd("ZREM")
-                        .arg(UNCOMMITTED_ORPHAN_INDEX_KEY)
-                        .arg(slice.slice_id.to_string())
-                        .ignore();
-                }
-                pipe.query_async::<()>(&mut conn).await.map_err(redis_err)?;
-            } else {
-                // No delayed slices, still clean up uncommitted records.
-                for slice in new_slices {
-                    let uc_key = self.uncommitted_key(slice.slice_id);
-                    redis::pipe()
-                        .atomic()
-                        .cmd("DEL")
-                        .arg(&uc_key)
-                        .ignore()
-                        .cmd("ZREM")
-                        .arg(UNCOMMITTED_PENDING_INDEX_KEY)
-                        .arg(slice.slice_id.to_string())
-                        .ignore()
-                        .cmd("ZREM")
-                        .arg(UNCOMMITTED_ORPHAN_INDEX_KEY)
-                        .arg(slice.slice_id.to_string())
-                        .ignore()
-                        .query_async::<()>(&mut conn)
-                        .await
-                        .map_err(redis_err)?;
-                }
             }
 
             return Ok(());

--- a/src/meta/stores/redis/tests.rs
+++ b/src/meta/stores/redis/tests.rs
@@ -109,6 +109,14 @@ fn test_config() -> Config {
     }
 }
 
+#[serial]
+#[tokio::test]
+#[ignore]
+async fn redis_standalone_capability_probe_accepts_test_server() {
+    cleanup_test_data().await.unwrap();
+    RedisMetaStore::from_config(test_config()).await.unwrap();
+}
+
 /// Configuration for shared database testing (multi-session)
 fn shared_db_config() -> Config {
     Config {
@@ -3198,6 +3206,131 @@ async fn test_delayed_slice_workflow_consistency() {
     assert!(
         delayed_after.is_empty(),
         "no delayed slice should remain after confirmation"
+    );
+}
+
+#[serial]
+#[tokio::test]
+#[ignore]
+async fn compact_delayed_record_failure_keeps_old_chunk_reachable() {
+    let store = new_test_store().await;
+    let root = store.root_ino();
+    let ino = store
+        .create_file(root, "compact_atomic_failure.txt".to_string())
+        .await
+        .unwrap();
+    let chunk_id = crate::vfs::chunk_id_for(ino, 0).unwrap();
+    let old_slice = crate::chunk::SliceDesc {
+        slice_id: 421,
+        chunk_id,
+        offset: 0,
+        length: 1024,
+    };
+    let new_slice = crate::chunk::SliceDesc {
+        slice_id: 422,
+        chunk_id,
+        offset: 0,
+        length: 1024,
+    };
+    store.append_slice(chunk_id, old_slice).await.unwrap();
+
+    // Fault injection: INCRBY on a hash fails. The old implementation had
+    // already committed the chunk CAS before discovering this error.
+    let mut conn = store.conn.clone();
+    redis::cmd("HSET")
+        .arg(super::DELAYED_COUNTER_KEY)
+        .arg("invalid")
+        .arg("counter")
+        .query_async::<()>(&mut conn)
+        .await
+        .unwrap();
+    let delayed_data = crate::chunk::SliceDesc::encode_delayed_data(&[old_slice], &[421]);
+
+    assert!(
+        store
+            .replace_slices_for_compact(chunk_id, &[new_slice], &delayed_data)
+            .await
+            .is_err(),
+        "the injected delayed-record failure must surface"
+    );
+    assert_eq!(
+        store.get_slices(chunk_id).await.unwrap(),
+        vec![old_slice],
+        "a failed compact must leave the old object reachable from the chunk list"
+    );
+    assert!(
+        store
+            .process_delayed_slices(10, 0)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[serial]
+#[tokio::test]
+#[ignore]
+async fn compact_version_conflict_leaves_chunk_and_delayed_index_unchanged() {
+    let store = new_test_store().await;
+    let root = store.root_ino();
+    let ino = store
+        .create_file(root, "compact_conflict.txt".to_string())
+        .await
+        .unwrap();
+    let chunk_id = crate::vfs::chunk_id_for(ino, 0).unwrap();
+    let old_slice = crate::chunk::SliceDesc {
+        slice_id: 431,
+        chunk_id,
+        offset: 0,
+        length: 1024,
+    };
+    let new_slice = crate::chunk::SliceDesc {
+        slice_id: 432,
+        chunk_id,
+        offset: 0,
+        length: 1024,
+    };
+    store.append_slice(chunk_id, old_slice).await.unwrap();
+    let delayed_data = crate::chunk::SliceDesc::encode_delayed_data(&[old_slice], &[431]);
+
+    let conflict = store
+        .replace_slices_for_compact_with_version(chunk_id, &[new_slice], &delayed_data, &[])
+        .await;
+    assert!(matches!(conflict, Err(MetaError::ContinueRetry(_))));
+    assert_eq!(store.get_slices(chunk_id).await.unwrap(), vec![old_slice]);
+    assert!(
+        store
+            .process_delayed_slices(10, 0)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+
+    store
+        .record_uncommitted_slice(new_slice.slice_id, chunk_id, new_slice.length, "compact")
+        .await
+        .unwrap();
+    store
+        .replace_slices_for_compact_with_version(
+            chunk_id,
+            &[new_slice],
+            &delayed_data,
+            &[old_slice],
+        )
+        .await
+        .unwrap();
+    assert_eq!(store.get_slices(chunk_id).await.unwrap(), vec![new_slice]);
+    assert_eq!(store.process_delayed_slices(10, 0).await.unwrap().len(), 1);
+
+    let mut conn = store.conn.clone();
+    let uncommitted_exists: bool = redis::cmd("EXISTS")
+        .arg(store.uncommitted_key(new_slice.slice_id))
+        .query_async(&mut conn)
+        .await
+        .unwrap();
+    assert!(
+        !uncommitted_exists,
+        "the newly referenced compacted slice must not remain eligible for orphan GC"
     );
 }
 


### PR DESCRIPTION
## Summary



- retain atomic compact-CAS, delayed-slice bookkeeping, and uncommitted cleanup
- document the current Redis metadata backend as standalone-only
- run a side-effect-free cross-slot Lua capability probe during startup
- reject Redis Cluster before scripts with dynamically derived keys can execute

## Validation

- `redis_standalone_capability_probe_accepts_test_server` passed against local Redis 8.10.1
- `cargo +1.97.1 fmt --all -- --check`
- `git diff --check`