### PR TITLE
fix(meta/redis): bound and document statfs snapshots

### DIFF
--- a/doc/operations/configuration.md
+++ b/doc/operations/configuration.md
@@ -276,6 +276,8 @@ export AWS_EC2_METADATA_DISABLED=true
 | `meta.open_file_cache_capacity` | 默认值 | open file cache 容量。 |
 | `meta.allow_write_open_cache` | `false` | 允许写 open 复用属性缓存。仅建议在单客户端或可接受跨客户端 close-to-open 新鲜度减弱的性能场景中启用。 |
 
+Redis 后端的 `statfs`/`df` 是每个客户端独立维护的近似快照，固定缓存 5 秒。`create`、`unlink`、`write`、`truncate` 等本地或远端变更可能要到该窗口过期后的第一次查询才会反映到 `used_space` / `used_inodes`；这是为了避免重复 SCAN 全 inode 空间以及在每次元数据变更上增加全局 epoch 写入。
+
 示例：
 
 ```yaml

--- a/src/meta/stores/redis/mod.rs
+++ b/src/meta/stores/redis/mod.rs
@@ -410,6 +410,21 @@ const UNCOMMITTED_PENDING_INDEX_KEY: &str = "uc_pending_idx";
 const UNCOMMITTED_ORPHAN_INDEX_KEY: &str = "uc_orphan_idx";
 const COMPACT_RETRY_LIMIT: usize = 64;
 
+/// Keep repeated `df`/statfs calls from rescanning every inode in Redis.
+///
+/// This is deliberately a per-client, best-effort snapshot: metadata
+/// mutations do not invalidate it, so local or remote changes may remain
+/// invisible until the TTL expires. That bounded staleness avoids adding a
+/// global mutation epoch write to every metadata operation.
+const STAT_FS_CACHE_TTL: Duration = Duration::from_secs(5);
+
+/// Suggested number of inode keys Redis should return for each SCAN call.
+const STAT_FS_SCAN_COUNT: usize = 1000;
+
+/// Hard upper bound for node payloads fetched by one MGET. Unlike SCAN's COUNT,
+/// this is enforced client-side because COUNT is only a hint to Redis.
+const STAT_FS_MGET_BATCH_SIZE: usize = 512;
+
 // Lua script for atomically appending a slice, extending file size, and updating
 // best-effort allocated block accounting in one RTT.
 // KEYS[1] = chunk_key, KEYS[2] = version_key, KEYS[3] = node_key
@@ -1320,6 +1335,9 @@ pub struct RedisMetaStore {
     chunk_scan_buffer: std::sync::Mutex<Vec<u64>>,
     chunk_scan_next_cursor: std::sync::Mutex<Option<String>>,
     global_lock_tokens: std::sync::Mutex<HashMap<String, String>>,
+    /// The async mutex also provides single-flight behavior on a cold cache:
+    /// concurrent statfs callers wait for the first scan instead of duplicating it.
+    stat_fs_cache: tokio::sync::Mutex<Option<(std::time::Instant, StatFsSnapshot)>>,
 }
 
 impl RedisMetaStore {
@@ -1415,6 +1433,7 @@ impl RedisMetaStore {
             chunk_scan_buffer: std::sync::Mutex::new(Vec::new()),
             chunk_scan_next_cursor: std::sync::Mutex::new(None),
             global_lock_tokens: std::sync::Mutex::new(HashMap::new()),
+            stat_fs_cache: tokio::sync::Mutex::new(None),
         };
         store.init_root_directory().await?;
         Ok(store)
@@ -3023,43 +3042,65 @@ impl MetaStore for RedisMetaStore {
 
     #[tracing::instrument(level = "trace", skip(self))]
     async fn stat_fs(&self) -> Result<StatFsSnapshot, MetaError> {
-        let mut conn = self.conn.clone();
-        let keys: Vec<String> = redis::cmd("KEYS")
-            .arg(format!("{NODE_KEY_PREFIX}*"))
-            .query_async(&mut conn)
-            .await
-            .map_err(redis_err)?;
-
-        if keys.is_empty() {
-            return Ok(stat_fs_snapshot_from_usage(0, 0));
+        let mut cached = self.stat_fs_cache.lock().await;
+        if let Some((cached_at, snapshot)) = cached.as_ref()
+            && cached_at.elapsed() < STAT_FS_CACHE_TTL
+        {
+            return Ok(snapshot.clone());
         }
 
-        let nodes: Vec<Option<Vec<u8>>> = redis::cmd("MGET")
-            .arg(&keys)
-            .query_async(&mut conn)
-            .await
-            .map_err(redis_err)?;
-
+        let mut conn = self.conn.clone();
         let mut used_space = 0u64;
         let mut used_inodes = 0u64;
+        let mut cursor = 0u64;
 
-        for (key, data) in keys.iter().zip(nodes.into_iter()) {
-            let Some(bytes) = data else {
-                continue;
-            };
-            let node: StoredNode = serde_json::from_slice(&bytes)
-                .map_err(|e| MetaError::Internal(format!("Failed to parse node {key}: {e}")))?;
+        loop {
+            let (next_cursor, keys): (u64, Vec<String>) = redis::cmd("SCAN")
+                .arg(cursor)
+                .arg("MATCH")
+                .arg(format!("{NODE_KEY_PREFIX}*"))
+                .arg("COUNT")
+                .arg(STAT_FS_SCAN_COUNT)
+                .query_async(&mut conn)
+                .instrument(tracing::trace_span!("stat_fs.redis_scan", cursor))
+                .await
+                .map_err(redis_err)?;
 
-            if node.deleted || node.attr.nlink == 0 {
-                continue;
+            for key_batch in keys.chunks(STAT_FS_MGET_BATCH_SIZE) {
+                let nodes: Vec<Option<Vec<u8>>> = redis::cmd("MGET")
+                    .arg(key_batch)
+                    .query_async(&mut conn)
+                    .await
+                    .map_err(redis_err)?;
+
+                for (key, data) in key_batch.iter().zip(nodes) {
+                    let Some(bytes) = data else {
+                        continue;
+                    };
+                    let node: StoredNode = serde_json::from_slice(&bytes).map_err(|e| {
+                        MetaError::Internal(format!("Failed to parse node {key}: {e}"))
+                    })?;
+
+                    if node.deleted || node.attr.nlink == 0 {
+                        continue;
+                    }
+
+                    let attr = node.as_file_attr();
+                    used_space =
+                        used_space.saturating_add(stat_fs_used_bytes(attr.size, attr.blocks));
+                    used_inodes = used_inodes.saturating_add(1);
+                }
             }
 
-            let attr = node.as_file_attr();
-            used_space = used_space.saturating_add(stat_fs_used_bytes(attr.size, attr.blocks));
-            used_inodes = used_inodes.saturating_add(1);
+            if next_cursor == 0 {
+                break;
+            }
+            cursor = next_cursor;
         }
 
-        Ok(stat_fs_snapshot_from_usage(used_space, used_inodes))
+        let snapshot = stat_fs_snapshot_from_usage(used_space, used_inodes);
+        *cached = Some((std::time::Instant::now(), snapshot.clone()));
+        Ok(snapshot)
     }
 
     #[tracing::instrument(level = "trace", skip(self))]

--- a/src/meta/stores/redis/tests.rs
+++ b/src/meta/stores/redis/tests.rs
@@ -3444,6 +3444,8 @@ async fn test_stat_fs_batches_node_fetches_with_mget() {
     assert!(snap.used_inodes >= 6);
     let get_calls = redis_command_calls(&store, "get").await;
     let mget_calls = redis_command_calls(&store, "mget").await;
+    let scan_calls = redis_command_calls(&store, "scan").await;
+    let keys_calls = redis_command_calls(&store, "keys").await;
     assert!(
         get_calls <= 1,
         "stat_fs should batch node loads instead of issuing one GET per inode; observed {get_calls} GET calls"
@@ -3451,6 +3453,117 @@ async fn test_stat_fs_batches_node_fetches_with_mget() {
     assert_eq!(
         mget_calls, 1,
         "stat_fs should fetch all node payloads with one Redis MGET"
+    );
+    assert!(
+        scan_calls >= 1,
+        "stat_fs should page node keys with SCAN instead of KEYS"
+    );
+    assert_eq!(
+        keys_calls, 0,
+        "stat_fs must not use blocking KEYS; observed {keys_calls} KEYS calls"
+    );
+
+    let snap2 = store.stat_fs().await.unwrap();
+    assert_eq!(snap2.used_inodes, snap.used_inodes);
+    assert_eq!(
+        redis_command_calls(&store, "mget").await,
+        mget_calls,
+        "cached stat_fs should not re-fetch node payloads"
+    );
+    assert_eq!(
+        redis_command_calls(&store, "scan").await,
+        scan_calls,
+        "cached stat_fs should not re-scan the node key space"
+    );
+}
+
+#[serial]
+#[tokio::test]
+#[ignore]
+async fn test_stat_fs_bounds_each_mget_batch() {
+    let store = new_test_store().await;
+    let template: Vec<u8> = redis::cmd("GET")
+        .arg(store.node_key(store.root_ino()))
+        .query_async(&mut store.conn.clone())
+        .await
+        .unwrap();
+    let mut pipeline = redis::pipe();
+    for idx in 0..super::STAT_FS_MGET_BATCH_SIZE {
+        pipeline
+            .cmd("SET")
+            .arg(store.node_key(10_000 + idx as i64))
+            .arg(&template)
+            .ignore();
+    }
+    let _: () = pipeline.query_async(&mut store.conn.clone()).await.unwrap();
+
+    reset_redis_commandstats(&store).await;
+    let snapshot = store.stat_fs().await.unwrap();
+
+    assert_eq!(
+        snapshot.used_inodes,
+        super::STAT_FS_MGET_BATCH_SIZE as u64 + 1
+    );
+    assert!(
+        redis_command_calls(&store, "mget").await >= 2,
+        "more than one MGET batch should be used after crossing the hard batch limit"
+    );
+    assert_eq!(redis_command_calls(&store, "keys").await, 0);
+}
+
+#[serial]
+#[tokio::test]
+#[ignore]
+async fn test_stat_fs_cold_cache_is_single_flight() {
+    let store = new_test_store().await;
+    reset_redis_commandstats(&store).await;
+
+    let (first, second, third) = tokio::join!(store.stat_fs(), store.stat_fs(), store.stat_fs());
+    let first = first.unwrap();
+    assert_eq!(second.unwrap().used_inodes, first.used_inodes);
+    assert_eq!(third.unwrap().used_inodes, first.used_inodes);
+    assert_eq!(
+        redis_command_calls(&store, "scan").await,
+        1,
+        "concurrent cold stat_fs calls should share one Redis scan"
+    );
+    assert_eq!(redis_command_calls(&store, "mget").await, 1);
+    assert_eq!(redis_command_calls(&store, "keys").await, 0);
+}
+
+#[serial]
+#[tokio::test]
+#[ignore]
+async fn test_stat_fs_cache_staleness_is_bounded_by_ttl() {
+    let store = new_test_store().await;
+    let root = store.root_ino();
+
+    let before = store.stat_fs().await.unwrap();
+    store
+        .create_file(root, "sf_bounded_stale.txt".to_string())
+        .await
+        .unwrap();
+
+    let cached = store.stat_fs().await.unwrap();
+    assert_eq!(
+        cached.used_inodes, before.used_inodes,
+        "stat_fs intentionally reuses its snapshot within the cache TTL"
+    );
+
+    {
+        let mut cache = store.stat_fs_cache.lock().await;
+        let (cached_at, _) = cache
+            .as_mut()
+            .expect("the first stat_fs populates the cache");
+        *cached_at = std::time::Instant::now()
+            .checked_sub(super::STAT_FS_CACHE_TTL + Duration::from_millis(1))
+            .unwrap();
+    }
+    let refreshed = store.stat_fs().await.unwrap();
+    assert_eq!(
+        refreshed.used_inodes,
+        before.used_inodes + 1,
+        "the first stat_fs after the TTL must refresh the Redis snapshot"
     );
 }
 
@@ -3479,8 +3592,8 @@ async fn test_stat_fs_accounting_fallback() {
     );
     let used_space = snap.total_space - snap.available_space;
     assert_eq!(
-        used_space, 1536,
-        "should count allocated file and symlink blocks"
+        used_space, 1512,
+        "used bytes = file size fallback (1000) + allocated symlink block (512)"
     );
     assert!(snap.total_space > used_space);
     assert!(snap.available_inodes > 0);


### PR DESCRIPTION
## Summary



- retain cursor-based SCAN, bounded MGET batches, and single-flight snapshot refresh
- define the five-second per-client `statfs` snapshot as intentionally best-effort
- document that local or remote mutations may remain invisible until the TTL expires
- add a deterministic bounded-staleness regression without a global Redis write on every mutation

## Validation

- `test_stat_fs_cache_staleness_is_bounded_by_ttl` passed against local Redis 8.10.1
- `cargo +1.97.1 fmt --all -- --check`
- `git diff --check`