### PR TITLE
fix(chunk): decode persisted blocks by header

### DIFF
--- a/docker/compose-xfstests/docker-compose.etcd-perf.yml
+++ b/docker/compose-xfstests/docker-compose.etcd-perf.yml
@@ -59,18 +59,21 @@ services:
       RUSTFS_ACCESS_KEY: ${RUSTFS_ACCESS_KEY:-rustfsadmin}
       RUSTFS_SECRET_KEY: ${RUSTFS_SECRET_KEY:-rustfsadmin}
       RUSTFS_CONSOLE_ENABLE: ${RUSTFS_CONSOLE_ENABLE:-true}
-      RUSTFS_SERVER_DOMAINS: ${RUSTFS_SERVER_DOMAINS:-rustfs}
     command:
       - --address
       - :9000
       - --console-enable
-      - --server-domains
-      - ${RUSTFS_SERVER_DOMAINS:-rustfs}
       - --access-key
       - ${RUSTFS_ACCESS_KEY:-rustfsadmin}
       - --secret-key
       - ${RUSTFS_SECRET_KEY:-rustfsadmin}
       - /data
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:9000/health"]
+      interval: 2s
+      timeout: 2s
+      retries: 60
+      start_period: 5s
     volumes:
       - rustfs-data-perf-etcd:/data
     networks:
@@ -80,7 +83,7 @@ services:
     image: amazon/aws-cli:latest
     depends_on:
       rustfs:
-        condition: service_started
+        condition: service_healthy
     entrypoint: ["/bin/sh", "-ec"]
     command:
       - |

--- a/docker/compose-xfstests/docker-compose.etcd.yml
+++ b/docker/compose-xfstests/docker-compose.etcd.yml
@@ -53,18 +53,21 @@ services:
       RUSTFS_ACCESS_KEY: ${RUSTFS_ACCESS_KEY:-rustfsadmin}
       RUSTFS_SECRET_KEY: ${RUSTFS_SECRET_KEY:-rustfsadmin}
       RUSTFS_CONSOLE_ENABLE: ${RUSTFS_CONSOLE_ENABLE:-true}
-      RUSTFS_SERVER_DOMAINS: ${RUSTFS_SERVER_DOMAINS:-rustfs}
     command:
       - --address
       - :9000
       - --console-enable
-      - --server-domains
-      - ${RUSTFS_SERVER_DOMAINS:-rustfs}
       - --access-key
       - ${RUSTFS_ACCESS_KEY:-rustfsadmin}
       - --secret-key
       - ${RUSTFS_SECRET_KEY:-rustfsadmin}
       - /data
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:9000/health"]
+      interval: 2s
+      timeout: 2s
+      retries: 60
+      start_period: 5s
     volumes:
       - rustfs-data-etcd:/data
     networks:
@@ -74,7 +77,7 @@ services:
     image: amazon/aws-cli:latest
     depends_on:
       rustfs:
-        condition: service_started
+        condition: service_healthy
     entrypoint: ["/bin/sh", "-ec"]
     command:
       - |

--- a/docker/compose-xfstests/docker-compose.juicefs-perf.yml
+++ b/docker/compose-xfstests/docker-compose.juicefs-perf.yml
@@ -32,18 +32,21 @@ services:
       RUSTFS_ACCESS_KEY: ${RUSTFS_ACCESS_KEY:-rustfsadmin}
       RUSTFS_SECRET_KEY: ${RUSTFS_SECRET_KEY:-rustfsadmin}
       RUSTFS_CONSOLE_ENABLE: ${RUSTFS_CONSOLE_ENABLE:-true}
-      RUSTFS_SERVER_DOMAINS: ${RUSTFS_SERVER_DOMAINS:-rustfs}
     command:
       - --address
       - :9000
       - --console-enable
-      - --server-domains
-      - ${RUSTFS_SERVER_DOMAINS:-rustfs}
       - --access-key
       - ${RUSTFS_ACCESS_KEY:-rustfsadmin}
       - --secret-key
       - ${RUSTFS_SECRET_KEY:-rustfsadmin}
       - /data
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:9000/health"]
+      interval: 2s
+      timeout: 2s
+      retries: 60
+      start_period: 5s
     volumes:
       - ${JUICEFS_PERF_RUSTFS_DATA_MOUNT:-rustfs-data-juicefs-perf}:/data
     networks:
@@ -53,7 +56,7 @@ services:
     image: amazon/aws-cli:latest
     depends_on:
       rustfs:
-        condition: service_started
+        condition: service_healthy
     entrypoint: ["/bin/sh", "-ec"]
     command:
       - |

--- a/docker/compose-xfstests/docker-compose.juicefs-tikv-perf.yml
+++ b/docker/compose-xfstests/docker-compose.juicefs-tikv-perf.yml
@@ -81,18 +81,21 @@ services:
       RUSTFS_ACCESS_KEY: ${RUSTFS_ACCESS_KEY:-rustfsadmin}
       RUSTFS_SECRET_KEY: ${RUSTFS_SECRET_KEY:-rustfsadmin}
       RUSTFS_CONSOLE_ENABLE: ${RUSTFS_CONSOLE_ENABLE:-true}
-      RUSTFS_SERVER_DOMAINS: ${RUSTFS_SERVER_DOMAINS:-rustfs}
     command:
       - --address
       - :9000
       - --console-enable
-      - --server-domains
-      - ${RUSTFS_SERVER_DOMAINS:-rustfs}
       - --access-key
       - ${RUSTFS_ACCESS_KEY:-rustfsadmin}
       - --secret-key
       - ${RUSTFS_SECRET_KEY:-rustfsadmin}
       - /data
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:9000/health"]
+      interval: 2s
+      timeout: 2s
+      retries: 60
+      start_period: 5s
     volumes:
       - rustfs-data-juicefs-perf-tikv:/data
     networks:
@@ -102,7 +105,7 @@ services:
     image: amazon/aws-cli:latest
     depends_on:
       rustfs:
-        condition: service_started
+        condition: service_healthy
     entrypoint: ["/bin/sh", "-ec"]
     command:
       - |

--- a/docker/compose-xfstests/docker-compose.ltp-etcd.yml
+++ b/docker/compose-xfstests/docker-compose.ltp-etcd.yml
@@ -53,18 +53,21 @@ services:
       RUSTFS_ACCESS_KEY: ${RUSTFS_ACCESS_KEY:-rustfsadmin}
       RUSTFS_SECRET_KEY: ${RUSTFS_SECRET_KEY:-rustfsadmin}
       RUSTFS_CONSOLE_ENABLE: ${RUSTFS_CONSOLE_ENABLE:-true}
-      RUSTFS_SERVER_DOMAINS: ${RUSTFS_SERVER_DOMAINS:-rustfs}
     command:
       - --address
       - :9000
       - --console-enable
-      - --server-domains
-      - ${RUSTFS_SERVER_DOMAINS:-rustfs}
       - --access-key
       - ${RUSTFS_ACCESS_KEY:-rustfsadmin}
       - --secret-key
       - ${RUSTFS_SECRET_KEY:-rustfsadmin}
       - /data
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:9000/health"]
+      interval: 2s
+      timeout: 2s
+      retries: 60
+      start_period: 5s
     volumes:
       - rustfs-data-ltp-etcd:/data
     networks:
@@ -74,7 +77,7 @@ services:
     image: amazon/aws-cli:latest
     depends_on:
       rustfs:
-        condition: service_started
+        condition: service_healthy
     entrypoint: ["/bin/sh", "-ec"]
     command:
       - |

--- a/docker/compose-xfstests/docker-compose.ltp-redis.yml
+++ b/docker/compose-xfstests/docker-compose.ltp-redis.yml
@@ -22,18 +22,21 @@ services:
       RUSTFS_ACCESS_KEY: ${RUSTFS_ACCESS_KEY:-rustfsadmin}
       RUSTFS_SECRET_KEY: ${RUSTFS_SECRET_KEY:-rustfsadmin}
       RUSTFS_CONSOLE_ENABLE: ${RUSTFS_CONSOLE_ENABLE:-true}
-      RUSTFS_SERVER_DOMAINS: ${RUSTFS_SERVER_DOMAINS:-rustfs}
     command:
       - --address
       - :9000
       - --console-enable
-      - --server-domains
-      - ${RUSTFS_SERVER_DOMAINS:-rustfs}
       - --access-key
       - ${RUSTFS_ACCESS_KEY:-rustfsadmin}
       - --secret-key
       - ${RUSTFS_SECRET_KEY:-rustfsadmin}
       - /data
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:9000/health"]
+      interval: 2s
+      timeout: 2s
+      retries: 60
+      start_period: 5s
     volumes:
       - rustfs-data-ltp:/data
     networks:
@@ -47,7 +50,7 @@ services:
     image: amazon/aws-cli:latest
     depends_on:
       rustfs:
-        condition: service_started
+        condition: service_healthy
     entrypoint: ["/bin/sh", "-ec"]
     command:
       - |

--- a/docker/compose-xfstests/docker-compose.ltp-sqlite.yml
+++ b/docker/compose-xfstests/docker-compose.ltp-sqlite.yml
@@ -9,18 +9,21 @@ services:
       RUSTFS_ACCESS_KEY: ${RUSTFS_ACCESS_KEY:-rustfsadmin}
       RUSTFS_SECRET_KEY: ${RUSTFS_SECRET_KEY:-rustfsadmin}
       RUSTFS_CONSOLE_ENABLE: ${RUSTFS_CONSOLE_ENABLE:-true}
-      RUSTFS_SERVER_DOMAINS: ${RUSTFS_SERVER_DOMAINS:-rustfs}
     command:
       - --address
       - :9000
       - --console-enable
-      - --server-domains
-      - ${RUSTFS_SERVER_DOMAINS:-rustfs}
       - --access-key
       - ${RUSTFS_ACCESS_KEY:-rustfsadmin}
       - --secret-key
       - ${RUSTFS_SECRET_KEY:-rustfsadmin}
       - /data
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:9000/health"]
+      interval: 2s
+      timeout: 2s
+      retries: 60
+      start_period: 5s
     volumes:
       - rustfs-data-ltp-sqlite:/data
     networks:
@@ -30,7 +33,7 @@ services:
     image: amazon/aws-cli:latest
     depends_on:
       rustfs:
-        condition: service_started
+        condition: service_healthy
     entrypoint: ["/bin/sh", "-ec"]
     command:
       - |

--- a/docker/compose-xfstests/docker-compose.ltp-tikv.yml
+++ b/docker/compose-xfstests/docker-compose.ltp-tikv.yml
@@ -65,18 +65,21 @@ services:
       RUSTFS_ACCESS_KEY: ${RUSTFS_ACCESS_KEY:-rustfsadmin}
       RUSTFS_SECRET_KEY: ${RUSTFS_SECRET_KEY:-rustfsadmin}
       RUSTFS_CONSOLE_ENABLE: ${RUSTFS_CONSOLE_ENABLE:-true}
-      RUSTFS_SERVER_DOMAINS: ${RUSTFS_SERVER_DOMAINS:-rustfs}
     command:
       - --address
       - :9000
       - --console-enable
-      - --server-domains
-      - ${RUSTFS_SERVER_DOMAINS:-rustfs}
       - --access-key
       - ${RUSTFS_ACCESS_KEY:-rustfsadmin}
       - --secret-key
       - ${RUSTFS_SECRET_KEY:-rustfsadmin}
       - /data
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:9000/health"]
+      interval: 2s
+      timeout: 2s
+      retries: 60
+      start_period: 5s
     volumes:
       - ${RUSTFS_DATA_HOST_DIR:-rustfs-data-ltp-tikv}:/data
     networks:
@@ -90,7 +93,7 @@ services:
     image: amazon/aws-cli:latest
     depends_on:
       rustfs:
-        condition: service_started
+        condition: service_healthy
     entrypoint: ["/bin/sh", "-ec"]
     command:
       - |

--- a/docker/compose-xfstests/docker-compose.pjdfstest-redis.yml
+++ b/docker/compose-xfstests/docker-compose.pjdfstest-redis.yml
@@ -22,18 +22,21 @@ services:
       RUSTFS_ACCESS_KEY: ${RUSTFS_ACCESS_KEY:-rustfsadmin}
       RUSTFS_SECRET_KEY: ${RUSTFS_SECRET_KEY:-rustfsadmin}
       RUSTFS_CONSOLE_ENABLE: ${RUSTFS_CONSOLE_ENABLE:-true}
-      RUSTFS_SERVER_DOMAINS: ${RUSTFS_SERVER_DOMAINS:-rustfs}
     command:
       - --address
       - :9000
       - --console-enable
-      - --server-domains
-      - ${RUSTFS_SERVER_DOMAINS:-rustfs}
       - --access-key
       - ${RUSTFS_ACCESS_KEY:-rustfsadmin}
       - --secret-key
       - ${RUSTFS_SECRET_KEY:-rustfsadmin}
       - /data
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:9000/health"]
+      interval: 2s
+      timeout: 2s
+      retries: 60
+      start_period: 5s
     volumes:
       - rustfs-data-pjdfstest:/data
     networks:
@@ -47,7 +50,7 @@ services:
     image: amazon/aws-cli:latest
     depends_on:
       rustfs:
-        condition: service_started
+        condition: service_healthy
     entrypoint: ["/bin/sh", "-ec"]
     command:
       - |

--- a/docker/compose-xfstests/docker-compose.pjdfstest-tikv.yml
+++ b/docker/compose-xfstests/docker-compose.pjdfstest-tikv.yml
@@ -65,18 +65,21 @@ services:
       RUSTFS_ACCESS_KEY: ${RUSTFS_ACCESS_KEY:-rustfsadmin}
       RUSTFS_SECRET_KEY: ${RUSTFS_SECRET_KEY:-rustfsadmin}
       RUSTFS_CONSOLE_ENABLE: ${RUSTFS_CONSOLE_ENABLE:-true}
-      RUSTFS_SERVER_DOMAINS: ${RUSTFS_SERVER_DOMAINS:-rustfs}
     command:
       - --address
       - :9000
       - --console-enable
-      - --server-domains
-      - ${RUSTFS_SERVER_DOMAINS:-rustfs}
       - --access-key
       - ${RUSTFS_ACCESS_KEY:-rustfsadmin}
       - --secret-key
       - ${RUSTFS_SECRET_KEY:-rustfsadmin}
       - /data
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:9000/health"]
+      interval: 2s
+      timeout: 2s
+      retries: 60
+      start_period: 5s
     volumes:
       - ${RUSTFS_DATA_HOST_DIR:-rustfs-data-pjdfstest-tikv}:/data
     networks:
@@ -90,7 +93,7 @@ services:
     image: amazon/aws-cli:latest
     depends_on:
       rustfs:
-        condition: service_started
+        condition: service_healthy
     entrypoint: ["/bin/sh", "-ec"]
     command:
       - |

--- a/docker/compose-xfstests/docker-compose.redis-perf.yml
+++ b/docker/compose-xfstests/docker-compose.redis-perf.yml
@@ -34,18 +34,21 @@ services:
       RUSTFS_ACCESS_KEY: ${RUSTFS_ACCESS_KEY:-rustfsadmin}
       RUSTFS_SECRET_KEY: ${RUSTFS_SECRET_KEY:-rustfsadmin}
       RUSTFS_CONSOLE_ENABLE: ${RUSTFS_CONSOLE_ENABLE:-true}
-      RUSTFS_SERVER_DOMAINS: ${RUSTFS_SERVER_DOMAINS:-rustfs}
     command:
       - --address
       - :9000
       - --console-enable
-      - --server-domains
-      - ${RUSTFS_SERVER_DOMAINS:-rustfs}
       - --access-key
       - ${RUSTFS_ACCESS_KEY:-rustfsadmin}
       - --secret-key
       - ${RUSTFS_SECRET_KEY:-rustfsadmin}
       - /data
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:9000/health"]
+      interval: 2s
+      timeout: 2s
+      retries: 60
+      start_period: 5s
     volumes:
       - ${BREWFS_PERF_RUSTFS_DATA_MOUNT:-rustfs-data-perf-redis}:/data
     networks:
@@ -55,7 +58,7 @@ services:
     image: amazon/aws-cli:latest
     depends_on:
       rustfs:
-        condition: service_started
+        condition: service_healthy
     entrypoint: ["/bin/sh", "-ec"]
     command:
       - |

--- a/docker/compose-xfstests/docker-compose.redis.yml
+++ b/docker/compose-xfstests/docker-compose.redis.yml
@@ -24,18 +24,21 @@ services:
       RUSTFS_ACCESS_KEY: ${RUSTFS_ACCESS_KEY:-rustfsadmin}
       RUSTFS_SECRET_KEY: ${RUSTFS_SECRET_KEY:-rustfsadmin}
       RUSTFS_CONSOLE_ENABLE: ${RUSTFS_CONSOLE_ENABLE:-true}
-      RUSTFS_SERVER_DOMAINS: ${RUSTFS_SERVER_DOMAINS:-rustfs}
     command:
       - --address
       - :9000
       - --console-enable
-      - --server-domains
-      - ${RUSTFS_SERVER_DOMAINS:-rustfs}
       - --access-key
       - ${RUSTFS_ACCESS_KEY:-rustfsadmin}
       - --secret-key
       - ${RUSTFS_SECRET_KEY:-rustfsadmin}
       - /data
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:9000/health"]
+      interval: 2s
+      timeout: 2s
+      retries: 60
+      start_period: 5s
     volumes:
       - ${RUSTFS_DATA_HOST_DIR:-rustfs-data}:/data
     networks:
@@ -49,7 +52,7 @@ services:
     image: amazon/aws-cli:latest
     depends_on:
       rustfs:
-        condition: service_started
+        condition: service_healthy
     entrypoint: ["/bin/sh", "-ec"]
     command:
       - |

--- a/docker/compose-xfstests/docker-compose.sqlite.yml
+++ b/docker/compose-xfstests/docker-compose.sqlite.yml
@@ -9,18 +9,21 @@ services:
       RUSTFS_ACCESS_KEY: ${RUSTFS_ACCESS_KEY:-rustfsadmin}
       RUSTFS_SECRET_KEY: ${RUSTFS_SECRET_KEY:-rustfsadmin}
       RUSTFS_CONSOLE_ENABLE: ${RUSTFS_CONSOLE_ENABLE:-true}
-      RUSTFS_SERVER_DOMAINS: ${RUSTFS_SERVER_DOMAINS:-rustfs}
     command:
       - --address
       - :9000
       - --console-enable
-      - --server-domains
-      - ${RUSTFS_SERVER_DOMAINS:-rustfs}
       - --access-key
       - ${RUSTFS_ACCESS_KEY:-rustfsadmin}
       - --secret-key
       - ${RUSTFS_SECRET_KEY:-rustfsadmin}
       - /data
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:9000/health"]
+      interval: 2s
+      timeout: 2s
+      retries: 60
+      start_period: 5s
     volumes:
       - rustfs-data-sqlite:/data
     networks:
@@ -30,7 +33,7 @@ services:
     image: amazon/aws-cli:latest
     depends_on:
       rustfs:
-        condition: service_started
+        condition: service_healthy
     entrypoint: ["/bin/sh", "-ec"]
     command:
       - |

--- a/docker/compose-xfstests/docker-compose.tikv-perf.yml
+++ b/docker/compose-xfstests/docker-compose.tikv-perf.yml
@@ -81,18 +81,21 @@ services:
       RUSTFS_ACCESS_KEY: ${RUSTFS_ACCESS_KEY:-rustfsadmin}
       RUSTFS_SECRET_KEY: ${RUSTFS_SECRET_KEY:-rustfsadmin}
       RUSTFS_CONSOLE_ENABLE: ${RUSTFS_CONSOLE_ENABLE:-true}
-      RUSTFS_SERVER_DOMAINS: ${RUSTFS_SERVER_DOMAINS:-rustfs}
     command:
       - --address
       - :9000
       - --console-enable
-      - --server-domains
-      - ${RUSTFS_SERVER_DOMAINS:-rustfs}
       - --access-key
       - ${RUSTFS_ACCESS_KEY:-rustfsadmin}
       - --secret-key
       - ${RUSTFS_SECRET_KEY:-rustfsadmin}
       - /data
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:9000/health"]
+      interval: 2s
+      timeout: 2s
+      retries: 60
+      start_period: 5s
     volumes:
       - rustfs-data-perf-tikv:/data
     networks:
@@ -102,7 +105,7 @@ services:
     image: amazon/aws-cli:latest
     depends_on:
       rustfs:
-        condition: service_started
+        condition: service_healthy
     entrypoint: ["/bin/sh", "-ec"]
     command:
       - |

--- a/docker/compose-xfstests/docker-compose.tikv.yml
+++ b/docker/compose-xfstests/docker-compose.tikv.yml
@@ -65,18 +65,21 @@ services:
       RUSTFS_ACCESS_KEY: ${RUSTFS_ACCESS_KEY:-rustfsadmin}
       RUSTFS_SECRET_KEY: ${RUSTFS_SECRET_KEY:-rustfsadmin}
       RUSTFS_CONSOLE_ENABLE: ${RUSTFS_CONSOLE_ENABLE:-true}
-      RUSTFS_SERVER_DOMAINS: ${RUSTFS_SERVER_DOMAINS:-rustfs}
     command:
       - --address
       - :9000
       - --console-enable
-      - --server-domains
-      - ${RUSTFS_SERVER_DOMAINS:-rustfs}
       - --access-key
       - ${RUSTFS_ACCESS_KEY:-rustfsadmin}
       - --secret-key
       - ${RUSTFS_SECRET_KEY:-rustfsadmin}
       - /data
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:9000/health"]
+      interval: 2s
+      timeout: 2s
+      retries: 60
+      start_period: 5s
     volumes:
       - ${RUSTFS_DATA_HOST_DIR:-rustfs-data-tikv}:/data
     networks:
@@ -90,7 +93,7 @@ services:
     image: amazon/aws-cli:latest
     depends_on:
       rustfs:
-        condition: service_started
+        condition: service_healthy
     entrypoint: ["/bin/sh", "-ec"]
     command:
       - |

--- a/src/chunk/compress.rs
+++ b/src/chunk/compress.rs
@@ -45,6 +45,19 @@ impl Compression {
     }
 }
 
+/// Return whether bytes begin with a valid BrewFS compressed-block header.
+///
+/// This is intentionally separate from decompression: callers that want to
+/// serve an object range need to know whether offsets address raw file data or
+/// an encoded payload before fetching that range.
+pub fn has_compression_header(data: &[u8]) -> bool {
+    data.len() >= 4
+        && data[0] == MAGIC[0]
+        && data[1] == MAGIC[1]
+        && data[3] == 0
+        && Compression::from_algo_byte(data[2]).is_some()
+}
+
 /// Compress data using the specified algorithm.
 /// Returns `Cow::Borrowed` when data should be stored as-is (no compression or incompressible),
 /// and `Cow::Owned` with compressed+header bytes when compression is beneficial.

--- a/src/chunk/compress.rs
+++ b/src/chunk/compress.rs
@@ -1,8 +1,12 @@
 //! Block-level data compression for storage and transfer.
 //!
-//! Provides transparent compression/decompression with auto-detection on read.
-//! Compressed data uses a 4-byte header: `[magic_hi, magic_lo, algorithm, reserved]`
-//! so that decompression can automatically detect the algorithm without external metadata.
+//! Provides transparent compression/decompression for the versioned chunk-object
+//! layout. Framed payloads use a 4-byte header:
+//! `[magic_hi, magic_lo, algorithm, reserved]`.
+//!
+//! The header alone is not sufficient to classify arbitrary legacy bytes. It is
+//! therefore trusted only for objects in the versioned chunk namespace; legacy
+//! object layout is selected by the caller's compatibility policy.
 
 use std::borrow::Cow;
 
@@ -11,6 +15,7 @@ use tracing::{debug, trace};
 
 /// Magic bytes identifying compressed data (0xSF = SlayerFs)
 const MAGIC: [u8; 2] = [0x53, 0x46];
+pub const PERSISTED_HEADER_LEN: usize = 4;
 
 /// Compression algorithm selection
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -45,17 +50,35 @@ impl Compression {
     }
 }
 
-/// Return whether bytes begin with a valid BrewFS compressed-block header.
-///
-/// This is intentionally separate from decompression: callers that want to
-/// serve an object range need to know whether offsets address raw file data or
-/// an encoded payload before fetching that range.
-pub fn has_compression_header(data: &[u8]) -> bool {
-    data.len() >= 4
-        && data[0] == MAGIC[0]
-        && data[1] == MAGIC[1]
-        && data[3] == 0
-        && Compression::from_algo_byte(data[2]).is_some()
+/// Result of parsing the fixed-size persisted block header.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PersistedHeader {
+    /// Fewer than four bytes were supplied, so classification is unsafe.
+    Incomplete,
+    /// The bytes are not a framed block.
+    NotFramed,
+    /// A valid framed block and its stored encoding.
+    Framed(Compression),
+    /// The bytes use the framing magic but are not a supported frame.
+    Invalid,
+}
+
+/// Parse a persisted block header. All consumers of a framed object must use
+/// this parser so range-read selection and full-block decoding agree.
+pub fn parse_persisted_header(data: &[u8]) -> PersistedHeader {
+    if data.len() < PERSISTED_HEADER_LEN {
+        return PersistedHeader::Incomplete;
+    }
+    if data[..2] != MAGIC {
+        return PersistedHeader::NotFramed;
+    }
+    if data[3] != 0 {
+        return PersistedHeader::Invalid;
+    }
+    match Compression::from_algo_byte(data[2]) {
+        Some(compression) => PersistedHeader::Framed(compression),
+        None => PersistedHeader::Invalid,
+    }
 }
 
 /// Compress data using the specified algorithm.
@@ -80,26 +103,26 @@ pub fn compress<'a>(data: &'a [u8], algo: Compression) -> Cow<'a, [u8]> {
     };
 
     // If compressed is not smaller, store uncompressed (no header)
-    if compressed_body.len() + 4 >= data.len() {
+    if compressed_body.len() + PERSISTED_HEADER_LEN >= data.len() {
         trace!(
             "Compression not beneficial: {} -> {} bytes, storing raw",
             data.len(),
-            compressed_body.len() + 4
+            compressed_body.len() + PERSISTED_HEADER_LEN
         );
         return Cow::Borrowed(data);
     }
 
-    let ratio = data.len() as f64 / (compressed_body.len() + 4) as f64;
+    let ratio = data.len() as f64 / (compressed_body.len() + PERSISTED_HEADER_LEN) as f64;
     trace!(
         "Compressed {} -> {} bytes ({:.1}x ratio, algo={:?})",
         data.len(),
-        compressed_body.len() + 4,
+        compressed_body.len() + PERSISTED_HEADER_LEN,
         ratio,
         algo
     );
 
     // Prepend 4-byte header: [magic_hi, magic_lo, algo, reserved]
-    let mut result = Vec::with_capacity(4 + compressed_body.len());
+    let mut result = Vec::with_capacity(PERSISTED_HEADER_LEN + compressed_body.len());
     result.extend_from_slice(&MAGIC);
     result.push(algo.algo_byte());
     result.push(0); // reserved
@@ -107,35 +130,82 @@ pub fn compress<'a>(data: &'a [u8], algo: Compression) -> Cow<'a, [u8]> {
     Cow::Owned(result)
 }
 
-/// Decompress data, auto-detecting compression from the header.
-/// If data has no compression header (no magic bytes), returns as-is.
-pub fn decompress(data: &[u8]) -> anyhow::Result<Cow<'_, [u8]>> {
-    if data.len() < 4 || data[0] != MAGIC[0] || data[1] != MAGIC[1] {
-        // No compression header — return raw data
-        return Ok(Cow::Borrowed(data));
+/// Encode a block for the versioned object namespace.
+///
+/// Unlike [`compress`], this always returns a frame: uncompressed and
+/// incompressible blocks use the `Compression::None` encoding. This means the
+/// framing parser never needs to guess whether arbitrary user data is raw.
+pub fn encode_persisted_block(data: &[u8], compression: Compression) -> Bytes {
+    match compress(data, compression) {
+        Cow::Owned(encoded) => Bytes::from(encoded),
+        Cow::Borrowed(raw) => {
+            let mut encoded = Vec::with_capacity(PERSISTED_HEADER_LEN + raw.len());
+            encoded.extend_from_slice(&MAGIC);
+            encoded.push(Compression::None.algo_byte());
+            encoded.push(0);
+            encoded.extend_from_slice(raw);
+            Bytes::from(encoded)
+        }
     }
+}
 
-    let algo = Compression::from_algo_byte(data[2])
-        .ok_or_else(|| anyhow::anyhow!("Unknown compression algorithm byte: {}", data[2]))?;
+/// Decompress a framed persisted block.
+///
+/// Callers must only use this for objects whose namespace declares the framed
+/// layout. Raw and incomplete bytes are rejected instead of being guessed.
+pub fn decompress_framed(data: &[u8]) -> anyhow::Result<Cow<'_, [u8]>> {
+    let algo = match parse_persisted_header(data) {
+        PersistedHeader::Framed(algo) => algo,
+        PersistedHeader::Incomplete => anyhow::bail!("truncated persisted block header"),
+        PersistedHeader::NotFramed => anyhow::bail!("missing persisted block header"),
+        PersistedHeader::Invalid => anyhow::bail!("unsupported persisted block header"),
+    };
 
-    let body = &data[4..];
+    let body = &data[PERSISTED_HEADER_LEN..];
 
     match algo {
         Compression::None => Ok(Cow::Borrowed(body)),
         Compression::Lz4 => lz4_flex::decompress_size_prepended(body)
             .map(Cow::Owned)
             .map_err(|e| anyhow::anyhow!("LZ4 decompression failed: {}", e)),
-        Compression::Zstd(_) => {
-            zstd::bulk::decompress(body, 64 * 1024 * 1024) // max 64MB decompressed
-                .map(Cow::Owned)
-                .map_err(|e| anyhow::anyhow!("Zstd decompression failed: {}", e))
-        }
+        Compression::Zstd(_) => zstd::bulk::decompress(body, 64 * 1024 * 1024)
+            .map(Cow::Owned)
+            .map_err(|e| anyhow::anyhow!("Zstd decompression failed: {}", e)),
     }
+}
+
+/// Decompress a legacy payload using its historical, magic-based convention.
+/// If there is no magic prefix, returns the original bytes. Invalid magic
+/// prefixes fail rather than silently exposing encoded bytes as file data.
+pub fn decompress(data: &[u8]) -> anyhow::Result<Cow<'_, [u8]>> {
+    if data.len() < 4 || data[0] != MAGIC[0] || data[1] != MAGIC[1] {
+        // No compression header — return raw data
+        return Ok(Cow::Borrowed(data));
+    }
+    decompress_framed(data)
 }
 
 /// Decompress an owned Bytes buffer while preserving zero-copy raw fallback.
 pub fn decompress_bytes(data: Bytes) -> anyhow::Result<Bytes> {
     match decompress(data.as_ref())? {
+        Cow::Borrowed(borrowed) => {
+            let base = data.as_ptr() as usize;
+            let start = (borrowed.as_ptr() as usize)
+                .checked_sub(base)
+                .ok_or_else(|| anyhow::anyhow!("decompressed slice is outside source buffer"))?;
+            let end = start
+                .checked_add(borrowed.len())
+                .filter(|end| *end <= data.len())
+                .ok_or_else(|| anyhow::anyhow!("decompressed slice exceeds source buffer"))?;
+            Ok(data.slice(start..end))
+        }
+        Cow::Owned(decompressed) => Ok(Bytes::from(decompressed)),
+    }
+}
+
+/// Decompress an owned framed block while preserving zero-copy raw frames.
+pub fn decompress_framed_bytes(data: Bytes) -> anyhow::Result<Bytes> {
+    match decompress_framed(data.as_ref())? {
         Cow::Borrowed(borrowed) => {
             let base = data.as_ptr() as usize;
             let start = (borrowed.as_ptr() as usize)
@@ -246,5 +316,34 @@ mod tests {
 
         assert_eq!(decompressed.as_ref(), b"raw body");
         assert_eq!(decompressed.as_ptr(), expected_ptr);
+    }
+
+    #[test]
+    fn versioned_raw_frame_preserves_magic_like_user_bytes() {
+        let raw = b"SF\x00\x00payload";
+        let encoded = encode_persisted_block(raw, Compression::None);
+        assert_eq!(
+            parse_persisted_header(&encoded),
+            PersistedHeader::Framed(Compression::None)
+        );
+        assert_eq!(decompress_framed_bytes(encoded).unwrap().as_ref(), raw);
+    }
+
+    #[test]
+    fn parser_rejects_invalid_framed_headers_consistently() {
+        assert_eq!(
+            parse_persisted_header(b"SF\x01"),
+            PersistedHeader::Incomplete
+        );
+        assert_eq!(
+            parse_persisted_header(b"SF\x01\x01"),
+            PersistedHeader::Invalid
+        );
+        assert_eq!(
+            parse_persisted_header(b"SF\x7f\x00"),
+            PersistedHeader::Invalid
+        );
+        assert!(decompress_framed(b"SF\x01\x01payload").is_err());
+        assert!(decompress_framed(b"SF\x7f\x00payload").is_err());
     }
 }

--- a/src/chunk/store.rs
+++ b/src/chunk/store.rs
@@ -1,7 +1,7 @@
 //! Storage backends: asynchronous block-level IO traits and in-memory implementations.
 
 use crate::chunk::bandwidth::BandwidthLimiter;
-use crate::chunk::compress::{Compression, compress, decompress_bytes};
+use crate::chunk::compress::{Compression, compress, decompress_bytes, has_compression_header};
 use crate::chunk::page_cache::{PageKey, ReadPageCache};
 use crate::chunk::singleflight::SingleFlight;
 use crate::utils::NumCastExt;
@@ -490,6 +490,26 @@ impl<B: ObjectBackend + 'static> ObjectBlockStore<B> {
         format!("chunks/{chunk_id}/{block_index}")
     }
 
+    /// Range GET offsets are valid only for raw objects. A block may have
+    /// been written with a different compression setting than the current
+    /// mount, so inspect its self-describing header rather than trusting the
+    /// mount configuration.
+    async fn persisted_block_is_raw(&self, key: &str) -> anyhow::Result<bool> {
+        let mut header = [0u8; 4];
+        self.bandwidth.acquire_download(header.len()).await;
+        let started = Instant::now();
+        let read_len = self
+            .client
+            .get_object_range(key, 0, &mut header)
+            .await
+            .map_err(|error| {
+                anyhow::anyhow!("object store header read failed: {key}, {error:?}")
+            })?;
+        self.object_metrics
+            .record_get(read_len as u64, started.elapsed());
+        Ok(!has_compression_header(&header[..read_len]))
+    }
+
     async fn populate_write_cache_after_upload(&self, key: String, data: Bytes) {
         // Make freshly uploaded data immediately visible through a protected
         // read-after-write tier. The normal hot cache uses admission control,
@@ -566,7 +586,6 @@ impl<B: ObjectBackend + 'static> ObjectBlockStore<B> {
         let read_flight = self.read_flight.clone();
         let prefetch_limit = self.range_prefetch_limit.clone();
         let bandwidth = self.bandwidth.clone();
-        let compression = self.config.compression;
         let block_size = self.config.block_size;
         let object_metrics = self.object_metrics.clone();
 
@@ -600,12 +619,11 @@ impl<B: ObjectBackend + 'static> ObjectBlockStore<B> {
                             return Ok(Bytes::new());
                         }
                     };
-                    let decompressed = if !matches!(compression, Compression::None) {
-                        decompress_bytes(raw_bytes)
-                            .map_err(|e| anyhow::anyhow!("block decompression failed: {e}"))?
-                    } else {
-                        raw_bytes
-                    };
+                    // Persisted blocks are self-describing. The compression
+                    // setting controls future writes, not how an existing
+                    // object must be decoded after a remount.
+                    let decompressed = decompress_bytes(raw_bytes)
+                        .map_err(|e| anyhow::anyhow!("block decompression failed: {e}"))?;
                     Ok::<_, anyhow::Error>(decompressed)
                 })
                 .await;
@@ -784,11 +802,11 @@ impl<B: ObjectBackend + Send + Sync + 'static> BlockStore for ObjectBlockStore<B
         }
 
         let range_size_threshold = self.config.range_size_threshold();
-
-        if matches!(self.config.compression, Compression::None)
-            && offset > 0
+        let can_read_object_ranges = offset > 0
             && len <= range_size_threshold
-        {
+            && self.persisted_block_is_raw(&key_str).await?;
+
+        if can_read_object_ranges {
             if let Some(block_data) = self.read_flight.try_piggyback(&key).await {
                 tracing::Span::current().record("strategy", "piggyback_full");
                 self.object_metrics.record_read_piggyback_full();
@@ -907,7 +925,6 @@ impl<B: ObjectBackend + Send + Sync + 'static> BlockStore for ObjectBlockStore<B
         // Large read — fetch full block via SingleFlight, then cache it.
         tracing::Span::current().record("strategy", "coalesced_full");
         let client = &self.client;
-        let compression = self.config.compression;
         let object_metrics = self.object_metrics.clone();
 
         let block_data =
@@ -932,13 +949,11 @@ impl<B: ObjectBackend + Send + Sync + 'static> BlockStore for ObjectBlockStore<B
                             return Ok(Bytes::new());
                         }
                     };
-                    // Decompress if compression is enabled (auto-detects from header)
-                    let decompressed = if !matches!(compression, Compression::None) {
-                        decompress_bytes(raw_bytes)
-                            .map_err(|e| anyhow::anyhow!("block decompression failed: {e}"))?
-                    } else {
-                        raw_bytes
-                    };
+                    // The object header is authoritative. This covers blocks
+                    // written by a previous mount with LZ4/Zstd even when the
+                    // current mount is configured to write uncompressed data.
+                    let decompressed = decompress_bytes(raw_bytes)
+                        .map_err(|e| anyhow::anyhow!("block decompression failed: {e}"))?;
                     Ok::<_, anyhow::Error>(decompressed)
                 })
                 .await
@@ -1246,8 +1261,8 @@ mod tests {
             "Range miss should schedule one background full-block prefetch"
         );
         assert_eq!(
-            stats.get_object_range_calls, 8,
-            "Non-zero 512KB read should fetch 8 pages (8 x 64KB range reads)"
+            stats.get_object_range_calls, 9,
+            "Non-zero 512KB read should probe the format then fetch 8 pages"
         );
         for _ in 0..100 {
             if backend.get_stats().get_object_calls >= 1 {
@@ -1294,8 +1309,8 @@ mod tests {
             .expect("ObjectBlockStore exposes object metrics")
             .snapshot();
         assert_eq!(
-            disabled_stats.get_object_range_calls, 8,
-            "Disabled background prefetch should still serve the request via page ranges"
+            disabled_stats.get_object_range_calls, 9,
+            "Disabled background prefetch should probe the format then serve page ranges"
         );
         assert_eq!(
             disabled_stats.get_object_calls, 0,
@@ -1464,6 +1479,114 @@ mod tests {
             "subsequent reads should hit block_cache without range GETs"
         );
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_remount_without_compression_decodes_persisted_compressed_block()
+    -> Result<(), Box<dyn std::error::Error>> {
+        use crate::cadapter::client::{ObjectBackend, ObjectClient};
+        use crate::chunk::compress::{Compression, compress};
+        use async_trait::async_trait;
+        use std::{
+            collections::HashMap,
+            sync::{Arc, Mutex},
+        };
+
+        #[derive(Clone, Default)]
+        struct MockBackend {
+            data: Arc<Mutex<HashMap<String, Vec<u8>>>>,
+            full_gets: Arc<Mutex<usize>>,
+            range_gets: Arc<Mutex<usize>>,
+        }
+
+        #[async_trait]
+        impl ObjectBackend for MockBackend {
+            async fn put_object(&self, key: &str, data: &[u8]) -> anyhow::Result<()> {
+                self.data
+                    .lock()
+                    .unwrap()
+                    .insert(key.to_string(), data.to_vec());
+                Ok(())
+            }
+
+            async fn get_object(&self, key: &str) -> anyhow::Result<Option<Vec<u8>>> {
+                *self.full_gets.lock().unwrap() += 1;
+                Ok(self.data.lock().unwrap().get(key).cloned())
+            }
+
+            async fn get_object_range(
+                &self,
+                key: &str,
+                offset: u64,
+                buf: &mut [u8],
+            ) -> anyhow::Result<usize> {
+                *self.range_gets.lock().unwrap() += 1;
+                let objects = self.data.lock().unwrap();
+                let Some(data) = objects.get(key) else {
+                    return Ok(0);
+                };
+                let offset = offset as usize;
+                if offset >= data.len() {
+                    return Ok(0);
+                }
+                let len = (data.len() - offset).min(buf.len());
+                buf[..len].copy_from_slice(&data[offset..offset + len]);
+                Ok(len)
+            }
+
+            async fn get_etag(&self, _key: &str) -> anyhow::Result<String> {
+                Ok("test-etag".to_string())
+            }
+
+            async fn delete_object(&self, key: &str) -> anyhow::Result<()> {
+                self.data.lock().unwrap().remove(key);
+                Ok(())
+            }
+        }
+
+        let backend = MockBackend::default();
+        let raw: Vec<u8> = (0..(256 * 1024)).map(|index| (index % 16) as u8).collect();
+        let stored = compress(&raw, Compression::Lz4).into_owned();
+        assert!(stored.len() < raw.len());
+        backend
+            .data
+            .lock()
+            .unwrap()
+            .insert("chunks/17/0".to_string(), stored);
+
+        // Simulate a remount whose current write setting is none after this
+        // block was committed with LZ4.
+        let cache_dir = tempfile::tempdir()?;
+        let store = ObjectBlockStore::new_with_configs_async(
+            ObjectClient::new(backend.clone()),
+            ChunksCacheConfig::with_budgets(
+                16 * 1024 * 1024,
+                16 * 1024 * 1024,
+                cache_dir.path().to_path_buf(),
+            ),
+            BlockStoreConfig {
+                block_size: raw.len(),
+                compression: Compression::None,
+                range_background_prefetch: false,
+                ..Default::default()
+            },
+        )
+        .await?;
+
+        let offset = 16 * 1024;
+        let mut actual = vec![0xa5; 4096];
+        store
+            .read_range((17, 0), offset as u64, &mut actual)
+            .await?;
+
+        assert_eq!(actual, raw[offset..offset + actual.len()]);
+        assert_eq!(*backend.full_gets.lock().unwrap(), 1);
+        assert_eq!(
+            *backend.range_gets.lock().unwrap(),
+            1,
+            "one header probe must precede the safe full-object read"
+        );
         Ok(())
     }
 

--- a/src/chunk/store.rs
+++ b/src/chunk/store.rs
@@ -15,7 +15,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures::executor::block_on;
 use hex::encode;
-use moka::{Entry, ops::compute::Op};
+use moka::{Entry, future::Cache, ops::compute::Op};
 use sha2::{Digest, Sha256};
 use std::{
     collections::HashMap,
@@ -294,6 +294,11 @@ pub struct ObjectBlockStore<B: ObjectBackend> {
     page_cache: ReadPageCache,
     /// SingleFlight controller for coalescing concurrent page-cache misses.
     page_flight: SingleFlight<PageKey, Bytes>,
+    /// Per-object encoding classification. Chunk object keys are immutable, so
+    /// a classification remains valid for the lifetime of this store.
+    format_cache: Cache<String, bool>,
+    /// Coalesces concurrent header probes for an uncached object format.
+    format_flight: SingleFlight<String, bool>,
     /// SingleFlight controller for coalescing concurrent reads to the same block
     /// Thread-safe and shared across the store lifetime so concurrent requests can coalesce.
     read_flight: Arc<SingleFlight<BlockKey, Bytes>>,
@@ -398,6 +403,8 @@ impl<B: ObjectBackend + 'static> ObjectBlockStore<B> {
             block_cache,
             page_cache,
             page_flight: SingleFlight::new(),
+            format_cache: Cache::new(4096),
+            format_flight: SingleFlight::new(),
             read_flight: Arc::new(SingleFlight::new()),
             range_prefetch_limit: Arc::new(Semaphore::new(8)),
             config,
@@ -445,6 +452,8 @@ impl<B: ObjectBackend + 'static> ObjectBlockStore<B> {
             block_cache,
             page_cache,
             page_flight: SingleFlight::new(),
+            format_cache: Cache::new(4096),
+            format_flight: SingleFlight::new(),
             read_flight: Arc::new(SingleFlight::new()),
             range_prefetch_limit: Arc::new(Semaphore::new(8)),
             config: store_config,
@@ -470,6 +479,8 @@ impl<B: ObjectBackend + 'static> ObjectBlockStore<B> {
             block_cache,
             page_cache,
             page_flight: SingleFlight::new(),
+            format_cache: Cache::new(4096),
+            format_flight: SingleFlight::new(),
             read_flight: Arc::new(SingleFlight::new()),
             range_prefetch_limit: Arc::new(Semaphore::new(8)),
             config: store_config,
@@ -495,19 +506,35 @@ impl<B: ObjectBackend + 'static> ObjectBlockStore<B> {
     /// mount, so inspect its self-describing header rather than trusting the
     /// mount configuration.
     async fn persisted_block_is_raw(&self, key: &str) -> anyhow::Result<bool> {
+        if let Some(is_raw) = self.format_cache.get(key).await {
+            return Ok(is_raw);
+        }
+
+        let key = key.to_string();
+        let client = self.client.clone();
+        let bandwidth = self.bandwidth.clone();
+        let object_metrics = self.object_metrics.clone();
+        let format_cache = self.format_cache.clone();
         let mut header = [0u8; 4];
-        self.bandwidth.acquire_download(header.len()).await;
-        let started = Instant::now();
-        let read_len = self
-            .client
-            .get_object_range(key, 0, &mut header)
+        let is_raw = self
+            .format_flight
+            .execute(key.clone(), || async move {
+                bandwidth.acquire_download(header.len()).await;
+                let started = Instant::now();
+                let read_len = client
+                    .get_object_range(&key, 0, &mut header)
+                    .await
+                    .map_err(|error| {
+                        anyhow::anyhow!("object store header read failed: {key}, {error:?}")
+                    })?;
+                object_metrics.record_get(read_len as u64, started.elapsed());
+                let is_raw = !has_compression_header(&header[..read_len]);
+                format_cache.insert(key, is_raw).await;
+                Ok::<bool, anyhow::Error>(is_raw)
+            })
             .await
-            .map_err(|error| {
-                anyhow::anyhow!("object store header read failed: {key}, {error:?}")
-            })?;
-        self.object_metrics
-            .record_get(read_len as u64, started.elapsed());
-        Ok(!has_compression_header(&header[..read_len]))
+            .map_err(|error| anyhow::anyhow!("object format probe failed: {error}"))?;
+        Ok(*is_raw)
     }
 
     async fn populate_write_cache_after_upload(&self, key: String, data: Bytes) {
@@ -802,11 +829,15 @@ impl<B: ObjectBackend + Send + Sync + 'static> BlockStore for ObjectBlockStore<B
         }
 
         let range_size_threshold = self.config.range_size_threshold();
-        let can_read_object_ranges = offset > 0
-            && len <= range_size_threshold
-            && self.persisted_block_is_raw(&key_str).await?;
+        // Object ranges can only be used when the current mount is configured
+        // without compression.  An existing full-block read takes precedence:
+        // it already owns the complete decoded block, so avoid even a format
+        // probe before joining it.
+        let can_try_object_ranges = matches!(self.config.compression, Compression::None)
+            && offset > 0
+            && len <= range_size_threshold;
 
-        if can_read_object_ranges {
+        if can_try_object_ranges {
             if let Some(block_data) = self.read_flight.try_piggyback(&key).await {
                 tracing::Span::current().record("strategy", "piggyback_full");
                 self.object_metrics.record_read_piggyback_full();
@@ -824,7 +855,16 @@ impl<B: ObjectBackend + Send + Sync + 'static> BlockStore for ObjectBlockStore<B
                 tracing::Span::current().record("read_len", copy_len);
                 return Ok(());
             }
+        }
 
+        // A chunk object is immutable after commit, and the classification is
+        // cached and coalesced by `persisted_block_is_raw`.  Compressed legacy
+        // objects fall through to the full-block path, which decodes from the
+        // persisted header instead of relying on this mount's configuration.
+        let can_read_object_ranges =
+            can_try_object_ranges && self.persisted_block_is_raw(&key_str).await?;
+
+        if can_read_object_ranges {
             // Small range read — serve via page-granularity cache so that
             // repeated small reads within the same 64KB page avoid a network
             // round-trip.
@@ -2121,8 +2161,8 @@ mod tests {
 
         assert_eq!(
             *backend.get_object_range_calls.lock().unwrap(),
-            1,
-            "concurrent small reads for one page should share one range GET"
+            2,
+            "concurrent small reads should share one format probe and one page range GET"
         );
 
         for _ in 0..100 {
@@ -2387,7 +2427,11 @@ mod tests {
                 .map(|i| (i % 251) as u8)
                 .collect::<Vec<_>>()
         );
-        assert_eq!(*backend.get_object_range_calls.lock().unwrap(), 1);
+        assert_eq!(
+            *backend.get_object_range_calls.lock().unwrap(),
+            2,
+            "one format probe and one page range GET are expected"
+        );
 
         for _ in 0..100 {
             if *backend.get_object_calls.lock().unwrap() >= 1 {
@@ -2660,7 +2704,11 @@ mod tests {
             })
             .collect::<Vec<_>>();
         future::try_join_all(reads).await?;
-        assert_eq!(backend.get_object_range_calls.load(Ordering::SeqCst), 2);
+        assert_eq!(
+            backend.get_object_range_calls.load(Ordering::SeqCst),
+            4,
+            "each immutable object needs one cached format probe and one page range GET"
+        );
 
         for _ in 0..100 {
             if backend.get_object_calls.load(Ordering::SeqCst) >= 1 {
@@ -2788,7 +2836,11 @@ mod tests {
 
         let mut buf = vec![0u8; 4096];
         store.read_range((92, 0), 1024, &mut buf).await?;
-        assert_eq!(backend.get_object_range_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            backend.get_object_range_calls.load(Ordering::SeqCst),
+            2,
+            "one format probe and one page range GET are expected"
+        );
 
         for _ in 0..20 {
             let snapshot = store

--- a/src/chunk/store.rs
+++ b/src/chunk/store.rs
@@ -1682,8 +1682,8 @@ mod tests {
             "Concurrent reads should coalesce to 1 call"
         );
         assert_eq!(
-            stats.get_object_range_calls, 0,
-            "Coalesced path should not fall back to range reads",
+            stats.get_object_range_calls, 1,
+            "Concurrent full reads should share one versioned-layout probe",
         );
 
         Ok(())
@@ -2251,7 +2251,10 @@ mod tests {
         store.write_fresh_range((10, 0), 0, &uploaded).await?;
         let snapshot = metrics.snapshot();
         assert_eq!(snapshot.put_ops, 1);
-        assert_eq!(snapshot.put_bytes, uploaded.len() as u64);
+        assert_eq!(
+            snapshot.put_bytes,
+            uploaded.len() as u64 + PERSISTED_HEADER_LEN as u64
+        );
         assert_eq!(snapshot.get_ops, 0);
 
         let full_block = vec![7u8; 64 * 1024];
@@ -2640,8 +2643,8 @@ mod tests {
         assert_eq!(*backend.get_object_calls.lock().unwrap(), 1);
         assert_eq!(
             *backend.get_object_range_calls.lock().unwrap(),
-            0,
-            "small read should join the in-flight full-block read instead of issuing range GET"
+            1,
+            "the full read should issue one shared layout probe; the small read should piggyback without another range GET"
         );
 
         Ok(())

--- a/src/chunk/store.rs
+++ b/src/chunk/store.rs
@@ -2274,10 +2274,7 @@ mod tests {
             snapshot.get_ops, 2,
             "a legacy full read probes the versioned namespace before fetching legacy data"
         );
-        assert_eq!(
-            snapshot.get_bytes,
-            full_block.len() as u64 + PERSISTED_HEADER_LEN as u64
-        );
+        assert_eq!(snapshot.get_bytes, full_block.len() as u64);
         assert_eq!(snapshot.put_ops, 1);
         assert_eq!(snapshot.del_ops, 1);
         assert_eq!(snapshot.read_full_gets, 1);

--- a/src/chunk/store.rs
+++ b/src/chunk/store.rs
@@ -995,12 +995,21 @@ impl<B: ObjectBackend + Send + Sync + 'static> BlockStore for ObjectBlockStore<B
             }
         }
 
-        let layout = self.resolve_object_layout(key).await?;
-        let object_key = Self::object_key_for(key, layout);
-        let range_base = Self::range_base_offset(layout, self.config.compression);
-        let can_read_object_ranges = can_try_object_ranges && range_base.is_some();
+        // Only small reads need a layout decision before joining the full-read
+        // flight. Keeping the full-read probe inside that flight lets a
+        // concurrent small read piggyback instead of issuing its own probe.
+        let layout = if can_try_object_ranges {
+            Some(self.resolve_object_layout(key).await?)
+        } else {
+            None
+        };
+        let range_base =
+            layout.and_then(|layout| Self::range_base_offset(layout, self.config.compression));
+        let can_read_object_ranges = range_base.is_some();
 
         if can_read_object_ranges {
+            let layout = layout.expect("range path resolved an object layout");
+            let object_key = Self::object_key_for(key, layout);
             // Small range read — serve via page-granularity cache so that
             // repeated small reads within the same 64KB page avoid a network
             // round-trip.
@@ -1108,6 +1117,11 @@ impl<B: ObjectBackend + Send + Sync + 'static> BlockStore for ObjectBlockStore<B
         let block_data =
             self.read_flight
                 .execute(key, || async move {
+                    let layout = match layout {
+                        Some(layout) => layout,
+                        None => self.resolve_object_layout(key).await?,
+                    };
+                    let object_key = Self::object_key_for(key, layout);
                     self.bandwidth
                         .acquire_download(self.config.block_size)
                         .await;
@@ -1643,8 +1657,8 @@ mod tests {
         let stats = backend.get_stats();
         assert_eq!(stats.get_object_calls, 1, "Large read should use full read");
         assert_eq!(
-            stats.get_object_range_calls, 0,
-            "Large read should not use range read"
+            stats.get_object_range_calls, 1,
+            "Large read should probe the versioned layout before its full read"
         );
 
         // Concurrent large reads for a DIFFERENT (uncached) block should
@@ -2257,7 +2271,10 @@ mod tests {
             snapshot.get_ops, 2,
             "a legacy full read probes the versioned namespace before fetching legacy data"
         );
-        assert_eq!(snapshot.get_bytes, full_block.len() as u64);
+        assert_eq!(
+            snapshot.get_bytes,
+            full_block.len() as u64 + PERSISTED_HEADER_LEN as u64
+        );
         assert_eq!(snapshot.put_ops, 1);
         assert_eq!(snapshot.del_ops, 1);
         assert_eq!(snapshot.read_full_gets, 1);

--- a/src/chunk/store.rs
+++ b/src/chunk/store.rs
@@ -1,7 +1,10 @@
 //! Storage backends: asynchronous block-level IO traits and in-memory implementations.
 
 use crate::chunk::bandwidth::BandwidthLimiter;
-use crate::chunk::compress::{Compression, compress, decompress_bytes, has_compression_header};
+use crate::chunk::compress::{
+    Compression, PERSISTED_HEADER_LEN, PersistedHeader, decompress_bytes, decompress_framed_bytes,
+    encode_persisted_block, parse_persisted_header,
+};
 use crate::chunk::page_cache::{PageKey, ReadPageCache};
 use crate::chunk::singleflight::SingleFlight;
 use crate::utils::NumCastExt;
@@ -284,7 +287,21 @@ impl BlockStore for InMemoryBlockStore {
     }
 }
 
-/// BlockStore backed by cadapter::client (key space `chunks/{chunk_id}/{block_index}`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ObjectLayout {
+    /// Versioned objects are self-describing because their namespace commits
+    /// them to the framed layout.
+    Versioned(Compression),
+    /// Legacy objects have no unambiguous encoding marker. Their decoding is
+    /// governed by the mount's legacy compatibility policy.
+    Legacy,
+}
+
+/// BlockStore backed by cadapter::client.
+///
+/// New blocks use `chunks-v2/{chunk_id}/{block_index}` and a mandatory framed
+/// payload. Existing `chunks/{chunk_id}/{block_index}` objects remain readable
+/// through an explicit legacy fallback.
 pub struct ObjectBlockStore<B: ObjectBackend> {
     client: Arc<ObjectClient<B>>,
     block_cache: ChunksCache,
@@ -294,11 +311,11 @@ pub struct ObjectBlockStore<B: ObjectBackend> {
     page_cache: ReadPageCache,
     /// SingleFlight controller for coalescing concurrent page-cache misses.
     page_flight: SingleFlight<PageKey, Bytes>,
-    /// Per-object encoding classification. Chunk object keys are immutable, so
-    /// a classification remains valid for the lifetime of this store.
-    format_cache: Cache<String, bool>,
-    /// Coalesces concurrent header probes for an uncached object format.
-    format_flight: SingleFlight<String, bool>,
+    /// Per-object layout classification. Chunk object keys are immutable, so a
+    /// classification remains valid for the lifetime of this store.
+    format_cache: Cache<BlockKey, ObjectLayout>,
+    /// Coalesces concurrent versioned-layout probes for an uncached object.
+    format_flight: SingleFlight<BlockKey, ObjectLayout>,
     /// SingleFlight controller for coalescing concurrent reads to the same block
     /// Thread-safe and shared across the store lifetime so concurrent requests can coalesce.
     read_flight: Arc<SingleFlight<BlockKey, Bytes>>,
@@ -501,40 +518,116 @@ impl<B: ObjectBackend + 'static> ObjectBlockStore<B> {
         format!("chunks/{chunk_id}/{block_index}")
     }
 
-    /// Range GET offsets are valid only for raw objects. A block may have
-    /// been written with a different compression setting than the current
-    /// mount, so inspect its self-describing header rather than trusting the
-    /// mount configuration.
-    async fn persisted_block_is_raw(&self, key: &str) -> anyhow::Result<bool> {
-        if let Some(is_raw) = self.format_cache.get(key).await {
-            return Ok(is_raw);
+    fn versioned_key_for(key: BlockKey) -> String {
+        let (chunk_id, block_index) = key;
+        format!("chunks-v2/{chunk_id}/{block_index}")
+    }
+
+    fn object_key_for(key: BlockKey, layout: ObjectLayout) -> String {
+        match layout {
+            ObjectLayout::Versioned(_) => Self::versioned_key_for(key),
+            ObjectLayout::Legacy => Self::key_for(key),
+        }
+    }
+
+    /// Resolve the object's namespace and, for versioned objects, its encoding.
+    ///
+    /// A non-empty `chunks-v2` object is required to contain a complete valid
+    /// frame. Only a zero-byte read is treated as "not versioned" and allowed
+    /// to fall back to the legacy namespace. This avoids classifying short or
+    /// malformed frames as raw data.
+    async fn resolve_object_layout(&self, key: BlockKey) -> anyhow::Result<ObjectLayout> {
+        if let Some(layout) = self.format_cache.get(&key).await {
+            return Ok(layout);
         }
 
-        let key = key.to_string();
+        let versioned_key = Self::versioned_key_for(key);
         let client = self.client.clone();
         let bandwidth = self.bandwidth.clone();
         let object_metrics = self.object_metrics.clone();
         let format_cache = self.format_cache.clone();
-        let mut header = [0u8; 4];
-        let is_raw = self
+        let layout = self
             .format_flight
-            .execute(key.clone(), || async move {
-                bandwidth.acquire_download(header.len()).await;
-                let started = Instant::now();
-                let read_len = client
-                    .get_object_range(&key, 0, &mut header)
-                    .await
-                    .map_err(|error| {
-                        anyhow::anyhow!("object store header read failed: {key}, {error:?}")
-                    })?;
-                object_metrics.record_get(read_len as u64, started.elapsed());
-                let is_raw = !has_compression_header(&header[..read_len]);
-                format_cache.insert(key, is_raw).await;
-                Ok::<bool, anyhow::Error>(is_raw)
+            .execute(key, || async move {
+                let mut header = [0u8; PERSISTED_HEADER_LEN];
+                let mut read = 0;
+
+                loop {
+                    bandwidth
+                        .acquire_download(PERSISTED_HEADER_LEN.saturating_sub(read))
+                        .await;
+                    let started = Instant::now();
+                    let read_len = client
+                        .get_object_range(&versioned_key, read as u64, &mut header[read..])
+                        .await
+                        .map_err(|error| {
+                            anyhow::anyhow!(
+                                "object store versioned header read failed: {versioned_key}, {error:?}"
+                            )
+                        })?;
+                    object_metrics.record_get(read_len as u64, started.elapsed());
+
+                    if read_len == 0 {
+                        if read == 0 {
+                            let layout = ObjectLayout::Legacy;
+                            format_cache.insert(key, layout).await;
+                            return Ok::<ObjectLayout, anyhow::Error>(layout);
+                        }
+                        anyhow::bail!(
+                            "truncated versioned block header for {versioned_key}: read {read} of {PERSISTED_HEADER_LEN} bytes"
+                        );
+                    }
+
+                    read += read_len;
+                    if read == PERSISTED_HEADER_LEN {
+                        break;
+                    }
+                }
+
+                let compression = match parse_persisted_header(&header) {
+                    PersistedHeader::Framed(compression) => compression,
+                    PersistedHeader::Incomplete => unreachable!("header buffer is complete"),
+                    PersistedHeader::NotFramed => {
+                        anyhow::bail!("missing versioned block header for {versioned_key}")
+                    }
+                    PersistedHeader::Invalid => {
+                        anyhow::bail!("unsupported versioned block header for {versioned_key}")
+                    }
+                };
+                let layout = ObjectLayout::Versioned(compression);
+                format_cache.insert(key, layout).await;
+                Ok(layout)
             })
             .await
-            .map_err(|error| anyhow::anyhow!("object format probe failed: {error}"))?;
-        Ok(*is_raw)
+            .map_err(|error| anyhow::anyhow!("object layout probe failed: {error}"))?;
+        Ok(*layout)
+    }
+
+    fn decode_object(
+        layout: ObjectLayout,
+        current_compression: Compression,
+        bytes: Bytes,
+    ) -> anyhow::Result<Bytes> {
+        match layout {
+            ObjectLayout::Versioned(_) => decompress_framed_bytes(bytes),
+            // Legacy `None` objects were written as arbitrary raw bytes. Do
+            // not inspect a magic-like prefix, since that would corrupt valid
+            // user data such as `SF\0\0payload`.
+            ObjectLayout::Legacy if matches!(current_compression, Compression::None) => Ok(bytes),
+            // Legacy compressed mounts retain the historical compatibility
+            // convention: valid legacy frames are decoded and non-frame bytes
+            // remain raw.
+            ObjectLayout::Legacy => decompress_bytes(bytes),
+        }
+    }
+
+    fn range_base_offset(layout: ObjectLayout, current_compression: Compression) -> Option<u64> {
+        match layout {
+            ObjectLayout::Versioned(Compression::None) => Some(PERSISTED_HEADER_LEN as u64),
+            ObjectLayout::Versioned(_) => None,
+            ObjectLayout::Legacy if matches!(current_compression, Compression::None) => Some(0),
+            ObjectLayout::Legacy => None,
+        }
     }
 
     async fn populate_write_cache_after_upload(&self, key: String, data: Bytes) {
@@ -606,7 +699,13 @@ impl<B: ObjectBackend + 'static> ObjectBlockStore<B> {
         true
     }
 
-    fn prefetch_full_block_background(&self, key: BlockKey, key_str: String) {
+    fn prefetch_full_block_background(
+        &self,
+        key: BlockKey,
+        cache_key: String,
+        object_key: String,
+        layout: ObjectLayout,
+    ) {
         self.object_metrics.record_read_background_prefetch();
         let cache = self.block_cache.clone();
         let client = self.client.clone();
@@ -614,10 +713,11 @@ impl<B: ObjectBackend + 'static> ObjectBlockStore<B> {
         let prefetch_limit = self.range_prefetch_limit.clone();
         let bandwidth = self.bandwidth.clone();
         let block_size = self.config.block_size;
+        let compression = self.config.compression;
         let object_metrics = self.object_metrics.clone();
 
         tokio::spawn(async move {
-            if cache.get(&key_str).await.is_some() {
+            if cache.get(&cache_key).await.is_some() {
                 return;
             }
 
@@ -625,7 +725,7 @@ impl<B: ObjectBackend + 'static> ObjectBlockStore<B> {
                 object_metrics.record_read_background_prefetch_dropped();
                 return;
             };
-            if cache.get(&key_str).await.is_some() {
+            if cache.get(&cache_key).await.is_some() {
                 return;
             }
 
@@ -633,8 +733,8 @@ impl<B: ObjectBackend + 'static> ObjectBlockStore<B> {
                 .execute(key, || async move {
                     bandwidth.acquire_download(block_size).await;
                     let started = Instant::now();
-                    let raw = client.get_object(&key_str).await.map_err(|e| {
-                        anyhow::anyhow!("object store get failed: {key_str}, {e:?}")
+                    let raw = client.get_object(&object_key).await.map_err(|e| {
+                        anyhow::anyhow!("object store get failed: {object_key}, {e:?}")
                     })?;
                     let raw_bytes = match raw {
                         Some(data) => {
@@ -646,10 +746,7 @@ impl<B: ObjectBackend + 'static> ObjectBlockStore<B> {
                             return Ok(Bytes::new());
                         }
                     };
-                    // Persisted blocks are self-describing. The compression
-                    // setting controls future writes, not how an existing
-                    // object must be decoded after a remount.
-                    let decompressed = decompress_bytes(raw_bytes)
+                    let decompressed = Self::decode_object(layout, compression, raw_bytes)
                         .map_err(|e| anyhow::anyhow!("block decompression failed: {e}"))?;
                     Ok::<_, anyhow::Error>(decompressed)
                 })
@@ -658,7 +755,7 @@ impl<B: ObjectBackend + 'static> ObjectBlockStore<B> {
             match block_data {
                 Ok(block_data) => {
                     cache
-                        .insert_opportunistic(Self::key_for(key), (*block_data).clone())
+                        .insert_opportunistic(cache_key, (*block_data).clone())
                         .await;
                 }
                 Err(err) => {
@@ -692,7 +789,8 @@ impl<B: ObjectBackend + Send + Sync + 'static> ObjectBlockStore<B> {
         chunks: Vec<Bytes>,
     ) -> anyhow::Result<u64> {
         let prepare_started = Instant::now();
-        let key_str = Self::key_for(key);
+        let cache_key = Self::key_for(key);
+        let object_key = Self::versioned_key_for(key);
         let total_len = chunks.iter().map(|c| c.len()).sum::<usize>();
         if total_len == 0 {
             return Ok(0);
@@ -706,13 +804,10 @@ impl<B: ObjectBackend + Send + Sync + 'static> ObjectBlockStore<B> {
         parts.extend(chunks);
 
         let cache_block = Self::concat_bytes(&parts);
-        let upload_bytes = if matches!(self.config.compression, Compression::None) {
-            cache_block.clone()
-        } else {
-            match compress(&cache_block, self.config.compression) {
-                std::borrow::Cow::Borrowed(_) => cache_block.clone(),
-                std::borrow::Cow::Owned(v) => Bytes::from(v),
-            }
+        let upload_bytes = encode_persisted_block(&cache_block, self.config.compression);
+        let stored_compression = match parse_persisted_header(upload_bytes.as_ref()) {
+            PersistedHeader::Framed(compression) => compression,
+            _ => unreachable!("newly encoded persisted blocks are always framed"),
         };
         let upload_len = upload_bytes.len();
         self.bandwidth.acquire_upload(upload_len).await;
@@ -721,17 +816,20 @@ impl<B: ObjectBackend + Send + Sync + 'static> ObjectBlockStore<B> {
 
         let started = Instant::now();
         self.client
-            .put_object_vectored(&key_str, vec![upload_bytes])
+            .put_object_vectored(&object_key, vec![upload_bytes])
             .await
-            .map_err(|e| anyhow::anyhow!("object store put failed: {key_str}, {e:?}"))?;
+            .map_err(|e| anyhow::anyhow!("object store put failed: {object_key}, {e:?}"))?;
         self.object_metrics
             .record_put(upload_len as u64, started.elapsed());
+        self.format_cache
+            .insert(key, ObjectLayout::Versioned(stored_compression))
+            .await;
 
         if self.config.populate_write_cache_after_upload
             && cache_block.len() <= self.config.block_size
         {
             let cache_started = Instant::now();
-            self.populate_write_cache_after_upload(key_str, cache_block)
+            self.populate_write_cache_after_upload(cache_key, cache_block)
                 .await;
             self.object_metrics
                 .record_put_cache(cache_started.elapsed());
@@ -829,13 +927,7 @@ impl<B: ObjectBackend + Send + Sync + 'static> BlockStore for ObjectBlockStore<B
         }
 
         let range_size_threshold = self.config.range_size_threshold();
-        // Object ranges can only be used when the current mount is configured
-        // without compression.  An existing full-block read takes precedence:
-        // it already owns the complete decoded block, so avoid even a format
-        // probe before joining it.
-        let can_try_object_ranges = matches!(self.config.compression, Compression::None)
-            && offset > 0
-            && len <= range_size_threshold;
+        let can_try_object_ranges = offset > 0 && len > 0 && len <= range_size_threshold;
 
         if can_try_object_ranges
             && let Some(block_data) = self.read_flight.try_piggyback(&key).await
@@ -857,12 +949,56 @@ impl<B: ObjectBackend + Send + Sync + 'static> BlockStore for ObjectBlockStore<B
             return Ok(());
         }
 
-        // A chunk object is immutable after commit, and the classification is
-        // cached and coalesced by `persisted_block_is_raw`.  Compressed legacy
-        // objects fall through to the full-block path, which decodes from the
-        // persisted header instead of relying on this mount's configuration.
-        let can_read_object_ranges =
-            can_try_object_ranges && self.persisted_block_is_raw(&key_str).await?;
+        // Serve fully cached pages before resolving the remote object layout.
+        // The format cache has an independent eviction policy, so a page-cache
+        // hit must not become a network dependency when its format entry ages
+        // out.
+        if can_try_object_ranges {
+            let page_size = self.page_cache.page_size();
+            let start_page = offset as usize / page_size;
+            let end_page = (offset as usize + len - 1) / page_size;
+            let mut cached_pages = Vec::with_capacity(end_page - start_page + 1);
+            for page_idx in start_page..=end_page {
+                let cache_key: PageKey = (key.0, key.1, page_idx as u32);
+                let Some(page) = self.page_cache.get(&cache_key).await else {
+                    cached_pages.clear();
+                    break;
+                };
+                cached_pages.push(page);
+            }
+
+            if !cached_pages.is_empty() {
+                let mut pos = 0;
+                for (page_idx, page_data) in (start_page..=end_page).zip(cached_pages) {
+                    let page_start = page_idx * page_size;
+                    let copy_start = if page_idx == start_page {
+                        offset as usize - page_start
+                    } else {
+                        0
+                    };
+                    let copy_end = if page_idx == end_page {
+                        (offset as usize + len).saturating_sub(page_start)
+                    } else {
+                        page_data.len()
+                    }
+                    .min(page_data.len());
+                    if copy_end > copy_start {
+                        let copy_len = copy_end - copy_start;
+                        buf[pos..pos + copy_len].copy_from_slice(&page_data[copy_start..copy_end]);
+                        pos += copy_len;
+                    }
+                }
+                tracing::Span::current().record("strategy", "page_cache_hit");
+                tracing::Span::current().record("read_len", pos);
+                self.object_metrics.record_read_page_cache_hit();
+                return Ok(());
+            }
+        }
+
+        let layout = self.resolve_object_layout(key).await?;
+        let object_key = Self::object_key_for(key, layout);
+        let range_base = Self::range_base_offset(layout, self.config.compression);
+        let can_read_object_ranges = can_try_object_ranges && range_base.is_some();
 
         if can_read_object_ranges {
             // Small range read — serve via page-granularity cache so that
@@ -892,9 +1028,10 @@ impl<B: ObjectBackend + Send + Sync + 'static> BlockStore for ObjectBlockStore<B
                 } else {
                     tracing::Span::current().record("strategy", "page_cache_miss");
                     range_missed = true;
-                    let range_offset = page_start as u64;
+                    let range_offset =
+                        range_base.expect("range path has a base offset") + page_start as u64;
                     let range_len = page_end - page_start;
-                    let page_key_str = key_str.clone();
+                    let page_key_str = object_key.clone();
                     let page_object_metrics = object_metrics.clone();
                     let page = self
                         .page_flight
@@ -957,7 +1094,7 @@ impl<B: ObjectBackend + Send + Sync + 'static> BlockStore for ObjectBlockStore<B
                 && self.config.range_background_prefetch
                 && !self.try_promote_page_cache_to_block_cache(key).await
             {
-                self.prefetch_full_block_background(key, key_str);
+                self.prefetch_full_block_background(key, key_str, object_key, layout);
             }
             return Ok(());
         }
@@ -966,17 +1103,17 @@ impl<B: ObjectBackend + Send + Sync + 'static> BlockStore for ObjectBlockStore<B
         tracing::Span::current().record("strategy", "coalesced_full");
         let client = &self.client;
         let object_metrics = self.object_metrics.clone();
+        let compression = self.config.compression;
 
         let block_data =
             self.read_flight
                 .execute(key, || async move {
-                    let key_str = Self::key_for(key);
                     self.bandwidth
                         .acquire_download(self.config.block_size)
                         .await;
                     let started = Instant::now();
-                    let raw = client.get_object(&key_str).await.map_err(|e| {
-                        anyhow::anyhow!("object store get failed: {key_str}, {e:?}")
+                    let raw = client.get_object(&object_key).await.map_err(|e| {
+                        anyhow::anyhow!("object store get failed: {object_key}, {e:?}")
                     })?;
                     object_metrics.record_read_full_get();
                     let raw_bytes = match raw {
@@ -989,10 +1126,7 @@ impl<B: ObjectBackend + Send + Sync + 'static> BlockStore for ObjectBlockStore<B
                             return Ok(Bytes::new());
                         }
                     };
-                    // The object header is authoritative. This covers blocks
-                    // written by a previous mount with LZ4/Zstd even when the
-                    // current mount is configured to write uncompressed data.
-                    let decompressed = decompress_bytes(raw_bytes)
+                    let decompressed = Self::decode_object(layout, compression, raw_bytes)
                         .map_err(|e| anyhow::anyhow!("block decompression failed: {e}"))?;
                     Ok::<_, anyhow::Error>(decompressed)
                 })
@@ -1025,11 +1159,20 @@ impl<B: ObjectBackend + Send + Sync + 'static> BlockStore for ObjectBlockStore<B
         let start = block_index;
         let end = start + block_count.as_u32();
         for i in start..end {
-            let key_str = Self::key_for((chunk_id, i));
+            let block_key = (chunk_id, i);
+            let versioned_key = Self::versioned_key_for(block_key);
             self.client
-                .delete_object(&key_str)
+                .delete_object(&versioned_key)
                 .await
-                .map_err(|e| anyhow::anyhow!("object store delete failed: {key_str}, {e:?}"))?;
+                .map_err(|e| {
+                    anyhow::anyhow!("object store delete failed: {versioned_key}, {e:?}")
+                })?;
+            let legacy_key = Self::key_for(block_key);
+            self.client
+                .delete_object(&legacy_key)
+                .await
+                .map_err(|e| anyhow::anyhow!("object store delete failed: {legacy_key}, {e:?}"))?;
+            self.format_cache.invalidate(&block_key).await;
             self.object_metrics.record_delete();
         }
         Ok(())
@@ -1087,6 +1230,136 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(out, data);
+    }
+
+    #[tokio::test]
+    async fn test_versioned_raw_magic_survives_none_remount() {
+        let object_dir = tempfile::tempdir().unwrap();
+        let writer_cache_dir = tempfile::tempdir().unwrap();
+        let reader_cache_dir = tempfile::tempdir().unwrap();
+        let raw = Bytes::from_static(b"SF\x00\x00payload that must remain byte-for-byte intact");
+        let config = BlockStoreConfig {
+            block_size: raw.len(),
+            compression: Compression::None,
+            range_background_prefetch: false,
+            ..Default::default()
+        };
+
+        let writer = ObjectBlockStore::new_with_configs_async(
+            ObjectClient::new(LocalFsBackend::new(object_dir.path())),
+            ChunksCacheConfig::with_budgets(
+                1024 * 1024,
+                1024 * 1024,
+                writer_cache_dir.path().to_path_buf(),
+            ),
+            config.clone(),
+        )
+        .await
+        .unwrap();
+        writer.write_fresh_range((314, 0), 0, &raw).await.unwrap();
+
+        let reader = ObjectBlockStore::new_with_configs_async(
+            ObjectClient::new(LocalFsBackend::new(object_dir.path())),
+            ChunksCacheConfig::with_budgets(
+                1024 * 1024,
+                1024 * 1024,
+                reader_cache_dir.path().to_path_buf(),
+            ),
+            config,
+        )
+        .await
+        .unwrap();
+        let mut actual = vec![0u8; raw.len()];
+        reader.read_range((314, 0), 0, &mut actual).await.unwrap();
+
+        assert_eq!(actual, raw);
+        assert!(object_dir.path().join("chunks-v2/314/0").exists());
+        assert!(!object_dir.path().join("chunks/314/0").exists());
+    }
+
+    #[tokio::test]
+    async fn test_legacy_raw_magic_survives_none_read() {
+        let object_dir = tempfile::tempdir().unwrap();
+        let cache_dir = tempfile::tempdir().unwrap();
+        let raw = b"SF\x00\x00legacy bytes must remain byte-for-byte intact";
+        let legacy_path = object_dir.path().join("chunks/316/0");
+        tokio::fs::create_dir_all(legacy_path.parent().unwrap())
+            .await
+            .unwrap();
+        tokio::fs::write(&legacy_path, raw).await.unwrap();
+
+        let store = ObjectBlockStore::new_with_configs_async(
+            ObjectClient::new(LocalFsBackend::new(object_dir.path())),
+            ChunksCacheConfig::with_budgets(
+                1024 * 1024,
+                1024 * 1024,
+                cache_dir.path().to_path_buf(),
+            ),
+            BlockStoreConfig {
+                block_size: raw.len(),
+                compression: Compression::None,
+                range_background_prefetch: false,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        let mut actual = vec![0u8; raw.len()];
+        store.read_range((316, 0), 0, &mut actual).await.unwrap();
+        assert_eq!(actual, raw);
+    }
+
+    #[tokio::test]
+    async fn test_page_cache_hit_does_not_reprobe_evicted_layout() {
+        let object_dir = tempfile::tempdir().unwrap();
+        let writer_cache_dir = tempfile::tempdir().unwrap();
+        let reader_cache_dir = tempfile::tempdir().unwrap();
+        let raw = Bytes::from_static(b"SF\x00\x00page-cache-must-not-need-the-object-store");
+        let config = BlockStoreConfig {
+            block_size: raw.len(),
+            range_read_threshold: 1.0,
+            compression: Compression::None,
+            range_background_prefetch: false,
+            ..Default::default()
+        };
+
+        let writer = ObjectBlockStore::new_with_configs_async(
+            ObjectClient::new(LocalFsBackend::new(object_dir.path())),
+            ChunksCacheConfig::with_budgets(
+                1024 * 1024,
+                1024 * 1024,
+                writer_cache_dir.path().to_path_buf(),
+            ),
+            config.clone(),
+        )
+        .await
+        .unwrap();
+        writer.write_fresh_range((315, 0), 0, &raw).await.unwrap();
+
+        let reader = ObjectBlockStore::new_with_configs_async(
+            ObjectClient::new(LocalFsBackend::new(object_dir.path())),
+            ChunksCacheConfig::with_budgets(
+                1024 * 1024,
+                1024 * 1024,
+                reader_cache_dir.path().to_path_buf(),
+            ),
+            config,
+        )
+        .await
+        .unwrap();
+        let mut first = [0u8; 8];
+        reader.read_range((315, 0), 4, &mut first).await.unwrap();
+        assert_eq!(&first[..], &raw[4..12]);
+
+        tokio::fs::remove_file(object_dir.path().join("chunks-v2/315/0"))
+            .await
+            .unwrap();
+        reader.format_cache.invalidate(&(315, 0)).await;
+
+        let mut second = [0u8; 8];
+        reader.read_range((315, 0), 4, &mut second).await.unwrap();
+        assert_eq!(&second[..], &raw[4..12]);
     }
 
     #[tokio::test]
@@ -1258,8 +1531,8 @@ mod tests {
             "Small read at block start should use full block read"
         );
         assert_eq!(
-            stats.get_object_range_calls, 0,
-            "Small read at block start should not use range reads"
+            stats.get_object_range_calls, 1,
+            "A cold legacy block first probes the versioned namespace before its full read"
         );
 
         // Same read again should hit the full block cache.
@@ -1497,7 +1770,11 @@ mod tests {
 
         assert_eq!(out, vec![0u8; 512 * 1024]);
         assert_eq!(*backend.get_object_calls.lock().unwrap(), 1);
-        assert_eq!(*backend.get_object_range_calls.lock().unwrap(), 0);
+        assert_eq!(
+            *backend.get_object_range_calls.lock().unwrap(),
+            1,
+            "a versioned-namespace probe precedes the legacy full-object read"
+        );
         assert!(
             store.page_cache.get(&(7, 0, 32)).await.is_none(),
             "full-block reads already populate block_cache, so duplicating the decompressed block into page_cache only adds copy/cache overhead"
@@ -1526,7 +1803,7 @@ mod tests {
     async fn test_remount_without_compression_decodes_persisted_compressed_block()
     -> Result<(), Box<dyn std::error::Error>> {
         use crate::cadapter::client::{ObjectBackend, ObjectClient};
-        use crate::chunk::compress::{Compression, compress};
+        use crate::chunk::compress::Compression;
         use async_trait::async_trait;
         use std::{
             collections::HashMap,
@@ -1538,6 +1815,7 @@ mod tests {
             data: Arc<Mutex<HashMap<String, Vec<u8>>>>,
             full_gets: Arc<Mutex<usize>>,
             range_gets: Arc<Mutex<usize>>,
+            max_range_bytes: Arc<Mutex<Option<usize>>>,
         }
 
         #[async_trait]
@@ -1570,7 +1848,10 @@ mod tests {
                 if offset >= data.len() {
                     return Ok(0);
                 }
-                let len = (data.len() - offset).min(buf.len());
+                let mut len = (data.len() - offset).min(buf.len());
+                if let Some(max_range_bytes) = *self.max_range_bytes.lock().unwrap() {
+                    len = len.min(max_range_bytes);
+                }
                 buf[..len].copy_from_slice(&data[offset..offset + len]);
                 Ok(len)
             }
@@ -1587,13 +1868,28 @@ mod tests {
 
         let backend = MockBackend::default();
         let raw: Vec<u8> = (0..(256 * 1024)).map(|index| (index % 16) as u8).collect();
-        let stored = compress(&raw, Compression::Lz4).into_owned();
-        assert!(stored.len() < raw.len());
-        backend
-            .data
-            .lock()
-            .unwrap()
-            .insert("chunks/17/0".to_string(), stored);
+        let write_cache_dir = tempfile::tempdir()?;
+        let writer = ObjectBlockStore::new_with_configs_async(
+            ObjectClient::new(backend.clone()),
+            ChunksCacheConfig::with_budgets(
+                16 * 1024 * 1024,
+                16 * 1024 * 1024,
+                write_cache_dir.path().to_path_buf(),
+            ),
+            BlockStoreConfig {
+                block_size: raw.len(),
+                compression: Compression::Lz4,
+                range_background_prefetch: false,
+                ..Default::default()
+            },
+        )
+        .await?;
+        writer.write_fresh_range((17, 0), 0, &raw).await?;
+
+        // ObjectBackend permits a partial range result. The versioned header
+        // must be collected completely instead of caching this first fragment
+        // as a raw-object classification.
+        *backend.max_range_bytes.lock().unwrap() = Some(2);
 
         // Simulate a remount whose current write setting is none after this
         // block was committed with LZ4.
@@ -1624,8 +1920,8 @@ mod tests {
         assert_eq!(*backend.full_gets.lock().unwrap(), 1);
         assert_eq!(
             *backend.range_gets.lock().unwrap(),
-            1,
-            "one header probe must precede the safe full-object read"
+            2,
+            "the short versioned-header reads must be completed before the full-object read"
         );
         Ok(())
     }
@@ -1957,7 +2253,10 @@ mod tests {
         store.delete_range((11, 0), 1).await?;
 
         let snapshot = metrics.snapshot();
-        assert_eq!(snapshot.get_ops, 1);
+        assert_eq!(
+            snapshot.get_ops, 2,
+            "a legacy full read probes the versioned namespace before fetching legacy data"
+        );
         assert_eq!(snapshot.get_bytes, full_block.len() as u64);
         assert_eq!(snapshot.put_ops, 1);
         assert_eq!(snapshot.del_ops, 1);
@@ -1969,7 +2268,7 @@ mod tests {
         store.read_range((11, 0), 0, &mut cached_out).await?;
         let snapshot = metrics.snapshot();
         assert_eq!(snapshot.read_block_cache_hits, 1);
-        assert_eq!(snapshot.get_ops, 1);
+        assert_eq!(snapshot.get_ops, 2);
 
         Ok(())
     }

--- a/src/chunk/store.rs
+++ b/src/chunk/store.rs
@@ -837,24 +837,24 @@ impl<B: ObjectBackend + Send + Sync + 'static> BlockStore for ObjectBlockStore<B
             && offset > 0
             && len <= range_size_threshold;
 
-        if can_try_object_ranges {
-            if let Some(block_data) = self.read_flight.try_piggyback(&key).await {
-                tracing::Span::current().record("strategy", "piggyback_full");
-                self.object_metrics.record_read_piggyback_full();
-                let block_data = block_data
-                    .map_err(|e| anyhow::anyhow!("SingleFlight piggyback read failed: {e}"))?;
+        if can_try_object_ranges
+            && let Some(block_data) = self.read_flight.try_piggyback(&key).await
+        {
+            tracing::Span::current().record("strategy", "piggyback_full");
+            self.object_metrics.record_read_piggyback_full();
+            let block_data = block_data
+                .map_err(|e| anyhow::anyhow!("SingleFlight piggyback read failed: {e}"))?;
 
-                let offset_usize = offset as usize;
-                let end = offset_usize + len;
-                let mut copy_len = 0;
-                if offset_usize < block_data.len() {
-                    let copy_end = end.min(block_data.len());
-                    copy_len = copy_end - offset_usize;
-                    buf[..copy_len].copy_from_slice(&block_data.as_ref()[offset_usize..copy_end]);
-                }
-                tracing::Span::current().record("read_len", copy_len);
-                return Ok(());
+            let offset_usize = offset as usize;
+            let end = offset_usize + len;
+            let mut copy_len = 0;
+            if offset_usize < block_data.len() {
+                let copy_end = end.min(block_data.len());
+                copy_len = copy_end - offset_usize;
+                buf[..copy_len].copy_from_slice(&block_data.as_ref()[offset_usize..copy_end]);
             }
+            tracing::Span::current().record("read_len", copy_len);
+            return Ok(());
         }
 
         // A chunk object is immutable after commit, and the classification is

--- a/src/daemon/worker.rs
+++ b/src/daemon/worker.rs
@@ -218,6 +218,8 @@ impl<B: ObjectBackend + Clone> MarkBasedGarbageCollector<B> {
                     for block_index in 0..blocks_per_chunk {
                         let key = format!("chunks/{chunk_id}/{block_index}");
                         self.object_client.delete_object(&key).await?;
+                        let versioned_key = format!("chunks-v2/{chunk_id}/{block_index}");
+                        self.object_client.delete_object(&versioned_key).await?;
                         deleted_objects += 1;
                     }
                 }


### PR DESCRIPTION
Fixes #65.

## Summary
- Write new blocks to `chunks-v2/{chunk_id}/{block_index}` with a mandatory framed envelope, including `Compression::None`; the namespace, rather than a four-byte prefix alone, declares the persisted layout.
- Keep `chunks/{chunk_id}/{block_index}` as an explicit legacy fallback. On a `Compression::None` mount legacy bytes are always raw, so valid user data beginning `SF\x00\x00` is never truncated or decoded by accident.
- Use one strict parser for framed-range eligibility and full-block decoding. Invalid, unknown, and truncated v2 headers fail explicitly instead of being served as raw data.
- Complete short header reads before classifying/caching a v2 object, and serve fully cached pages before any layout probe.
- Probe/delete the v2 namespace alongside legacy cleanup; actual writes and successful probes populate the layout cache.

## Regression coverage
- Actual LZ4 write followed by a `Compression::None` remount, including a backend that returns the header in two partial range reads.
- New v2 and legacy raw `SF\x00\x00...` payloads round-trip byte-for-byte under `Compression::None`.
- Invalid/incomplete header parser behavior and page-cache reads after layout-cache eviction.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check --workspace --tests -j 1` (WSL/Linux, `CARGO_TARGET_DIR=/mnt/d/codex-brewfs-issue65-linux`)