### PR TITLE
fix(meta): make RENAME_NOREPLACE atomic

### DIFF
--- a/src/meta/client/mod.rs
+++ b/src/meta/client/mod.rs
@@ -1715,6 +1715,7 @@ impl<T: MetaStore + ?Sized + 'static> MetaClient<T> {
         known_src: Option<(i64, FileAttr)>,
         known_new_parent_attr: Option<FileAttr>,
         known_dest_ino: Option<Option<i64>>,
+        noreplace: bool,
     ) -> Result<(), MetaError> {
         self.ensure_writable()?;
 
@@ -1752,16 +1753,24 @@ impl<T: MetaStore + ?Sized + 'static> MetaClient<T> {
             }
         }
 
-        // Resolve destination inode before store rename so we can invalidate its
+        // Resolve destination inode before replace-capable store renames so we can invalidate its
         // cache entry afterwards.  When the store replaces an existing destination,
         // its nlink is decremented (possibly to 0, which deletes the node).  The
         // cache must reflect this, otherwise a subsequent stat on an fd that was
         // open before the overwrite returns a stale (non-zero) nlink.
-        let dest_ino = match known_dest_ino {
-            Some(dest_ino) => dest_ino.map(|ino| self.check_root(ino)),
-            None => self.cached_lookup(new_parent, &new_name).await?,
+        // A no-replace operation must not make a correctness decision based on
+        // this cache: another client may create the name after a lookup. Its
+        // backend transaction/script is the sole authority for the absence
+        // check.
+        let dest_ino = if noreplace {
+            None
+        } else {
+            match known_dest_ino {
+                Some(dest_ino) => dest_ino.map(|ino| self.check_root(ino)),
+                None => self.cached_lookup(new_parent, &new_name).await?,
+            }
         };
-        if dest_ino == Some(src_ino) {
+        if !noreplace && dest_ino == Some(src_ino) {
             return Ok(());
         }
         let dest_attr = match dest_ino {
@@ -1770,9 +1779,15 @@ impl<T: MetaStore + ?Sized + 'static> MetaClient<T> {
         };
 
         // Execute the store-level rename with atomic cache updates.
-        self.store
-            .rename(old_parent, old_name, new_parent, new_name.clone())
-            .await?;
+        if noreplace {
+            self.store
+                .rename_noreplace(old_parent, old_name, new_parent, new_name.clone())
+                .await?;
+        } else {
+            self.store
+                .rename(old_parent, old_name, new_parent, new_name.clone())
+                .await?;
+        }
         self.invalidate_open_file_cache_inode(src_ino).await;
         if let Some(dest_ino) = dest_ino {
             self.invalidate_open_file_cache_inode(dest_ino).await;
@@ -2621,8 +2636,23 @@ impl<T: MetaStore + ?Sized + 'static> MetaLayer for MetaClient<T> {
         new_parent: i64,
         new_name: String,
     ) -> Result<(), MetaError> {
-        self.rename_cached(old_parent, old_name, new_parent, new_name, None, None, None)
-            .await
+        self.rename_cached(
+            old_parent, old_name, new_parent, new_name, None, None, None, false,
+        )
+        .await
+    }
+
+    async fn rename_noreplace(
+        &self,
+        old_parent: i64,
+        old_name: &str,
+        new_parent: i64,
+        new_name: String,
+    ) -> Result<(), MetaError> {
+        self.rename_cached(
+            old_parent, old_name, new_parent, new_name, None, None, None, true,
+        )
+        .await
     }
 
     #[tracing::instrument(
@@ -2659,6 +2689,7 @@ impl<T: MetaStore + ?Sized + 'static> MetaLayer for MetaClient<T> {
             Some((src_ino, src_attr)),
             Some(new_parent_attr),
             known_dest_ino,
+            false,
         )
         .await
     }
@@ -2817,14 +2848,7 @@ impl<T: MetaStore + ?Sized + 'static> MetaLayer for MetaClient<T> {
             self.rename_exchange(old_parent, old_name, new_parent, &new_name)
                 .await
         } else if flags.noreplace {
-            // Check if destination exists
-            if self.cached_lookup(new_parent, &new_name).await?.is_some() {
-                return Err(MetaError::AlreadyExists {
-                    parent: new_parent,
-                    name: new_name,
-                });
-            }
-            self.rename(old_parent, old_name, new_parent, new_name)
+            self.rename_noreplace(old_parent, old_name, new_parent, new_name)
                 .await
         } else {
             // Default behavior

--- a/src/meta/layer.rs
+++ b/src/meta/layer.rs
@@ -186,6 +186,18 @@ pub trait MetaLayer: Send + Sync {
         new_name: String,
     ) -> Result<(), MetaError>;
 
+    /// Atomically rename only when the destination name is absent.
+    ///
+    /// Implementations must delegate to metadata storage that checks and
+    /// updates the namespace within one atomic operation.
+    async fn rename_noreplace(
+        &self,
+        old_parent: i64,
+        old_name: &str,
+        new_parent: i64,
+        new_name: String,
+    ) -> Result<(), MetaError>;
+
     /// Rename after the caller already resolved the source and destination
     /// parent attributes. Implementations that cannot use this context can
     /// fall back to the regular rename path.
@@ -281,14 +293,7 @@ pub trait MetaLayer: Send + Sync {
             self.rename_exchange(old_parent, old_name, new_parent, &new_name)
                 .await
         } else if flags.noreplace {
-            // Check if destination exists
-            if self.lookup(new_parent, &new_name).await?.is_some() {
-                return Err(MetaError::AlreadyExists {
-                    parent: new_parent,
-                    name: new_name,
-                });
-            }
-            self.rename(old_parent, old_name, new_parent, new_name)
+            self.rename_noreplace(old_parent, old_name, new_parent, new_name)
                 .await
         } else {
             // Default behavior

--- a/src/meta/store.rs
+++ b/src/meta/store.rs
@@ -712,6 +712,35 @@ pub trait MetaStore: Send + Sync {
         old_name: &str,
         new_parent: i64,
         new_name: String,
+    ) -> Result<(), MetaError> {
+        self.rename_with_mode(old_parent, old_name, new_parent, new_name, false)
+            .await
+    }
+
+    /// Atomically rename an entry only if `new_parent/new_name` is absent.
+    ///
+    /// Implementations must perform the absence check in the same transaction,
+    /// compare-and-swap, or script as the namespace mutation. Callers must not
+    /// emulate this operation with a lookup followed by [`Self::rename`].
+    async fn rename_noreplace(
+        &self,
+        old_parent: i64,
+        old_name: &str,
+        new_parent: i64,
+        new_name: String,
+    ) -> Result<(), MetaError> {
+        self.rename_with_mode(old_parent, old_name, new_parent, new_name, true)
+            .await
+    }
+
+    /// Backend implementation for ordinary and no-replace rename.
+    async fn rename_with_mode(
+        &self,
+        old_parent: i64,
+        old_name: &str,
+        new_parent: i64,
+        new_name: String,
+        noreplace: bool,
     ) -> Result<(), MetaError>;
 
     async fn rename_with_outcome(

--- a/src/meta/stores/database/mod.rs
+++ b/src/meta/stores/database/mod.rs
@@ -1972,12 +1972,13 @@ impl MetaStore for DatabaseMetaStore {
         skip(self),
         fields(old_parent, old_name, new_parent, new_name)
     )]
-    async fn rename(
+    async fn rename_with_mode(
         &self,
         old_parent: i64,
         old_name: &str,
         new_parent: i64,
         new_name: String,
+        noreplace: bool,
     ) -> Result<(), MetaError> {
         let (_sqlite_txn_guard, txn) = self.begin_transaction().await?;
 
@@ -2034,6 +2035,14 @@ impl MetaStore for DatabaseMetaStore {
             .one(&txn)
             .await
             .map_err(MetaError::Database)?;
+
+        if noreplace && existing.is_some() {
+            txn.rollback().await.map_err(MetaError::Database)?;
+            return Err(MetaError::AlreadyExists {
+                parent: new_parent,
+                name: new_name,
+            });
+        }
 
         if let Some(existing) = existing {
             if existing.inode == target_entry.inode {

--- a/src/meta/stores/etcd/mod.rs
+++ b/src/meta/stores/etcd/mod.rs
@@ -2181,12 +2181,13 @@ impl MetaStore for EtcdMetaStore {
         skip(self),
         fields(old_parent, old_name, new_parent, new_name)
     )]
-    async fn rename(
+    async fn rename_with_mode(
         &self,
         old_parent: i64,
         old_name: &str,
         new_parent: i64,
         new_name: String,
+        noreplace: bool,
     ) -> Result<(), MetaError> {
         if old_parent == new_parent && old_name == new_name {
             return Ok(());
@@ -2207,6 +2208,7 @@ impl MetaStore for EtcdMetaStore {
                 let old_name = old_name.to_string();
                 let new_name = new_name.clone();
                 let client = self.client.clone();
+                let noreplace = noreplace;
 
                 Box::pin(async move {
                     let old_forward_entry: EtcdForwardEntry = tx
@@ -2225,6 +2227,12 @@ impl MetaStore for EtcdMetaStore {
                         .get_typed_json::<EtcdForwardEntry>(&new_forward_key)
                         .await?
                     {
+                        if noreplace {
+                            return Err(MetaError::AlreadyExists {
+                                parent: new_parent,
+                                name: new_name,
+                            });
+                        }
                         if replaced_forward.inode == entry_ino {
                             return Ok(entry_ino);
                         }

--- a/src/meta/stores/etcd/mod.rs
+++ b/src/meta/stores/etcd/mod.rs
@@ -2208,7 +2208,6 @@ impl MetaStore for EtcdMetaStore {
                 let old_name = old_name.to_string();
                 let new_name = new_name.clone();
                 let client = self.client.clone();
-                let noreplace = noreplace;
 
                 Box::pin(async move {
                     let old_forward_entry: EtcdForwardEntry = tx

--- a/src/meta/stores/redis/mod.rs
+++ b/src/meta/stores/redis/mod.rs
@@ -1018,6 +1018,7 @@ const RENAME_LUA: &str = r#"
     local timestamp = tonumber(ARGV[5])
     local node_prefix = ARGV[6]
     local link_parent_prefix = ARGV[7]
+    local noreplace = ARGV[8] == "1"
 
     -- Check source dentry exists.
     local dentry_ino = redis.call('HGET', old_parent_dir_key, old_name)
@@ -1057,6 +1058,9 @@ const RENAME_LUA: &str = r#"
     local replaced_ino = nil
     local dest_ino_str = redis.call('HGET', new_parent_dir_key, new_name)
     if dest_ino_str then
+        if noreplace then
+            return cjson.encode({ok=false, error="already_exists", ino=tonumber(dest_ino_str)})
+        end
         if dest_ino_str == dentry_ino then
             return cjson.encode({ok=true, ino=child_ino})
         end
@@ -2764,16 +2768,73 @@ impl MetaStore for RedisMetaStore {
         skip(self),
         fields(old_parent, old_name, new_parent, new_name)
     )]
-    async fn rename(
+    async fn rename_with_mode(
         &self,
         old_parent: i64,
         old_name: &str,
         new_parent: i64,
         new_name: String,
+        noreplace: bool,
     ) -> Result<(), MetaError> {
-        self.rename_with_outcome(old_parent, old_name, new_parent, new_name)
+        if !noreplace {
+            return self
+                .rename_with_outcome(old_parent, old_name, new_parent, new_name)
+                .await
+                .map(|_| ());
+        }
+
+        let old_parent_dir_key = self.dir_key(old_parent);
+        let new_parent_dir_key = self.dir_key(new_parent);
+        let old_parent_node_key = self.node_key(old_parent);
+        let new_parent_node_key = self.node_key(new_parent);
+        let deleted_set_key = self.deleted_set_key();
+        let now = current_time();
+
+        let result: String = redis::Script::new(RENAME_LUA)
+            .key(&old_parent_dir_key)
+            .key(&new_parent_dir_key)
+            .key(&old_parent_node_key)
+            .key(&new_parent_node_key)
+            .key(deleted_set_key)
+            .arg(old_name)
+            .arg(&new_name)
+            .arg(old_parent)
+            .arg(new_parent)
+            .arg(now)
+            .arg(NODE_KEY_PREFIX)
+            .arg(LINK_PARENT_KEY_PREFIX)
+            .arg(1)
+            .invoke_async(&mut self.conn.clone())
             .await
-            .map(|_| ())
+            .map_err(redis_err)?;
+        let response: LuaResponse = serde_json::from_str(&result)
+            .map_err(|e| MetaError::Internal(format!("Lua response parse error: {e}")))?;
+
+        match response.error.as_deref() {
+            Some("already_exists") => Err(MetaError::AlreadyExists {
+                parent: new_parent,
+                name: new_name,
+            }),
+            Some("not_found") => Err(MetaError::NotFound(response.ino.unwrap_or(old_parent))),
+            Some("parent_not_found") => Err(MetaError::ParentNotFound(new_parent)),
+            Some("parent_not_directory") => Err(MetaError::NotDirectory(new_parent)),
+            Some("node_not_found") => Err(MetaError::NotFound(response.ino.unwrap_or(old_parent))),
+            Some("corrupt_node") => Err(MetaError::Internal("corrupt node data".into())),
+            Some("link_parent_not_found") => Err(MetaError::Internal(format!(
+                "expected link parent binding {old_parent}/{old_name} for inode {}",
+                response.ino.unwrap_or(old_parent)
+            ))),
+            Some(other) => Err(MetaError::Internal(format!("Lua error: {other}"))),
+            None if response.ok => {
+                let child = response
+                    .ino
+                    .ok_or_else(|| MetaError::Internal("missing ino in rename response".into()))?;
+                self.invalidate_nodes(&[old_parent, new_parent, child])
+                    .await;
+                Ok(())
+            }
+            None => Err(MetaError::Internal("unexpected Lua response".into())),
+        }
     }
 
     async fn rename_with_outcome(

--- a/src/meta/stores/tikv/mod.rs
+++ b/src/meta/stores/tikv/mod.rs
@@ -1758,12 +1758,13 @@ impl MetaStore for TiKvMetaStore {
         .await
     }
 
-    async fn rename(
+    async fn rename_with_mode(
         &self,
         old_parent: i64,
         old_name: &str,
         new_parent: i64,
         new_name: String,
+        noreplace: bool,
     ) -> Result<(), MetaError> {
         if old_parent == new_parent && old_name == new_name {
             return Ok(());
@@ -1774,6 +1775,7 @@ impl MetaStore for TiKvMetaStore {
         self.write_txn_serialized(operation, old_parent as u64, |store, txn| {
             let old_name = old_name.clone();
             let new_name = new_name.clone();
+            let noreplace = noreplace;
             Box::pin(async move {
                 let old_parent_key = store.inode_key(old_parent);
                 let new_parent_key = store.inode_key(new_parent);
@@ -1824,6 +1826,12 @@ impl MetaStore for TiKvMetaStore {
                     .as_deref()
                     .map(Self::decode_dentry)
                     .transpose()?;
+                if noreplace && destination.is_some() {
+                    return Err(MetaError::AlreadyExists {
+                        parent: new_parent,
+                        name: new_name,
+                    });
+                }
                 let source_inode_key = store.inode_key(source_dentry.ino);
                 let mut inode_keys = vec![source_inode_key.clone()];
                 if let Some(dest_dentry) = destination.as_ref() {

--- a/src/meta/stores/tikv/mod.rs
+++ b/src/meta/stores/tikv/mod.rs
@@ -1775,7 +1775,6 @@ impl MetaStore for TiKvMetaStore {
         self.write_txn_serialized(operation, old_parent as u64, |store, txn| {
             let old_name = old_name.clone();
             let new_name = new_name.clone();
-            let noreplace = noreplace;
             Box::pin(async move {
                 let old_parent_key = store.inode_key(old_parent);
                 let new_parent_key = store.inode_key(new_parent);

--- a/src/vfs/fs/mod.rs
+++ b/src/vfs/fs/mod.rs
@@ -2344,6 +2344,49 @@ where
         Ok(())
     }
 
+    /// Rename an entry without replacement, using the metadata backend's
+    /// atomic no-replace primitive for the final namespace mutation.
+    pub(crate) async fn rename_at_noreplace(
+        &self,
+        old_parent_ino: i64,
+        old_name: &str,
+        new_parent_ino: i64,
+        new_name: &str,
+    ) -> Result<(), VfsError> {
+        Self::validate_entry_name(old_name)?;
+        Self::validate_entry_name(new_name)?;
+
+        let src_ino = self
+            .meta_lookup_required(old_parent_ino, old_name, PathHint::none())
+            .await?;
+        let src_attr = self.meta_stat_required(src_ino, PathHint::none()).await?;
+        let new_parent_attr = self
+            .meta_stat_required(new_parent_ino, PathHint::none())
+            .await?;
+        if new_parent_attr.kind != FileType::Dir {
+            return Err(VfsError::NotADirectory {
+                path: PathHint::none(),
+            });
+        }
+        if src_attr.kind == FileType::Dir
+            && self
+                .parent_is_descendant_of(new_parent_ino, src_ino)
+                .await?
+        {
+            return Err(VfsError::CircularRename {
+                path: PathHint::none(),
+            });
+        }
+
+        self.meta_rename_noreplace(
+            old_parent_ino,
+            old_name,
+            new_parent_ino,
+            new_name.to_string(),
+        )
+        .await
+    }
+
     /// Create a hard link at `link_path` that references `existing_path`.
     #[tracing::instrument(level = "debug", skip(self), fields(existing_path, link_path))]
     pub async fn link(&self, existing_path: &str, link_path: &str) -> Result<FileAttr, VfsError> {
@@ -2538,16 +2581,12 @@ where
     pub async fn rename_noreplace(&self, old: &str, new: &str) -> Result<(), VfsError> {
         let old = Self::norm_path(old);
         let new = Self::norm_path(new);
-
-        // Check if destination exists
-        if self.meta_lookup_path(&new).await?.is_some() {
-            return Err(VfsError::AlreadyExists {
-                path: PathHint::some(format!("destination '{}' already exists", new)),
-            });
-        }
-
-        // Use standard rename
-        self.rename(&old, &new).await
+        let (old_dir, old_name) = Self::split_dir_file(&old);
+        let (new_dir, new_name) = Self::split_dir_file(&new);
+        let old_parent_ino = self.resolve_parent_inode(&old_dir).await?;
+        let new_parent_ino = self.resolve_parent_inode(&new_dir).await?;
+        self.rename_at_noreplace(old_parent_ino, &old_name, new_parent_ino, &new_name)
+            .await
     }
 
     /// Atomically exchange the source and destination (RENAME_EXCHANGE).

--- a/src/vfs/fs/tests.rs
+++ b/src/vfs/fs/tests.rs
@@ -366,6 +366,53 @@ mod rename_tests {
         println!("All VFS rename boundary condition tests passed!");
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn rename_noreplace_preserves_concurrently_created_destination() {
+        let meta_handle = create_meta_store_from_url("sqlite::memory:").await.unwrap();
+        let fs = Arc::new(
+            VFS::new(
+                ChunkLayout::default(),
+                InMemoryBlockStore::new(),
+                meta_handle.store(),
+            )
+            .await
+            .unwrap(),
+        );
+        fs.mkdir_p("/race").await.unwrap();
+        fs.create_file("/race/left").await.unwrap();
+        fs.create_file("/race/right").await.unwrap();
+
+        let barrier = Arc::new(tokio::sync::Barrier::new(2));
+        let left_fs = Arc::clone(&fs);
+        let left_barrier = Arc::clone(&barrier);
+        let left = tokio::spawn(async move {
+            left_barrier.wait().await;
+            left_fs
+                .rename_noreplace("/race/left", "/race/destination")
+                .await
+        });
+        let right_fs = Arc::clone(&fs);
+        let right_barrier = Arc::clone(&barrier);
+        let right = tokio::spawn(async move {
+            right_barrier.wait().await;
+            right_fs
+                .rename_noreplace("/race/right", "/race/destination")
+                .await
+        });
+
+        let left = left.await.unwrap();
+        let right = right.await.unwrap();
+        assert_ne!(left.is_ok(), right.is_ok(), "exactly one rename must win");
+        assert!(fs.exists("/race/destination").await);
+        if left.is_ok() {
+            assert!(!fs.exists("/race/left").await);
+            assert!(fs.exists("/race/right").await);
+        } else {
+            assert!(fs.exists("/race/left").await);
+            assert!(!fs.exists("/race/right").await);
+        }
+    }
+
     #[tokio::test]
     async fn test_rename_error_cases_vfs() {
         let layout = ChunkLayout::default();

--- a/src/vfs/meta_ops.rs
+++ b/src/vfs/meta_ops.rs
@@ -302,6 +302,19 @@ where
             .map_err(meta_err_to_vfs)
     }
 
+    pub(super) async fn meta_rename_noreplace(
+        &self,
+        old_parent: i64,
+        old_name: &str,
+        new_parent: i64,
+        new_name: String,
+    ) -> Result<(), VfsError> {
+        self.meta_layer()
+            .rename_noreplace(old_parent, old_name, new_parent, new_name)
+            .await
+            .map_err(meta_err_to_vfs)
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub(super) async fn meta_rename_with_known_attrs(
         &self,

--- a/src/workspace_overlay/meta_layer/mod.rs
+++ b/src/workspace_overlay/meta_layer/mod.rs
@@ -932,6 +932,23 @@ impl<W: WorkspaceStore + 'static> MetaLayer for WorkspaceMetaLayer<W> {
         Ok(())
     }
 
+    async fn rename_noreplace(
+        &self,
+        _old_parent: i64,
+        _old_name: &str,
+        _new_parent: i64,
+        _new_name: String,
+    ) -> Result<(), MetaError> {
+        // The workspace namespace uses an optimistic head guard. Its current
+        // replacement rename path cannot use an already-resolved destination
+        // as a no-replace precondition without reintroducing a TOCTOU window.
+        // Refuse the operation until it has a dedicated guarded mutation,
+        // rather than silently degrading RENAME_NOREPLACE to replacement.
+        Err(MetaError::NotSupported(
+            "atomic RENAME_NOREPLACE is not yet available for workspace overlays".into(),
+        ))
+    }
+
     async fn rename_exchange(
         &self,
         old_parent: i64,


### PR DESCRIPTION
Fixes #64.

## Summary
- Add a `MetaStore::rename_noreplace` operation and require every flat metadata backend to execute the destination-absence check inside its atomic mutation boundary.
- Route `MetaClient`, `MetaLayer::rename_with_flags`, and VFS directly to that primitive; remove the former lookup-then-replace path.
- Use Redis Lua, TiKV pessimistic transactions, etcd transaction retries/CAS, and the database transaction to reject an existing destination.
- Keep workspace overlay safe by returning `NotSupported` for this flag until it has a dedicated guarded namespace mutation, rather than silently falling back to replacement.
- Add a barrier-based VFS regression: two concurrent no-replace renames target one name; exactly one succeeds and the loser source remains.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check --lib --target-dir /mnt/d/codex-brewfs-issue65-linux -j 1` (Linux): passed
- `cargo test --lib rename_noreplace_preserves_concurrently_created_destination --target-dir /mnt/d/codex-brewfs-issue65-linux -j 1` (Linux): passed (1 test)