### PR TITLE
fix(meta): fuse cached lookup and define dangling-dentry errors

### DIFF
--- a/src/meta/client/mod.rs
+++ b/src/meta/client/mod.rs
@@ -1494,6 +1494,10 @@ impl<T: MetaStore + ?Sized + 'static> MetaClient<T> {
     ///
     /// * `Ok(Some(i64))` - The inode number of the child entry if found
     /// * `Ok(None)` - If no entry with the given name exists in the parent
+    /// * `Err(MetaError::NotFound)` - If the store contains a dangling directory
+    ///   entry whose inode attributes no longer exist. This keeps inode-only
+    ///   lookup consistent with `lookup_with_attr` and maps to `ENOENT` at the
+    ///   FUSE boundary.
     /// * `Err(MetaError)` - On storage errors
     #[tracing::instrument(level = "trace", skip(self), fields(parent, name))]
     async fn cached_lookup(&self, parent: i64, name: &str) -> Result<Option<i64>, MetaError> {
@@ -1527,16 +1531,10 @@ impl<T: MetaStore + ?Sized + 'static> MetaClient<T> {
         trace!("MetaClient: lookup MISS ({}, '{}')", parent, name);
         self.metrics.record_lookup_cache_miss();
 
-        let result = self.store.lookup(parent, name).await?;
+        let result = self.store.lookup_with_attr(parent, name).await?;
 
-        if let Some(ino) = result {
-            if let Ok(Some(attr)) = self.store.stat(ino).await {
-                self.cache_lookup_attr(parent, name, ino, attr).await;
-            } else {
-                self.inode_cache
-                    .add_child(parent, name.to_string(), ino)
-                    .await;
-            }
+        if let Some((ino, attr)) = result {
+            self.cache_lookup_attr(parent, name, ino, attr).await;
             Ok(Some(ino))
         } else if self.options.case_insensitive {
             self.resolve_case(parent, name).await
@@ -3645,7 +3643,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_meta_client_lookup_only_does_not_count_lookup_attr_fused_path() {
+    async fn test_meta_client_lookup_only_does_not_change_lookup_with_attr_api_metrics() {
         let client = create_test_client().await;
         let ino = client
             .create_file(1, "lookup-only.txt".to_string())
@@ -3664,7 +3662,7 @@ mod tests {
 
         assert_eq!(
             after.lookup_attr_fused_miss, before.lookup_attr_fused_miss,
-            "lookup-only callers should stay on the lighter inode-only path"
+            "lookup-only callers should not be counted as lookup_with_attr API calls"
         );
     }
 

--- a/src/meta/stores/database/tests.rs
+++ b/src/meta/stores/database/tests.rs
@@ -1,8 +1,16 @@
 use super::*;
+use crate::chunk::{layout::ChunkLayout, store::InMemoryBlockStore};
+use crate::meta::MetaLayer;
+use crate::meta::client::MetaClient;
+use crate::meta::config::{CacheCapacity, CacheTtl};
 use crate::meta::config::{CacheConfig, ClientOptions, CompactConfig, DatabaseConfig};
 use crate::meta::file_lock::{FileLockQuery, FileLockRange, FileLockType};
+use crate::vfs::fs::VFS;
+use asyncfuse::Errno;
+use asyncfuse::raw::{Filesystem, Request};
 use sea_orm::sqlx::sqlite::SqliteConnectOptions;
 use sea_orm::sqlx::{Connection, Executor, SqliteConnection};
+use std::ffi::OsStr;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -59,6 +67,66 @@ async fn new_test_store_with_session(session_id: Uuid) -> DatabaseMetaStore {
     let store = new_test_store().await;
     store.set_sid(session_id).expect("Failed to set session ID");
     store
+}
+
+#[tokio::test]
+async fn dangling_dentry_fused_lookup_returns_not_found_and_fuse_enoent() {
+    let store = Arc::new(new_test_store().await);
+    let root = store.root_ino();
+    let name = "dangling-client-lookup.txt";
+    let ino = store.create_file(root, name.to_string()).await.unwrap();
+
+    let deleted = FileMeta::delete_by_id(ino)
+        .exec(&store.db)
+        .await
+        .expect("delete inode metadata while retaining the dentry");
+    assert_eq!(deleted.rows_affected, 1);
+    assert_eq!(
+        store.lookup(root, name).await.unwrap(),
+        Some(ino),
+        "the directory entry must remain after deleting the inode record"
+    );
+
+    let client = MetaClient::new(
+        store,
+        CacheCapacity {
+            inode: 100,
+            path: 100,
+        },
+        CacheTtl {
+            inode_ttl: Duration::from_secs(60),
+            path_ttl: Duration::from_secs(60),
+        },
+    );
+    assert!(matches!(
+        client.lookup(root, name).await,
+        Err(MetaError::NotFound(found)) if found == ino
+    ));
+    assert!(matches!(
+        client.lookup_with_attr(root, name).await,
+        Err(MetaError::NotFound(found)) if found == ino
+    ));
+
+    let fs = VFS::with_meta_layer_with_default_background(
+        ChunkLayout::default(),
+        Arc::new(InMemoryBlockStore::new()),
+        client,
+    )
+    .unwrap();
+    let err = Filesystem::lookup(
+        &fs,
+        Request {
+            unique: 1,
+            uid: 0,
+            gid: 0,
+            pid: 1,
+        },
+        root as u64,
+        OsStr::new(name),
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err, Errno::from(libc::ENOENT));
 }
 
 #[tokio::test]

--- a/src/meta/stores/redis/tests.rs
+++ b/src/meta/stores/redis/tests.rs
@@ -10,8 +10,11 @@ use crate::meta::stores::RedisMetaStore;
 use crate::meta::{MetaLayer, MetaStore};
 use crate::vfs::fs::VFS;
 use crate::{chunk::layout::ChunkLayout, chunk::store::InMemoryBlockStore};
+use asyncfuse::Errno;
+use asyncfuse::raw::{Filesystem, Request};
 use redis::AsyncCommands;
 use serial_test::serial;
+use std::ffi::OsStr;
 use std::sync::Arc;
 use tokio::time::{self, Duration};
 use uuid::Uuid;
@@ -2513,6 +2516,100 @@ async fn test_lookup_with_attr_returns_inode_attr_and_warms_node_cache() {
 
     let missing = store.lookup_with_attr(root, "missing.txt").await.unwrap();
     assert!(missing.is_none());
+}
+
+#[serial]
+#[tokio::test]
+#[ignore]
+async fn test_meta_client_lookup_uses_fused_store_path() {
+    let store = Arc::new(new_test_store().await);
+    let root = store.root_ino();
+    let ino = store
+        .create_file(root, "client_lookup_attr.txt".to_string())
+        .await
+        .unwrap();
+    let client = MetaClient::new(
+        store.clone(),
+        CacheCapacity {
+            inode: 100,
+            path: 100,
+        },
+        CacheTtl::for_redis(),
+    );
+
+    store.node_cache.invalidate(&ino).await;
+    store
+        .lookup_with_attr(root, "warm-lookup-script")
+        .await
+        .unwrap();
+    reset_redis_commandstats(&store).await;
+
+    assert_eq!(
+        client.lookup(root, "client_lookup_attr.txt").await.unwrap(),
+        Some(ino)
+    );
+
+    let script_calls = redis_script_calls(&store).await;
+    assert!(
+        (1..=2).contains(&script_calls),
+        "MetaClient::lookup should use Redis lookup_with_attr as one business Lua script; observed {script_calls} script calls including client-side script cache handling"
+    );
+}
+
+#[serial]
+#[tokio::test]
+#[ignore]
+async fn test_dangling_dentry_lookup_returns_not_found_and_fuse_enoent() {
+    let store = Arc::new(new_test_store().await);
+    let root = store.root_ino();
+    let name = "dangling-client-lookup.txt";
+    let ino = store.create_file(root, name.to_string()).await.unwrap();
+
+    let deleted: usize = store.conn.clone().del(store.node_key(ino)).await.unwrap();
+    assert_eq!(
+        deleted, 1,
+        "test must remove the inode but retain its dentry"
+    );
+    store.node_cache.invalidate(&ino).await;
+    assert_eq!(
+        store.lookup(root, name).await.unwrap(),
+        Some(ino),
+        "the directory entry must remain after deleting the inode record"
+    );
+
+    let client = MetaClient::new(
+        store,
+        CacheCapacity {
+            inode: 100,
+            path: 100,
+        },
+        CacheTtl::for_redis(),
+    );
+    assert!(matches!(
+        client.lookup(root, name).await,
+        Err(MetaError::NotFound(found)) if found == ino
+    ));
+
+    let fs = VFS::with_meta_layer_with_default_background(
+        ChunkLayout::default(),
+        Arc::new(InMemoryBlockStore::new()),
+        client,
+    )
+    .unwrap();
+    let err = Filesystem::lookup(
+        &fs,
+        Request {
+            unique: 1,
+            uid: 0,
+            gid: 0,
+            pid: 1,
+        },
+        root as u64,
+        OsStr::new(name),
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err, Errno::from(libc::ENOENT));
 }
 
 #[serial]


### PR DESCRIPTION
## Summary



- retain the fused cache-miss `lookup_with_attr` backend operation
- define a dangling dentry as `MetaError::NotFound`
- document and verify the corresponding FUSE `ENOENT` mapping
- add non-ignored SQLite/VFS coverage alongside the Redis regression

## Validation

- `dangling_dentry_fused_lookup_returns_not_found_and_fuse_enoent` — 1 passed
- `cargo +1.97.1 fmt --all -- --check`
- `git diff --check`