### PR TITLE
docs(protocols): multi-protocol gateway specs (S3, WebDAV, NFS) and roadmap

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -27,6 +27,7 @@ plans under `doc/` unless a tool explicitly requires another location.
 | [meta-api/](meta-api/) | Meta client API audit, mapping, extension plan, and read/write follow-up work. |
 | [juicefs/](juicefs/) | JuiceFS internals notes used for cross-project comparison. |
 | [gap/](gap/) | BrewFS/JuiceFS module gap analysis and iteration roadmap. |
+| [protocols/](protocols/) | Multi-protocol gateway specs (S3, WebDAV, NFS), shared conventions, and the milestone roadmap. |
 | [vfs/](vfs/) | VFS module-specific implementation guide. |
 | [bugfix/](bugfix/) | Historical bug investigations and fix notes that are still useful for regression context. |
 | [superpowers/](superpowers/) | Dated agent plans and specs. Treat these as historical execution records unless a plan is explicitly current. |

--- a/doc/protocols/README.md
+++ b/doc/protocols/README.md
@@ -1,0 +1,227 @@
+# BrewFS 协议网关总体设计
+
+本文档是 BrewFS 多协议接入的总设计，定义协议网关层的公共架构、共用约定与协议选型。
+各协议的详细 spec：
+
+| 协议 | Spec | 状态 |
+|---|---|---|
+| S3 Gateway | [s3-gateway.md](s3-gateway.md) | 已立项，首个实现目标 |
+| WebDAV（网盘） | [webdav.md](webdav.md) | 已立项 |
+| NFS | [nfs.md](nfs.md) | 已立项 |
+| 其他协议评估 | 见本文 §6 | SMB / SFTP / HDFS 等 |
+
+## 1. 背景与目标
+
+BrewFS 目前对外只有两类入口：
+
+- **FUSE mount**：POSIX 接口，需要内核 FUSE 与挂载权限；
+- **console / control plane**：管理面，不是数据面。
+
+JuiceFS 在此之上的成熟实践是 `juicefs gateway`（S3）与 `juicefs webdav`：同一套文件系统核心，
+不经内核，直接以网络协议对外提供数据访问。本设计为 BrewFS 补齐这一层，目标是：
+
+1. **同一 volume，多协议并存**：FUSE、S3、WebDAV、NFS 可同时挂在同一份 meta/data 后端上；
+2. **不经过内核 FUSE**：网关进程内直接构造 `VFS`/`Client`，避免 FUSE 上下文切换与挂载权限要求；
+3. **协议语义忠实**：不是"能通就行"，每个协议都要定义清楚一致性语义、错误码映射与不支持的特性；
+4. **可测试**：每个协议都有客户端工具的端到端验证（aws cli / mc、litmus / davfs2、mount -t nfs）。
+
+非目标：
+
+- 不做协议网关的横向扩展调度（多网关实例的负载均衡由部署层解决，见各 spec 的一致性章节）；
+- 不在网关层实现对象存储后端能力（versioning、对象锁、生命周期等，见 S3 spec 的显式排除项）。
+
+## 2. 分层架构
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  FUSE mount   │  S3 gateway  │  WebDAV  │  NFS server   │   ← 前端（平级）
+├─────────────────────────────────────────────────────────┤
+│  SDK Client (path, std::fs 风格)  │  VFS (inode/handle)   │   ← 消费层
+├─────────────────────────────────────────────────────────┤
+│  MetaClient 缓存 │ Chunk/Block 数据路径 │ 读写缓存/写回     │
+├─────────────────────────────────────────────────────────┤
+│  MetaStore (sqlite/postgres/redis/etcd/tikv)            │
+│  ObjectBackend (localfs / S3 兼容对象存储)                │
+└─────────────────────────────────────────────────────────┘
+```
+
+代码布局（新增 `src/gateway/`，与 `src/fuse/` 平级）：
+
+```
+src/gateway/
+├── mod.rs            # 公共：GatewayContext 构造、系统目录、xattr 常量、锁
+├── s3/               # S3 网关（s3s crate）
+├── webdav/           # WebDAV 网关（dav-server crate）
+└── nfs/              # NFS 网关（nfsserve crate）
+```
+
+### 2.1 消费层选择
+
+BrewFS 核心对前端暴露三层抽象（详见 `doc/architecture/arch.md` 与源码）：
+
+| 层 | 类型 | 特点 | 适用协议 |
+|---|---|---|---|
+| SDK | `Client` / `ClientBackend`（`src/sdk_fs.rs`） | path-based、`io::Result`、公开稳定 API | WebDAV、S3 |
+| VFS | `VFS<S, M>`（`src/vfs/fs/mod.rs`） | path-based 公开 + inode/handle 内部 API | NFS（需要 inode 文件句柄） |
+| FUSE | `impl asyncfuse::raw::Filesystem for VFS` | 内核挂载 | —（已存在） |
+
+约定：
+
+- **WebDAV / S3 网关基于 `Client`**：路径天然映射 URL，无需 inode；
+- **NFS 网关基于 `VFS`**：NFSv3 的文件句柄需要稳定的 inode 号，且是无状态协议（无 open/close），
+  需要直接使用 VFS 的 inode 级 API。当前 `VFS` 的 `*_ino` / `*_at` 方法为 `pub(crate)`，
+  NFS 实现时需要：提升可见性，或新增公开 wrapper（推荐后者，见 [nfs.md](nfs.md) §3）。
+
+### 2.2 CLI 形态
+
+沿用现有 clap derive 结构（`src/config.rs` 的 `Command` 枚举），新增一个子命令树：
+
+```bash
+brewfs gateway s3     --listen 0.0.0.0:9000 --access-key ... --secret-key ... \
+                      --meta-url sqlite:///tmp/meta.db --data-backend local-fs --data-dir /data
+brewfs gateway webdav --listen 0.0.0.0:9001 [--user u --password p] <同一批后端参数>
+brewfs gateway nfs    --listen 0.0.0.0:2049 [--squash root|all|none] <同一批后端参数>
+```
+
+- 后端连接参数（`--meta-url` / `--data-backend` / `--data-dir` / S3 后端参数 / 缓存参数）与
+  `mount` 子命令完全复用同一套定义，保证"mount 能连的 volume，gateway 就能连"；
+- 每个协议是独立 Cargo feature：`gateway-s3`、`gateway-webdav`、`gateway-nfs`，默认全部开启，
+  可用 `--no-default-features --features gateway-s3` 裁剪二进制；
+- 网关进程注册到与 mount 相同的 session/heartbeat 机制（meta 层已有 session 概念），
+  使 `info`/`console` 能看到网关实例。
+
+## 3. 共用约定
+
+所有协议网关共享以下约定，集中在 `src/gateway/mod.rs` 定义常量与工具函数。
+
+### 3.1 系统目录 `/.brewfs.sys/`
+
+网关内部状态统一放在 volume 根下的隐藏目录（类比 JuiceFS gateway 的 `/.sys`）：
+
+```
+/.brewfs.sys/
+├── s3/
+│   ├── uploads/<hh>/<upload-id>/     # S3 multipart：每个 part 一个普通文件
+│   │   ├── part-1, part-2, ...       #   part 数据（xattr 记录 etag）
+│   │   └── .target                   #   xattr: 目标 bucket/key
+│   └── tmp/<uuid>                    # PutObject/Complete 的暂存文件
+├── webdav/                           # WebDAV 暂无内部状态
+└── locks/                            # 跨网关实例的分布式锁文件（后续）
+```
+
+- 所有协议的 list 操作必须在根目录过滤 `.brewfs.sys`；
+- FUSE 挂载下该目录可见但应视为内部实现（文档中声明不要直接使用）；
+- GC 约定：超过 24h 未更新的 `uploads/` 与 `tmp/` 条目由网关的后台清理任务回收
+  （等价 JuiceFS gateway 的 `cleanup()` 周期任务）。
+
+### 3.2 xattr 命名
+
+协议元数据一律存 xattr，前缀 `brewfs.<proto>.`：
+
+| xattr | 内容 | 协议 |
+|---|---|---|
+| `brewfs.s3.etag` | 对象 ETag（小对象 MD5 或 multipart 的 md5-of-md5s-N） | S3 |
+| `brewfs.s3.meta` | JSON：`x-amz-meta-*` 用户元数据 + 白名单系统头 | S3 |
+| `brewfs.s3.tags` | JSON：对象 tagging | S3 |
+| `brewfs.s3.dirobj` | 空值标记：该目录是 S3 "目录对象"（key 以 `/` 结尾显式创建） | S3 |
+| `brewfs.dav.deadprops` | JSON：PROPPATCH 的 dead properties | WebDAV |
+
+选择 xattr 而非 JuiceFS 的 `atime==0` 目录对象标记，原因：xattr 语义显式、不污染时间戳、
+FUSE/其他协议下行为可预期。JuiceFS 的 atime 技巧在 spec 中仅作为参考记录。
+
+### 3.3 原子发布
+
+所有"完整对象/文件落位"的写路径（S3 PutObject、CompleteMultipartUpload、CopyObject、
+WebDAV PUT 可选开启）遵循同一模式：
+
+1. 写入 `/.brewfs.sys/<proto>/tmp/<uuid>`；
+2. 数据落盘（按协议语义决定是否 fsync/flush）；
+3. `rename` 到最终路径（BrewFS rename 具备原子性，xref `RENAME_NOREPLACE` 修复 #81）；
+4. 失败路径清理 tmp。
+
+### 3.4 一致性语义
+
+- **单网关实例**：直接走 meta 事务，读写强一致（等同 FUSE 单挂载点）；
+- **多实例（同 volume 多网关 / 网关与 FUSE 并存）**：以 MetaClient 缓存失效粒度为界，
+  提供 close-to-open 一致性；协议层不额外承诺。各 spec 中写明该协议可见的弱化点
+  （如 S3 list 可能短暂滞后、NFS 客户端属性缓存）；
+- **写冲突**：单实例内用进程内锁（dashmap 按 key 分片）；跨实例写同一 key 的串行化
+  依赖 meta 层 rename/create 的原子性，跨实例分布式锁（flock on `/.brewfs.sys/locks/`）
+  列入后续里程碑（参考 JuiceFS `NewNSLock` 用 meta.Flock 的实现）。
+
+### 3.5 认证与身份
+
+| 协议 | MVP | 后续 |
+|---|---|---|
+| S3 | 静态 access-key/secret-key（flag 或 env），SigV4 由 s3s 处理 | 多租户密钥对、STS 兼容层 |
+| WebDAV | HTTP Basic（flag 或 env）；可关闭 | 复用 console 的 Bearer token、HTTPS |
+| NFS | AUTH_SYS + squash 选项（root_squash 默认） | Kerberos（依赖 crate 生态，暂不承诺） |
+
+身份到文件系统的映射：网关操作以可配置的 `uid/gid`（默认 root）调用核心；
+NFS 按 AUTH_SYS 凭据 + squash 规则映射到 `CallerIdentity`（`src/fs.rs` 已有该结构，
+当前为 `pub(crate)`，随 NFS 里程碑一并公开）。
+
+### 3.6 错误码映射原则
+
+每个 spec 附完整映射表，总原则：
+
+- `NotFound` → S3 `NoSuchKey/NoSuchBucket`、WebDAV 404、NFS `NFS3ERR_NOENT`；
+- `PermissionDenied` → 403 / 403 / `NFS3ERR_ACCES`；
+- `AlreadyExists` → 409（S3 按操作细分）/ 405 或 412 / `NFS3ERR_EXIST`；
+- `DirectoryNotEmpty` → S3 `BucketNotEmpty` / WebDAV 409 / `NFS3ERR_NOTEMPTY`；
+- 其余内部错误 → 500 / 500 / `NFS3ERR_IO`，并带 request id 记 tracing 日志。
+
+## 4. 技术选型
+
+| 协议 | crate | 版本 | 说明 |
+|---|---|---|---|
+| S3 | [`s3s`](https://crates.io/crates/s3s) | 0.15 | S3 Service Adapter：实现 `S3` trait 即得完整 HTTP/SigV4 服务；RustFS 同源框架，生态对齐 |
+| WebDAV | [`dav-server`](https://crates.io/crates/dav-server) | 0.11 | 实现 `DavFileSystem`/`DavFile` trait；支持 axum 集成、可插拔 lock system |
+| NFS | [`nfsserve`](https://crates.io/crates/nfsserve) | 0.11 | NFSv3 + mount 协议 over TCP；实现 `NFSFileSystem` trait（inode 语义，正合 VFS） |
+
+运输层统一 tokio + axum（HTTP 类协议），与现有 `console` 模块的服务器模式
+（`src/console/server.rs`、bearer token 认证）保持一致。
+
+选型时考虑过但否决的方案：
+
+- **自实现 S3 HTTP 层**（axum 手写路由 + 手写 SigV4）：工作量大且兼容性风险高，s3s 已成熟；
+- **嵌入 MinIO**（JuiceFS 路线）：Go 生态产物，Rust 无对应物；
+- **内核 nfsd / Samba 重导出 FUSE 挂载**（JuiceFS 官方 NFS/SMB 建议）：可行但要求先 FUSE mount，
+  违背"不经内核"目标；作为过渡方案写入 NFS spec 的备选章节。
+
+## 5. 与 FUSE 挂载的关系
+
+网关与 FUSE 挂载是同一 volume 的并列前端：
+
+- 数据互通：S3 PUT 的对象在 FUSE 下是同名文件（`bucket/key` → `/bucket/key`），反之亦然；
+  WebDAV/NFS 同理（路径即路径）；
+- 元数据互通：协议特有元数据（etag、tags、deadprops）在 FUSE 下以 xattr 可见；
+- 锁不跨协议互通（S3 无锁语义；WebDAV lock 与 POSIX lock 暂不做双向映射，见 WebDAV spec）。
+
+## 6. 其他协议评估
+
+| 协议 | 结论 | 理由 |
+|---|---|---|
+| **SMB** | 暂不实现，给过渡方案 | 无成熟 Rust SMB server crate；过渡方案：FUSE mount + Samba 重导出（同 JuiceFS 官方 NFS 建议的形态）。长期若生态出现可用 crate（或自研）再立项 |
+| **SFTP/FTP** | 不立项 | 价值低于上述三者；SFTP 可经由 SSH + FUSE mount 天然获得 |
+| **HDFS** | 长期方向 | JuiceFS 以 Java SDK（JNI over libjfs）实现；BrewFS 需要先有稳定的 C ABI（cbindgen over SDK Client），工程量大，列入远期 |
+| **CSI / K8s** | 独立线 | 已有 operator 雏形（`operator/`），走控制面路线，不在本协议网关范围 |
+| **NFSv4** | 随 NFS spec 评估 | nfsserve 仅实现 v3；v4 的有状态语义（open/lock/delegation）与 VFS 句柄模型契合度高，但 crate 生态缺失，列入远期 |
+| **pNFS / 9P** | 不立项 | 生态与需求均不足 |
+
+## 7. 测试与验收总原则
+
+每个协议里程碑必须包含：
+
+1. **单元测试**：操作映射层（tmp/rename、xattr 读写、路径过滤 `.brewfs.sys`）；
+2. **集成测试**（`tests/`，进程内构造 VFS + 内存/本地后端，起真实监听端口）；
+3. **端到端验证**（docker compose 或本地脚本，真实客户端工具）：
+   - S3：`aws s3 cp/ls/rm/mb` + `mc` 全流程；
+   - WebDAV：`litmus` 测试套件 + `davfs2` 挂载 + Windows 网络驱动器映射冒烟；
+   - NFS：`mount -t nfs -o vers=3` + 常规文件操作 + xfstests 子集；
+4. **一致性检查**：协议写入 → FUSE 挂载读取（反向亦然）的交叉验证脚本。
+
+## 8. 里程碑总览
+
+详见 [ROADMAP.md](ROADMAP.md)。首个实现目标为 S3 网关（生态价值最高，
+与 BrewFS 现有的 S3 后端故事闭环："数据可存于 S3，也可通过 S3 协议被访问"）。

--- a/doc/protocols/README.md
+++ b/doc/protocols/README.md
@@ -5,7 +5,7 @@
 
 | 协议 | Spec | 状态 |
 |---|---|---|
-| S3 Gateway | [s3-gateway.md](s3-gateway.md) | 已立项，首个实现目标 |
+| S3 Gateway | [s3-gateway.md](s3-gateway.md) | M1 已实现（PR #83）；M3 兼容性/后端矩阵规划中 |
 | WebDAV（网盘） | [webdav.md](webdav.md) | 已立项 |
 | NFS | [nfs.md](nfs.md) | 已立项 |
 | 其他协议评估 | 见本文 §6 | SMB / SFTP / HDFS 等 |
@@ -61,13 +61,14 @@ BrewFS 核心对前端暴露三层抽象（详见 `doc/architecture/arch.md` 与
 
 | 层 | 类型 | 特点 | 适用协议 |
 |---|---|---|---|
-| SDK | `Client` / `ClientBackend`（`src/sdk_fs.rs`） | path-based、`io::Result`、公开稳定 API | WebDAV、S3 |
-| VFS | `VFS<S, M>`（`src/vfs/fs/mod.rs`） | path-based 公开 + inode/handle 内部 API | NFS（需要 inode 文件句柄） |
+| SDK | `Client` / `ClientBackend`（`src/sdk_fs.rs`） | path-based、`io::Result`、公开稳定 API | WebDAV |
+| VFS | `VFS<S, M>`（`src/vfs/fs/mod.rs`） | path-based 公开 + inode/handle 内部 API | S3、NFS（NFS 需要 inode 文件句柄） |
 | FUSE | `impl asyncfuse::raw::Filesystem for VFS` | 内核挂载 | —（已存在） |
 
 约定：
 
-- **WebDAV / S3 网关基于 `Client`**：路径天然映射 URL，无需 inode；
+- **WebDAV 网关基于 `Client`**：路径天然映射 URL，无需 inode；
+- **S3 网关直接使用 `VFS`**：对象流、原子发布、xattr 与 inode snapshot 需要 VFS 原语；
 - **NFS 网关基于 `VFS`**：NFSv3 的文件句柄需要稳定的 inode 号，且是无状态协议（无 open/close），
   需要直接使用 VFS 的 inode 级 API。当前 `VFS` 的 `*_ino` / `*_at` 方法为 `pub(crate)`，
   NFS 实现时需要：提升可见性，或新增公开 wrapper（推荐后者，见 [nfs.md](nfs.md) §3）。

--- a/doc/protocols/ROADMAP.md
+++ b/doc/protocols/ROADMAP.md
@@ -5,24 +5,27 @@
 
 ## 现状（2026-09）
 
-- BrewFS 对外接口：FUSE mount、console（管理面）、control plane；无任何数据面协议网关。
-- `doc/gap/` 将 `gateway`/`webdav` 标为 P2（"视产品方向"）、`06-roadmap.md` 建议"核心稳定后再做网关"。
-  本路线图正式立项推进，理由：核心 POSIX 正确性基线已达成（708 xfstests 全后端通过，
-  见 README「POSIX Correctness」），协议网关反向成为生态短板。
+- S3 网关 M1 已由 PR #83 合入：支持 single/multi bucket、核心对象操作、multipart、静态 SigV4
+  密钥和流式数据路径；SQLite + LocalFS 上 76 项 boto3 E2E 与 22 项单元测试通过。
+- **Redis metadata + RustFS data backend 尚未做 S3 gateway E2E**。仓库已有该后端组合的
+  FUSE/POSIX、xfstests 与性能验证，但不能替代对 `brewfs gateway s3` 端点的协议验证。
+- WebDAV、NFS 与 S3 完整兼容性仍按以下里程碑推进。
 
 ## 里程碑
 
 | 里程碑 | 内容 | 验收标准 | 状态 |
 |---|---|---|---|
-| **M0** 设计立项 | 本目录全部 spec + 路线图 | 文档评审通过（PR 合入） | ✅ 本 PR |
-| **M1** S3 网关 MVP | `brewfs gateway s3`：单 bucket、核心对象操作（Put/Get/Head/Delete/List/Copy）、multipart 全流程、静态密钥、流式数据路径 | 集成测试（aws-sdk-s3 断言）通过；`aws s3 cp/ls/rm` + `mc` e2e 通过；S3 写入 ↔ FUSE 读取交叉验证 | 🚧 进行中 |
-| **M2** WebDAV 网关 | `brewfs gateway webdav`：§3 方法全表、memls、Basic auth、TLS | `litmus` basic/copymove/props/locks 全过；davfs2 挂载读写；Windows 网络驱动器映射冒烟 | ⬜ |
-| **M3** S3 完整化 | 多 bucket、tagging、GetObjectAttributes、条件头、跨实例锁（`/.brewfs.sys/locks/`）、CORS、rustls | `mc` 全功能回归；多实例并发写同一 key 无撕裂 | ⬜ |
-| **M4** NFS 网关 | `brewfs gateway nfs`：NFSv3+mount 全映射表、squash、COMMIT 语义、`InodeAccess` 公开 wrapper | `mount -t nfs -o vers=3` 冒烟；xfstests NFS 子集；NFS ↔ FUSE 交叉验证 | ⬜ |
-| **M5** 生产化 | 三协议指标（tracing/Prometheus 埋点）、CI 准入矩阵接入 compose、部署文档（systemd/k8s/operator sidecar）、性能基线报告 | CI 全绿；性能报告达到各 spec §性能目标 | ⬜ |
+| **M0** 设计立项 | 本目录全部 spec + 路线图 | 文档评审通过（PR 合入） | PR #82 评审中 |
+| **M1** S3 网关 MVP | `brewfs gateway s3`：single/multi bucket、核心对象操作、multipart、静态密钥、流式数据路径及单实例一致性边界 | SQLite + LocalFS：76 项 boto3 E2E、22 项单元测试、并发/生命周期专项回归及 CI 全绿 | 已完成（PR #83） |
+| **M2** WebDAV 网关 | `brewfs gateway webdav`：§3 方法全表、memls、Basic auth、TLS | `litmus` basic/copymove/props/locks 全过；davfs2 挂载读写；Windows 网络驱动器映射冒烟 | 未开始 |
+| **M3** S3 兼容性与后端矩阵 | Redis + RustFS gateway E2E/重启/跨端验证；tagging、GetObjectAttributes、条件头、list/CopySource 扩展、CORS；带租约/fencing 的跨实例锁 | Redis + RustFS 跑同一 boto3 suite 且 0 failure；AWS CLI/`mc`/s3fs/presigned URL smoke；双网关故障注入无撕裂或删桶重建 | 未开始 |
+| **M4** NFS 网关 | `brewfs gateway nfs`：NFSv3+mount 全映射表、squash、COMMIT 语义、`InodeAccess` 公开 wrapper | `mount -t nfs -o vers=3` 冒烟；xfstests NFS 子集；NFS ↔ FUSE 交叉验证 | 未开始 |
+| **M5** 生产化 | 多身份/ACL/policy/STS、原生 TLS、三协议 tracing/Prometheus、CI compose 准入、部署文档与性能/soak 基线 | CI 全绿；安全模型评审通过；性能报告达到各 spec 目标；Redis + RustFS 24h soak 无数据或 metadata 丢失 | 未开始 |
 
 ## 远期（未排期）
 
+- S3 高级数据语义：Versioning、SSE、Object Lock/Retention、Lifecycle、Notification、
+  Replication、Inventory 和 SelectObjectContent；详细依赖见 [s3-gateway.md](s3-gateway.md) §12；
 - SMB：FUSE + Samba 重导出文档（过渡）；原生实现待 Rust 生态或自研决策；
 - NFSv4：见 [nfs.md](nfs.md) §9；
 - NLM：见 [nfs.md](nfs.md) §6；
@@ -32,6 +35,8 @@
 ## 工作方式约定
 
 - 每个里程碑 = 至少一个 PR：spec 先行（本目录），代码随后；行为变更、测试、文档同 PR；
-- 所有 e2e 验证可在本地 WSL（Ubuntu-22.04）复现：sqlite meta + local-fs data + 真实客户端；
+- 默认开发 e2e 可在本地 WSL（Ubuntu-22.04）使用 SQLite + LocalFS + 真实客户端复现；
+- 每个已宣称支持的生产后端组合必须单独跑协议 endpoint E2E；底层 FUSE/VFS 测试不能替代网关测试；
+- S3 的 Redis + RustFS 最小 smoke 纳入普通 CI，完整回归、重启和故障注入进入定时/手动 workflow；
 - 依赖 crate（s3s/dav-server/nfsserve）版本升级需单独 PR 并附兼容性说明；
 - 协议互通性回归：任何涉及 VFS/meta 的核心改动，需跑 `tests/` 下协议集成测试冒烟。

--- a/doc/protocols/ROADMAP.md
+++ b/doc/protocols/ROADMAP.md
@@ -1,0 +1,37 @@
+# 协议网关路线图
+
+本文档是多协议接入的滚动计划，随每个里程碑完成而更新当前状态。
+设计总纲见 [README.md](README.md)；各协议 spec：[S3](s3-gateway.md) / [WebDAV](webdav.md) / [NFS](nfs.md)。
+
+## 现状（2026-09）
+
+- BrewFS 对外接口：FUSE mount、console（管理面）、control plane；无任何数据面协议网关。
+- `doc/gap/` 将 `gateway`/`webdav` 标为 P2（"视产品方向"）、`06-roadmap.md` 建议"核心稳定后再做网关"。
+  本路线图正式立项推进，理由：核心 POSIX 正确性基线已达成（708 xfstests 全后端通过，
+  见 README「POSIX Correctness」），协议网关反向成为生态短板。
+
+## 里程碑
+
+| 里程碑 | 内容 | 验收标准 | 状态 |
+|---|---|---|---|
+| **M0** 设计立项 | 本目录全部 spec + 路线图 | 文档评审通过（PR 合入） | ✅ 本 PR |
+| **M1** S3 网关 MVP | `brewfs gateway s3`：单 bucket、核心对象操作（Put/Get/Head/Delete/List/Copy）、multipart 全流程、静态密钥、流式数据路径 | 集成测试（aws-sdk-s3 断言）通过；`aws s3 cp/ls/rm` + `mc` e2e 通过；S3 写入 ↔ FUSE 读取交叉验证 | 🚧 进行中 |
+| **M2** WebDAV 网关 | `brewfs gateway webdav`：§3 方法全表、memls、Basic auth、TLS | `litmus` basic/copymove/props/locks 全过；davfs2 挂载读写；Windows 网络驱动器映射冒烟 | ⬜ |
+| **M3** S3 完整化 | 多 bucket、tagging、GetObjectAttributes、条件头、跨实例锁（`/.brewfs.sys/locks/`）、CORS、rustls | `mc` 全功能回归；多实例并发写同一 key 无撕裂 | ⬜ |
+| **M4** NFS 网关 | `brewfs gateway nfs`：NFSv3+mount 全映射表、squash、COMMIT 语义、`InodeAccess` 公开 wrapper | `mount -t nfs -o vers=3` 冒烟；xfstests NFS 子集；NFS ↔ FUSE 交叉验证 | ⬜ |
+| **M5** 生产化 | 三协议指标（tracing/Prometheus 埋点）、CI 准入矩阵接入 compose、部署文档（systemd/k8s/operator sidecar）、性能基线报告 | CI 全绿；性能报告达到各 spec §性能目标 | ⬜ |
+
+## 远期（未排期）
+
+- SMB：FUSE + Samba 重导出文档（过渡）；原生实现待 Rust 生态或自研决策；
+- NFSv4：见 [nfs.md](nfs.md) §9；
+- NLM：见 [nfs.md](nfs.md) §6；
+- HDFS/Java SDK：需先稳定 C ABI（cbindgen over SDK Client）；
+- console 与网关打通：Web 文件管理器、网关实例注册与监控（复用 session/heartbeat）。
+
+## 工作方式约定
+
+- 每个里程碑 = 至少一个 PR：spec 先行（本目录），代码随后；行为变更、测试、文档同 PR；
+- 所有 e2e 验证可在本地 WSL（Ubuntu-22.04）复现：sqlite meta + local-fs data + 真实客户端；
+- 依赖 crate（s3s/dav-server/nfsserve）版本升级需单独 PR 并附兼容性说明；
+- 协议互通性回归：任何涉及 VFS/meta 的核心改动，需跑 `tests/` 下协议集成测试冒烟。

--- a/doc/protocols/nfs.md
+++ b/doc/protocols/nfs.md
@@ -1,0 +1,190 @@
+# NFS Gateway Spec
+
+状态：已立项
+依赖：`nfsserve = "0.11"`（feature `gateway-nfs`）
+CLI：`brewfs gateway nfs --listen <addr:2049> [--squash root|all|none] [后端参数...]`
+
+## 1. 目标与非目标
+
+### 目标
+
+- 以 **NFSv3**（RFC 1813，含 mount 协议 MOUNTv3）直接暴露 BrewFS volume，
+  客户端 `mount -t nfs -o vers=3,tcp` 即可使用，**不经过内核 FUSE**；
+- 文件句柄 = BrewFS inode 号（稳定、重启可恢复），支持 `no_root_squash` 之外的标准 squash；
+- 语义忠实：写路径 COMMIT 保证、readdirplus、符号链接/硬链接/mknod 全映射；
+- 性能不低于"FUSE mount + kernel nfsd 重导出"方案（理论上更优：少一层内核往返）。
+
+### 非目标
+
+- NFSv4 / v4.1 / pNFS（有状态语义需要另一套设计，见 §9 评估）；
+- UDP 传输（nfsserve 为 TCP；现代客户端默认 TCP，可接受）；
+- Kerberos / RPCSEC_GSS（AUTH_SYS only）；
+- NLM（网络锁管理器）——v3 配套的锁协议，nfsserve 未实现，见 §6。
+
+## 2. 背景：为什么自实现而不是重导出
+
+JuiceFS 官方方案是"FUSE mount + kernel nfsd 重导出"（`/etc/exports` 配 `fsid=N`）。
+该方案对 BrewFS 同样有效，作为**过渡方案**写入部署文档；但它有三个根本限制：
+
+1. 依赖 FUSE 挂载权限与内核态数据路径，容器/非特权环境不友好；
+2. 两层缓存（NFS 客户端页缓存 ↔ kernel nfsd ↔ FUSE ↔ BrewFS 缓存）一致性窗口叠加；
+3. 无法在网关层做协议感知的优化（如 COMMIT 直接映射 fsync 策略、readdirplus 批量取属性）。
+
+自实现基于 `nfsserve` crate：实现 `NFSFileSystem` trait 即获得完整 NFSv3+mount 服务。
+
+## 3. 文件句柄与 VFS 访问层
+
+```
+NFS client (kernel)
+      │ NFSv3 over TCP (port 2049)
+      ▼
+┌────────────┐  NFSFileSystem trait   ┌──────────────┐  inode API   ┌─────┐
+│ nfsserve    │ ─────────────────────▶ │ BrewFsNfs     │ ───────────▶ │ VFS │
+│ (tcp server)│   fileid = inode       │ (src/gateway/nfs)│            └─────┘
+└────────────┘                        └──────────────┘
+```
+
+关键决策：
+
+- **fileid 即 inode**：`fileid: u64 = ino`。BrewFS inode 由 meta 层分配，稳定且唯一，
+  满足 NFS 句柄"重启后仍可解析"的要求（stale handle → `NFS3ERR_STALE`）；
+- **VFS inode API 公开化**：`VFS` 的 inode 级方法（`stat_ino`、`readdir_ino`、`child_of`、
+  `mkdir_at_new`、`create_file_at_with_attrs`、`rename_at_with_known_attrs`、`parent_of`、`path_of` 等，
+  `src/vfs/fs/mod.rs:1250-4465`）当前为 `pub(crate)`。实现时新增公开 wrapper：
+
+  ```rust
+  // src/vfs/handles.rs（新）
+  pub struct InodeAccess<S, M> { vfs: VFS<S, M> }
+  ```
+
+  只暴露 NFS 需要的子集，保持 VFS 内部演进自由。不直接改 `pub`（避免把内部 API 表面固化）；
+- **句柄与路径的互转**：NFS 侧绝大多数操作直接给 inode；少数需要路径的场景
+  （诊断日志、stale 恢复提示）用 `path_of(ino)`。
+
+## 4. 操作映射表（NFSPROC3）
+
+| NFS 过程 | BrewFS（VFS inode API）映射 | 说明 |
+|---|---|---|
+| `NULL` / `MOUNT` / `UMNT` | 直接应答 | mount 协议返回根句柄 + auth flavors `[AUTH_SYS]` |
+| `GETATTR` | `stat_ino(ino)` | 属性缓存见 §5 |
+| `SETATTR` | `set_attr`（mode/uid/gid/size/atime/mtime） | size 变化走 `truncate` 路径；guard（ctime 检查）支持 |
+| `LOOKUP` | `child_of(dir_ino, name)` + `stat_ino` | |
+| `ACCESS` | 按 squash 后的 uid/gid 对 `stat_ino` 的 mode 位做权限判定 | 不真正以该身份执行（MVP），语义等价 `access(2)` |
+| `READ` | `open(ino, read)` → `read(fh, off, len)` → `close` | 无状态：每次独立 open/close（BrewFS open 开销小）；后续可加 fh 池 |
+| `WRITE` | `open(ino, write)` → `write(fh, off, data)` → `close` | stable_how 语义见 §5 |
+| `CREATE` | `create_file_at_with_attrs(dir, name, attrs)` | EXCLUSIVE 模式：以 verifier 存 xattr 实现幂等（`brewfs.nfs.createverf`） |
+| `MKDIR` / `RMDIR` | `mkdir_at_new` / `rmdir_at` | 非空 → `NFS3ERR_NOTEMPTY` |
+| `REMOVE` | `unlink`（按 dir+name） | |
+| `RENAME` | `rename_at_with_known_attrs` | 跨目录 rename 由 meta 事务保证原子 |
+| `LINK` / `SYMLINK` / `READLINK` | `link_by_ino` / `create_symlink_at` / `readlink_ino` | |
+| `MKNOD` | 按类型分发（fifo/socket 由 meta 特殊文件支持） | 无权限创建 device 时返回 `NFS3ERR_PERM` |
+| `READDIR` / `READDIRPLUS` | `readdir_ino(ino)`（内部已分页） | readdirplus 批量带 attr，显著减少客户端 GETATTR 往返；cookie/verifier 用 (ino, 条目序号) 编码，快照内单调 |
+| `FSSTAT` | `stat_fs()` | |
+| `FSINFO` | 静态通告：`rtmax/wtmax = 1 MiB`、`rtpref/wtpref = 256 KiB`、time_delta=1ms、`properties = FSF3_LINK|SYMLINK|HOMOGENEOUS|CANSETTIME` | |
+| `PATHCONF` | 静态：`linkmax/chown_restricted=true/no_trunc=true/name_max=255` | |
+| `COMMIT` | 对该 inode `open` + `fsync`（或直接触发写回队列 flush 该文件） | §5 |
+
+错误码映射：`NotFound→NOENT`、`PermissionDenied→ACCES`、`AlreadyExists→EXIST`、
+`DirectoryNotEmpty→NOTEMPTY`、非目录→`NOTDIR`、是目录→`ISDIR`、
+句柄对应 inode 已不存在→`STALE`、空间不足→`NOSPC`、其他→`IO`。
+
+## 5. 写路径与 COMMIT 语义（重点）
+
+NFSv3 无 open/close，客户端写经过其页缓存，依赖 `WRITE` 的 `stable_how` 与 `COMMIT` 保证持久性：
+
+| 客户端请求 | BrewFS 行为 |
+|---|---|
+| `WRITE stable=UNSTABLE` | 写入即返回（数据进 BrewFS 写路径/写回缓存），返回 `committed=UNSTABLE` + write verifier |
+| `WRITE stable=FILE_SYNC` | 写入并等该文件数据落盘（`flush` 语义），返回 `FILE_SYNC` |
+| `WRITE stable=DATA_SYNC` | 同 FILE_SYNC（BrewFS 元数据与数据同事务，无单独 data-only 通道） |
+| `COMMIT` | `fsync` 目标 inode：确保该文件所有已写数据到达持久层（或写回缓存已排队且副本安全——
+  按 mount 的 writeback 配置如实选择：writeback 模式下 COMMIT 语义以
+  "写入 SSD 写回缓存 + meta 已记录"为准，与 FUSE 挂载的 fsync 策略保持一致） |
+
+- **write verifier**：网关启动时生成的随机 u64，重启变更，客户端据此重发未提交写；
+- 性能要求：`UNSTABLE` 写绝不触发 fsync；`COMMIT` 粒度为单文件，不全局刷盘；
+- 大顺序写吞吐目标：≥ 同机 FUSE 直挂的 70%（少了内核 nfsd 一层，预期更高，留有余量）。
+
+## 6. 锁（NLM 缺失的应对）
+
+- NFSv3 的文件锁由带外协议 NLM 提供，nfsserve 未实现；
+- **MVP 行为**：客户端 `lockf/fcntl` 将失败或退化为本地锁（取决于客户端挂载选项
+  `nolock`/`local_lock`）。文档强制建议挂载参数：
+  `mount -t nfs -o vers=3,tcp,nolock`（单写者/读多场景）；
+- 后续：评估自实现 NLMv4（ONC-RPC 直写，工作量中等）或向 nfsserve 上游贡献；
+  BrewFS 侧已有 `get_plock/set_plock`（`src/vfs/fs/mod.rs:4471/4482`）可承接。
+
+## 7. 认证、squash 与身份映射
+
+- AUTH_SYS（uid/gid 明文随包）；
+- `--squash`：
+  - `root`（默认）：客户端 uid0 → 匿名 uid/gid（默认 65534，可配 `--anon-uid/--anon-gid`）；
+  - `all`：所有用户 → 匿名；
+  - `none`：信任客户端身份（仅可信网络）；
+- 身份使用：squash 后的 (uid,gid,groups) 构造 `CallerIdentity`（`src/fs.rs:279`，
+  随本里程碑公开化）参与权限判定；文件创建继承该身份；
+- 导出访问控制：MVP 单导出（整个 volume）+ `--allow <cidr,...>` IP 白名单；
+  多导出/子目录导出列后续。
+
+## 8. 与 FUSE/其他网关的一致性
+
+- NFS 客户端属性缓存（默认 3-60s）是主要弱一致窗口：FUSE 侧改文件后，NFS 客户端
+  最坏 60s 才看到；文档建议对强一致需求客户端 `mount -o actimeo=0,noac`；
+- 网关内不额外缓存 attr（每次 GETATTR 走 MetaClient，其缓存失效机制与 FUSE 挂载一致）；
+- 重命名/删除正在被 NFS 客户端打开的文件：POSIX 语义由 meta 层 inode 引用计数保证
+  （与 FUSE 的 silly-rename 需求不同，NFS 客户端自己会处理 `.nfsXXXX` 模式，无需网关配合）。
+
+## 9. NFSv4 评估（远期）
+
+- v4 核心差异：有状态（open/lock stateid、delegation）、复合操作、单一端口、UTF-8 域名；
+- 与 BrewFS 契合点：VFS 句柄模型可承接 open state；delegation 可对接 MetaClient 缓存失效；
+- 障碍：Rust 生态无 v4 server crate（nfsserve 仅 v3），需自研或上游共建——工作量远超 v3；
+- 结论：v3 先行覆盖"Unix 集群共享"场景；v4 待 v3 稳定后按需求立项。
+
+## 10. 过渡方案：kernel nfsd 重导出（文档项）
+
+实现落地前/不满足自实现条件时，部署文档提供：
+
+```bash
+brewfs mount /mnt/brewfs ...
+# /etc/exports: /mnt/brewfs *(rw,async,fsid=1,no_subtree_check)
+exportfs -ra
+```
+
+注明：`fsid` 必须显式（FUSE 文件系统无设备号）；`async` + BrewFS writeback 组合的性能提示。
+（JuiceFS 官方即此方案，`juicefs/docs/en/deployment/nfs.md`。）
+
+## 11. 测试计划
+
+1. **单元测试**：verifier/cookie 编码、错误码映射、squash 判定、EXCLUSIVE CREATE 幂等；
+2. **集成测试**（`tests/nfs_gateway_test.rs`）：进程内起服务 + `mount -t nfs -o vers=3,tcp,port=<p>,mountport=<p>`
+   （测试容器内需 nfs-common），跑 create/read/write/rename/link/readdir 断言；
+3. **e2e**：WSL/compose 内真实挂载，跑：
+   - 常规：`cp/rsync/tar` 大文件与小文件集；
+   - `xfstests` 通用用例子集（NFS 适配组）；
+   - 并发：多客户端同目录创建/重命名；
+   - 重启网关 → 客户端 stale handle 与重挂载恢复；
+4. **交叉一致性**：NFS 写入 → FUSE/S3 读取验证。
+
+## 12. CLI 参数
+
+```
+brewfs gateway nfs \
+  --listen 0.0.0.0:2049 \
+  [--squash root|all|none] [--anon-uid 65534 --anon-gid 65534] \
+  [--allow 10.0.0.0/8,192.168.0.0/16] \
+  [--max-read 1MiB --max-write 1MiB] \
+  <与 mount 相同的后端参数>
+```
+
+## 13. 里程碑
+
+- **M4（首个实现）**：§4 全表 + AUTH_SYS/squash + COMMIT 语义 + mount 挂载冒烟 + e2e 脚本。
+- **后续**：NLM、fh 池/属性缓存优化、多导出、`xfstests` NFS 组全量、NFSv4 立项评估。
+
+## 14. 参考
+
+- nfsserve crate：<https://crates.io/crates/nfsserve>（NFSv3+mount，TCP）；
+- RFC 1813（NFSv3）、RFC 1094（mount）、RFC 5716（squash/安全相关背景）；
+- JuiceFS NFS 部署文档（重导出方案）：`juicefs/docs/en/deployment/nfs.md`；
+- BrewFS VFS inode API：`src/vfs/fs/mod.rs:1250-4465`；CallerIdentity：`src/fs.rs:279`。

--- a/doc/protocols/s3-gateway.md
+++ b/doc/protocols/s3-gateway.md
@@ -1,0 +1,187 @@
+# S3 Gateway Spec
+
+状态：已立项（首个实现目标）
+依赖：`s3s = "0.15"`（feature `gateway-s3`）
+CLI：`brewfs gateway s3 --listen <addr> --access-key <ak> --secret-key <sk> [后端参数...]`
+
+## 1. 目标与非目标
+
+### 目标
+
+- 以 S3 兼容协议暴露一个 BrewFS volume，支持 `aws cli`、`mc`、s3fs、各类 SDK（boto3/aws-sdk）直接访问；
+- 覆盖单 bucket 与多 bucket 两种模式（见 §3）；
+- 覆盖核心对象操作与 multipart 上传（§4 映射表中标 ★ 的操作）；
+- 与 FUSE 挂载数据互通：S3 写入的对象可在 FUSE 下按路径读取，反之亦然；
+- 流式数据路径：GET/PUT 不整对象入内存，range 请求走 `read_at`。
+
+### 非目标（显式排除，调用返回 NotImplemented）
+
+- Bucket/Object versioning（`ListObjectVersions` 浅实现或直接 501）；
+- Object Lock / Retention / Legal Hold；
+- SSE（服务端加密）与对象级压缩；
+- Bucket policy / IAM / STS（MVP 只有静态密钥对，见 §6）；
+- Event notification、Lifecycle、Replication、Inventory；
+- Presigned URL 由 s3s 的 SigV4 校验天然支持（客户端侧功能），不额外开发。
+
+## 2. 架构
+
+```
+aws cli / mc / SDK
+      │ HTTP + SigV4
+      ▼
+┌─────────────┐   S3 trait (s3s)   ┌──────────────┐   ClientBackend (path ops)
+│ s3s::service │ ─────────────────▶ │ BrewFsS3      │ ────────────────────▶ Client ─▶ VFS ─▶ meta/data
+│ (axum/tokio) │                   │ (src/gateway/s3)│
+└─────────────┘                   └──────────────┘
+                                         │ xattr: brewfs.s3.{etag,meta,tags,dirobj}
+                                         │ 内部状态: /.brewfs.sys/s3/{uploads,tmp}
+```
+
+- HTTP/SigV4/路由/序列化全部交给 s3s；我们只实现 `s3s::S3` trait 的方法；
+- 存储映射层（`BrewFsS3`）基于 SDK `Client`（path-based），不依赖 FUSE；
+- 大对象分段流式转发：s3s 的请求 body 是 `Stream<Byte>`，写侧以固定窗口（默认 4 MiB，
+  对齐 chunk block 大小）`write_at` 到 tmp 文件；读侧用 s3s 的 `StreamingBlob` 包装
+  `read_at` 迭代器。
+
+## 3. Bucket 模型
+
+| 模式 | 开启方式 | 映射 | 说明 |
+|---|---|---|---|
+| 单 bucket（默认） | `--bucket <name>`（缺省为 volume 名） | 整个 volume = 一个 bucket；`/` 是 bucket 根 | 与 JuiceFS gateway 默认行为一致 |
+| 多 bucket | `--multi-buckets` | 顶层目录即 bucket：`/<bucket>/<key>` | `CreateBucket` = mkdir 顶层目录；`ListBuckets` = readdir `/` 并过滤合法 bucket 名与 `.brewfs.sys` |
+
+约束：
+
+- bucket 名合法性按 S3 规则（3-63 字符、小写、无连续点等）校验，不合法目录在多 bucket 模式下不出现在 ListBuckets；
+- 两种模式下 object key → 路径的映射都是直接的 `/<key>`（单 bucket）或 `/<bucket>/<key>`（多 bucket），**不做 key 编码**；
+  key 中的 `..`、以 `/` 开头等畸形输入在入口校验拒绝（`InvalidArgument`），防止逃逸 bucket 根；
+- `HeadBucket` = stat bucket 根目录；`DeleteBucket` = rmdir 空目录（非空返回 `BucketNotEmpty`）。
+
+## 4. 操作映射表
+
+★ = MVP 必须；○ = 后续里程碑；✗ = 显式不支持（501）。
+
+| S3 操作 | 状态 | BrewFS 映射 |
+|---|---|---|
+| PutObject | ★ | 流式写 `/.brewfs.sys/s3/tmp/<uuid>` → flush → `rename` 到目标路径（父目录按需 `mkdir_p`）；随后写入 etag/meta/tags xattr。覆盖写 = 同流程（rename 原子替换） |
+| GetObject | ★ | `stat` + `read_at` 流式返回；支持 `Range`（含 suffix range）、`If-Modified-Since` 等条件头 |
+| HeadObject | ★ | `stat` + 读 xattr 还原 ETag/Content-Type/user meta；目录对象判定见 §5 |
+| DeleteObject | ★ | `unlink`；随后自底向上回收变空的父目录，直到 bucket 根或遇到目录对象（§5）——模拟 S3 扁平命名空间 |
+| DeleteObjects（批量） | ★ | 循环单删，逐项汇报错误（S3 语义允许部分失败） |
+| ListObjectsV1 / V2 | ★ | 基于 `readdir` 的前缀树遍历，实现 delimiter/prefix/marker(start-after)/max-keys；根目录过滤 `.brewfs.sys`；目录对象按 §5 规则出现或隐藏 |
+| CreateBucket / DeleteBucket / HeadBucket / ListBuckets | ★ | 见 §3 |
+| CopyObject | ★ | 服务端内完成：源 `read_at` → tmp 文件 → rename（不经客户端）；xattr 按 `MetadataDirective` 复制或替换。大数据量后续可优化为 chunk 级克隆（需要 chunk 层支持，记为后续项） |
+| CreateMultipartUpload | ★ | 建目录 `/.brewfs.sys/s3/uploads/<hh>/<upload-id>/`，`.target` 占位文件 xattr 记录目标 bucket/key、content-type、user meta；`<hh>` = upload-id 前 2 位十六进制扇出 |
+| UploadPart | ★ | 流式写 `uploads/<hh>/<id>/part-<n>`（覆盖同 n 即重写），part etag 记 xattr `brewfs.s3.etag` |
+| ListParts | ★ | readdir upload 目录 + 逐 part stat/xattr |
+| ListMultipartUploads | ★ | 扫描 `uploads/` 两级目录，读 `.target` xattr 还原 key，支持 prefix/delimiter 过滤 |
+| CompleteMultipartUpload | ★ | 校验 part 序号连续性与 etag；按序 `read_at` 各 part 追加写 tmp 文件（流式，不整读）→ 计算 S3 multipart etag（md5(part-md5...) + "-" + N）→ rename 落位 → 写 xattr → `remove_dir_all` upload 目录 |
+| AbortMultipartUpload | ★ | `remove_dir_all` upload 目录 |
+| PutObjectTagging / GetObjectTagging / DeleteObjectTagging | ○ | xattr `brewfs.s3.tags` |
+| GetObjectAttributes | ○ | 组合 stat + xattr |
+| SelectObjectContent | ✗ | 501 |
+| Versioning 系列 | ✗ | 501 |
+| Object Lock / Retention | ✗ | 501 |
+| SSE-KMS/SSE-C | ✗ | 501（SSE 头出现时可选择拒绝或忽略，MVP 选择拒绝并返回 `NotImplemented`，避免"假装加密"） |
+| Bucket policy / ACL / CORS / Lifecycle / Notification / Replication | ✗/○ | MVP 返回静态默认值或 501；CORS 后续按部署需要加 |
+
+### 条件写（If-None-Match / If-Match）
+
+MVP 支持 `If-None-Match: *`（create_new 语义 → `AlreadyExists` 映射 `PreconditionFailed`），
+其余条件头在 MVP 记录并忽略，后续里程碑补齐。
+
+## 5. 目录语义（S3 扁平空间 ↔ POSIX 层级）
+
+这是 S3 网关最难做对的部分，规则如下（与 JuiceFS gateway 行为对齐，但用 xattr 代替 atime 技巧）：
+
+1. **隐式目录**：`PUT a/b/c.txt` 自动 `mkdir_p a/b`；list `a/` 时 `a/b/` 作为 CommonPrefix 出现。
+   这些目录没有 xattr 标记，DeleteObject 后被回收（逐级向上，遇非空停）。
+2. **显式目录对象**：`PUT a/b/`（key 以 `/` 结尾，零长度 body）创建真实目录并打
+   `brewfs.s3.dirobj` xattr；它在 list 中作为一条零字节对象出现（key 带尾 `/`），
+   DeleteObject 父级回收遇到它停止；`--hide-dir-objects` 选项可在 list 中隐藏。
+3. **文件与目录同名冲突**：POSIX 下不可能共存；若 FUSE 侧手工构造出与对象同前缀的结构，
+   list 结果以目录优先（与 JuiceFS 一致），文档声明避免混用。
+4. `HEAD key/`（带尾斜杠）命中目录对象返回 200；命中隐式目录返回 404（S3 真实行为）。
+
+## 6. 认证与安全
+
+- MVP：单一静态密钥对。`--access-key/--secret-key` 或环境变量 `BREWFS_S3_ACCESS_KEY/BREWFS_S3_SECRET_KEY`；
+  SigV4 校验由 s3s 的 auth 组件完成（支持 header 签名与 presigned URL）；
+- 未配置密钥时拒绝启动（不允许匿名读写）；`--anonymous-read` 显式开启匿名只读（公共桶场景）；
+- TLS：MVP 为 HTTP；生产部署建议前置反向代理（nginx/caddy）终结 TLS。
+  原生 TLS（rustls）列后续里程碑；
+- 后续：多密钥对（静态配置表）、与 console 认证打通。
+
+## 7. 一致性与并发
+
+- **写-写冲突**：单实例内 dashmap 按 `(bucket,key)` 分片互斥，串行化同一 key 的
+  Put/Complete/Delete/Rename 路径；不同 key 完全并发；
+- **写-读冲突**：读旧对象期间发生覆盖写，rename 原子性保证读者拿到完整旧版或完整新版，
+  不会读到半个对象（tmp+rename 模式的核心收益）；
+- **multipart 并发**：同一 upload-id 的 part 上传并发安全（不同 part 不同文件）；
+  同一 part number 重复上传后者覆盖前者（S3 语义）；
+- **多网关实例**：MVP 不保证跨实例的 key 级串行化（依赖 rename/create 原子性兜底，
+  语义为 last-writer-wins）；跨实例分布式锁（`/.brewfs.sys/locks/` + meta flock）列入 M3；
+- **list 一致性**：以 meta 层 readdir 时点快照为准，分页遍历期间的并发增删不保证边界精确
+  （与 S3 实际一致：list 是弱一致）。
+
+## 8. 错误码映射
+
+| BrewFS 错误 | S3 响应 |
+|---|---|
+| `NotFound`（对象） | 404 `NoSuchKey` |
+| `NotFound`（bucket 根） | 404 `NoSuchBucket` |
+| `AlreadyExists`（bucket） | 409 `BucketAlreadyExists` / `BucketAlreadyOwnedByYou` |
+| `DirectoryNotEmpty` | 409 `BucketNotEmpty` |
+| `PermissionDenied` | 403 `AccessDenied` |
+| `InvalidInput`（key 畸形/part 序号错） | 400 `InvalidArgument` / `InvalidPartOrder` |
+| 空间不足 / 配额 | 507 `InsufficientStorage`（自定义 message） |
+| 其他内部错误 | 500 `InternalError` + request id |
+
+etag 不匹配的 part 校验 → 400 `InvalidPart`；upload-id 不存在 → 404 `NoSuchUpload`。
+
+## 9. 性能目标与要求
+
+- PUT/GET 大对象（≥1 GiB）稳态吞吐不低于同机 FUSE 挂载直写的 80%（无内核路径，理论上应更高）；
+- 全程流式：单连接内存占用有界（≤ 2 × 4 MiB 缓冲 + 协议栈开销），与对象大小无关；
+- 并发：默认 tokio worker 全核；单 key 串行不成为全局瓶颈；
+- list 每页 max-keys=1000 的 p99 延迟 < 200ms（sqlite meta，10 万对象规模内）。
+
+## 10. CLI 参数
+
+```
+brewfs gateway s3 \
+  --listen 0.0.0.0:9000            # 监听地址
+  --access-key / --secret-key      # 静态密钥（或 env）
+  [--bucket <name>]                # 单 bucket 名（默认 volume 名）
+  [--multi-buckets]                # 多 bucket 模式
+  [--hide-dir-objects]             # list 隐藏目录对象
+  [--anonymous-read]               # 匿名只读
+  [--domain <base>]                # virtual-host 风格访问（后续）
+  <与 mount 相同的后端参数>
+```
+
+## 11. 测试计划
+
+1. **单元测试**（`src/gateway/s3/` 内）：key→路径校验、目录对象判定、etag 计算、
+   分页遍历的 marker 边界、`.brewfs.sys` 过滤；
+2. **集成测试**（`tests/s3_gateway_test.rs`）：进程内 `VFS`（sqlite memory + 本地目录数据后端）
+   + 起 s3s 服务于随机端口，用 `aws-sdk-s3`（已在依赖树）做客户端断言全映射表；
+3. **端到端**（`scripts/` 或 compose）：真实二进制 + `aws s3 cp/ls/rm/mb/rb`、`mc cp/ls`，
+   含 multipart（>8 MiB 文件强制分片）、FUSE 交叉读写验证；
+4. **兼容性冒烟**：boto3、s3fs 挂载读、presigned URL 下载。
+
+## 12. 里程碑拆分
+
+- **M1（本 spec 首个实现）**：单 bucket；§4 全部 ★；静态密钥；流式 PUT/GET；
+  集成测试 + aws cli e2e。
+- **M3（完整化）**：多 bucket、tagging、GetObjectAttributes、条件头补全、
+  跨实例锁、CORS、rustls、mc 全功能回归。
+
+## 13. 参考
+
+- JuiceFS gateway：`pkg/gateway/gateway.go`（tmp+rename、`/.sys`、xattr etag/meta、
+  DeleteObject 父目录回收、multipart 目录模型、cleanup 周期任务）；
+  文档 `juicefs/docs/en/guide/gateway.md`；
+- s3s crate：<https://crates.io/crates/s3s>（RustFS 同源 S3 服务框架）；
+- 本目录 [README.md](README.md) §3 共用约定。

--- a/doc/protocols/s3-gateway.md
+++ b/doc/protocols/s3-gateway.md
@@ -1,6 +1,6 @@
 # S3 Gateway Spec
 
-状态：已立项（首个实现目标）
+状态：M1 MVP 已实现（PR #83），进入兼容性与生产化迭代
 依赖：`s3s = "0.15"`（feature `gateway-s3`）
 CLI：`brewfs gateway s3 --listen <addr> --access-key <ak> --secret-key <sk> [后端参数...]`
 
@@ -8,20 +8,29 @@ CLI：`brewfs gateway s3 --listen <addr> --access-key <ak> --secret-key <sk> [�
 
 ### 目标
 
-- 以 S3 兼容协议暴露一个 BrewFS volume，支持 `aws cli`、`mc`、s3fs、各类 SDK（boto3/aws-sdk）直接访问；
+- 以 S3 兼容协议暴露一个 BrewFS volume；当前已用 boto3 验证，目标兼容 `aws cli`、`mc`、s3fs 与各类 AWS SDK；
 - 覆盖单 bucket 与多 bucket 两种模式（见 §3）；
-- 覆盖核心对象操作与 multipart 上传（§4 映射表中标 ★ 的操作）；
+- 覆盖核心对象操作与 multipart 上传（见 §4 的 M1 操作）；
 - 与 FUSE 挂载数据互通：S3 写入的对象可在 FUSE 下按路径读取，反之亦然；
 - 流式数据路径：GET/PUT 不整对象入内存，range 请求走 `read_at`。
 
 ### 非目标（显式排除，调用返回 NotImplemented）
 
-- Bucket/Object versioning（`ListObjectVersions` 浅实现或直接 501）；
+以下能力不属于当前 M1 MVP，除非另有说明，调用应返回 `NotImplemented` 或协议对应的明确“不支持”错误：
+
+- Bucket/Object versioning（`ListObjectVersions`）；
 - Object Lock / Retention / Legal Hold；
 - SSE（服务端加密）与对象级压缩；
-- Bucket policy / IAM / STS（MVP 只有静态密钥对，见 §6）；
+- Bucket policy / ACL / IAM / STS；M1 只有单一静态密钥对（见 §6）；
 - Event notification、Lifecycle、Replication、Inventory；
-- Presigned URL 由 s3s 的 SigV4 校验天然支持（客户端侧功能），不额外开发。
+- SelectObjectContent；
+- Bucket tagging、Website、Logging、Notification 等桶级配置接口；
+- 完整的 `encoding-type`、`fetch-owner` 及 V1 `NextMarker` 列表扩展语义；
+- ARN 形式的 `x-amz-copy-source`；M1 仅支持 `bucket/key`；
+- 跨网关实例的分布式 key/bucket 锁；M1 仅提供进程内互斥；
+- 原生 TLS；M1 使用 HTTP，生产环境需由反向代理终结 TLS。
+
+Presigned URL 不需要服务端新增 API，但仍须验证 s3s SigV4 query authentication 与 BrewFS 路由的组合行为，列入 M3 客户端兼容性矩阵。
 
 ## 2. 架构
 
@@ -29,8 +38,8 @@ CLI：`brewfs gateway s3 --listen <addr> --access-key <ak> --secret-key <sk> [�
 aws cli / mc / SDK
       │ HTTP + SigV4
       ▼
-┌─────────────┐   S3 trait (s3s)   ┌──────────────┐   ClientBackend (path ops)
-│ s3s::service │ ─────────────────▶ │ BrewFsS3      │ ────────────────────▶ Client ─▶ VFS ─▶ meta/data
+┌─────────────┐   S3 trait (s3s)   ┌──────────────┐   inode/path operations
+│ s3s::service │ ─────────────────▶ │ BrewFsS3      │ ───────────────────────▶ VFS ─▶ meta/data
 │ (axum/tokio) │                   │ (src/gateway/s3)│
 └─────────────┘                   └──────────────┘
                                          │ xattr: brewfs.s3.{etag,meta,tags,dirobj}
@@ -38,16 +47,16 @@ aws cli / mc / SDK
 ```
 
 - HTTP/SigV4/路由/序列化全部交给 s3s；我们只实现 `s3s::S3` trait 的方法；
-- 存储映射层（`BrewFsS3`）基于 SDK `Client`（path-based），不依赖 FUSE；
+- 存储映射层（`BrewFsS3`）直接使用进程内 `VFS`，不依赖 FUSE；
 - 大对象分段流式转发：s3s 的请求 body 是 `Stream<Byte>`，写侧以固定窗口（默认 4 MiB，
-  对齐 chunk block 大小）`write_at` 到 tmp 文件；读侧用 s3s 的 `StreamingBlob` 包装
-  `read_at` 迭代器。
+  对齐 chunk block 大小）写入 staging 文件；读侧用 s3s 的 `StreamingBlob` 包装固定 inode 的
+  分块读取流，并通过 bounded channel 提供背压。
 
 ## 3. Bucket 模型
 
 | 模式 | 开启方式 | 映射 | 说明 |
 |---|---|---|---|
-| 单 bucket（默认） | `--bucket <name>`（缺省为 volume 名） | 整个 volume = 一个 bucket；`/` 是 bucket 根 | 与 JuiceFS gateway 默认行为一致 |
+| 单 bucket（默认） | `--bucket <name>`（缺省为 `brewfs`） | 整个 volume = 一个 bucket；`/` 是 bucket 根 | 与 JuiceFS gateway 默认行为一致 |
 | 多 bucket | `--multi-buckets` | 顶层目录即 bucket：`/<bucket>/<key>` | `CreateBucket` = mkdir 顶层目录；`ListBuckets` = readdir `/` 并过滤合法 bucket 名与 `.brewfs.sys` |
 
 约束：
@@ -59,36 +68,43 @@ aws cli / mc / SDK
 
 ## 4. 操作映射表
 
-★ = MVP 必须；○ = 后续里程碑；✗ = 显式不支持（501）。
+状态含义：`M1` = 已随 PR #83 实现；`M3` = S3 兼容性补全计划；`M5/远期` = 生产化或长期能力。
 
-| S3 操作 | 状态 | BrewFS 映射 |
+| S3 操作 | 状态 | BrewFS 映射或计划 |
 |---|---|---|
-| PutObject | ★ | 流式写 `/.brewfs.sys/s3/tmp/<uuid>` → flush → `rename` 到目标路径（父目录按需 `mkdir_p`）；随后写入 etag/meta/tags xattr。覆盖写 = 同流程（rename 原子替换） |
-| GetObject | ★ | `stat` + `read_at` 流式返回；支持 `Range`（含 suffix range）、`If-Modified-Since` 等条件头 |
-| HeadObject | ★ | `stat` + 读 xattr 还原 ETag/Content-Type/user meta；目录对象判定见 §5 |
-| DeleteObject | ★ | `unlink`；随后自底向上回收变空的父目录，直到 bucket 根或遇到目录对象（§5）——模拟 S3 扁平命名空间 |
-| DeleteObjects（批量） | ★ | 循环单删，逐项汇报错误（S3 语义允许部分失败） |
-| ListObjectsV1 / V2 | ★ | 基于 `readdir` 的前缀树遍历，实现 delimiter/prefix/marker(start-after)/max-keys；根目录过滤 `.brewfs.sys`；目录对象按 §5 规则出现或隐藏 |
-| CreateBucket / DeleteBucket / HeadBucket / ListBuckets | ★ | 见 §3 |
-| CopyObject | ★ | 服务端内完成：源 `read_at` → tmp 文件 → rename（不经客户端）；xattr 按 `MetadataDirective` 复制或替换。大数据量后续可优化为 chunk 级克隆（需要 chunk 层支持，记为后续项） |
-| CreateMultipartUpload | ★ | 建目录 `/.brewfs.sys/s3/uploads/<hh>/<upload-id>/`，`.target` 占位文件 xattr 记录目标 bucket/key、content-type、user meta；`<hh>` = upload-id 前 2 位十六进制扇出 |
-| UploadPart | ★ | 流式写 `uploads/<hh>/<id>/part-<n>`（覆盖同 n 即重写），part etag 记 xattr `brewfs.s3.etag` |
-| ListParts | ★ | readdir upload 目录 + 逐 part stat/xattr |
-| ListMultipartUploads | ★ | 扫描 `uploads/` 两级目录，读 `.target` xattr 还原 key，支持 prefix/delimiter 过滤 |
-| CompleteMultipartUpload | ★ | 校验 part 序号连续性与 etag；按序 `read_at` 各 part 追加写 tmp 文件（流式，不整读）→ 计算 S3 multipart etag（md5(part-md5...) + "-" + N）→ rename 落位 → 写 xattr → `remove_dir_all` upload 目录 |
-| AbortMultipartUpload | ★ | `remove_dir_all` upload 目录 |
-| PutObjectTagging / GetObjectTagging / DeleteObjectTagging | ○ | xattr `brewfs.s3.tags` |
-| GetObjectAttributes | ○ | 组合 stat + xattr |
-| SelectObjectContent | ✗ | 501 |
-| Versioning 系列 | ✗ | 501 |
-| Object Lock / Retention | ✗ | 501 |
-| SSE-KMS/SSE-C | ✗ | 501（SSE 头出现时可选择拒绝或忽略，MVP 选择拒绝并返回 `NotImplemented`，避免"假装加密"） |
-| Bucket policy / ACL / CORS / Lifecycle / Notification / Replication | ✗/○ | MVP 返回静态默认值或 501；CORS 后续按部署需要加 |
+| PutObject | M1 | 流式写 staging 文件，写完数据与 xattr 后 `rename` 到目标路径；覆盖发布保持原子性 |
+| GetObject | M1 | `stat` + 固定 inode 分块流式返回；支持完整对象与单 Range 读取 |
+| HeadObject | M1 | `stat` + xattr 还原 ETag、Content-Type 和 user metadata；目录对象判定见 §5 |
+| DeleteObject | M1 | `unlink`；随后自底向上回收变空的隐式父目录，直到 bucket 根或显式目录对象 |
+| DeleteObjects（批量） | M1 | 逐项删除并返回每项结果 |
+| ListObjectsV1 / V2 | M1 | 前缀树遍历；支持 prefix、delimiter、marker/start-after、continuation-token 和 max-keys；在分页计数前过滤不可见目录 |
+| CreateBucket / DeleteBucket / HeadBucket / ListBuckets / GetBucketLocation | M1 | 见 §3；进程内 bucket lifecycle lock 防止删桶与迟到发布竞态 |
+| CopyObject | M1 | VFS 内部分块复制到 staging 后原子发布；支持 `bucket/key` copy source 和 metadata copy/replace |
+| CreateMultipartUpload | M1 | 建目录 `/.brewfs.sys/s3/uploads/<hh>/<upload-id>/`，`.target` 记录目标 bucket/key 和 metadata |
+| UploadPart | M1 | 流式写 `part-<n>`，part ETag 记入 `brewfs.s3.etag` xattr |
+| ListParts / ListMultipartUploads | M1 | 分页扫描内部 upload 状态并验证 upload ID、bucket、key 归属 |
+| CompleteMultipartUpload | M1 | 校验严格递增的 part 序号与 ETag（允许序号有空档）；除最后一片外检查 5 MiB 下限；分块合并 staging 后原子发布 |
+| AbortMultipartUpload | M1 | 验证归属后递归删除 upload 目录 |
+| Put/Get/DeleteObjectTagging | M3 | 以 `brewfs.s3.tags` xattr 持久化，并补充与 COPY、multipart completion 的继承规则 |
+| GetObjectAttributes | M3 | 组合 `stat`、ETag xattr 和 multipart 信息 |
+| 条件请求（If-Match、If-None-Match、If-Modified-Since 等） | M3 | 为 GET/HEAD/COPY/PUT 补齐 S3 precondition 顺序和错误码 |
+| List 扩展（`encoding-type`、`fetch-owner`、完整 V1 `NextMarker`） | M3 | 扩展现有 list collector 与响应字段，不改变现有 continuation token |
+| CopySource 扩展 | M3 | 支持 URL 编码细节及 ARN 等当前 `bucket/key` 之外的形式 |
+| CORS、Bucket Tagging | M3 | 优先补齐常用浏览器与运维客户端场景，并纳入兼容性矩阵 |
+| Website / Logging 等其余桶级配置 | M5/远期 | 按客户端需求逐项实现，未实现时返回明确错误而非静态成功 |
+| Bucket/Object ACL、Bucket Policy | M5 | 在多身份与授权模型确定后实现；M1 不伪造权限语义 |
+| 多密钥、IAM/STS 兼容层 | M5 | 与 console 身份体系整合，定义 principal 到 BrewFS identity 的映射 |
+| 匿名只读与 virtual-host addressing | M5 | 作为显式 policy/domain 配置实现，并覆盖 host/path-style 路由隔离 |
+| 原生 TLS | M5 | rustls 监听与证书热更新；此前由反向代理终结 TLS |
+| Versioning | M5/远期 | 需先定义版本数据布局、删除标记、LIST 语义和跨协议可见性 |
+| SSE-S3 / SSE-KMS / SSE-C | M5/远期 | 需定义密钥管理、加密 metadata 与 range/multipart 数据路径；禁止静默忽略加密请求头 |
+| Object Lock / Retention / Legal Hold | 远期 | 依赖 versioning、不可变策略和绕过权限模型 |
+| Lifecycle / Notification / Replication / Inventory | 远期 | 依赖持久任务、事件日志、幂等重试与运维控制面 |
+| SelectObjectContent | 远期评估 | 仅在有明确需求和可维护的执行引擎后立项 |
 
-### 条件写（If-None-Match / If-Match）
+### 条件请求
 
-MVP 支持 `If-None-Match: *`（create_new 语义 → `AlreadyExists` 映射 `PreconditionFailed`），
-其余条件头在 MVP 记录并忽略，后续里程碑补齐。
+M1 仅承诺已验证的基础读写与 Range 语义，不承诺完整条件头行为。所有未实现的条件头必须明确拒绝，不能静默表现为已满足；完整 precondition 语义列入 M3。
 
 ## 5. 目录语义（S3 扁平空间 ↔ POSIX 层级）
 
@@ -105,25 +121,27 @@ MVP 支持 `If-None-Match: *`（create_new 语义 → `AlreadyExists` 映射 `Pr
 
 ## 6. 认证与安全
 
-- MVP：单一静态密钥对。`--access-key/--secret-key` 或环境变量 `BREWFS_S3_ACCESS_KEY/BREWFS_S3_SECRET_KEY`；
-  SigV4 校验由 s3s 的 auth 组件完成（支持 header 签名与 presigned URL）；
-- 未配置密钥时拒绝启动（不允许匿名读写）；`--anonymous-read` 显式开启匿名只读（公共桶场景）；
-- TLS：MVP 为 HTTP；生产部署建议前置反向代理（nginx/caddy）终结 TLS。
-  原生 TLS（rustls）列后续里程碑；
-- 后续：多密钥对（静态配置表）、与 console 认证打通。
+- M1：单一静态密钥对。`--access-key/--secret-key` 或环境变量 `BREWFS_S3_ACCESS_KEY/BREWFS_S3_SECRET_KEY`；
+  SigV4 校验由 s3s 的 auth 组件完成；
+- 未配置密钥时拒绝启动；M1 不支持匿名访问、多密钥、IAM、STS 或 ACL/policy 授权；
+- TLS：M1 为 HTTP；生产部署应前置反向代理（nginx/caddy）终结 TLS；
+- M3/M5：先定义多 principal 与 BrewFS identity 的映射，再实现多密钥、ACL/policy、STS 和原生 rustls，
+  避免在没有权限模型时仅返回看似成功的 S3 配置响应。
 
 ## 7. 一致性与并发
 
-- **写-写冲突**：单实例内 dashmap 按 `(bucket,key)` 分片互斥，串行化同一 key 的
-  Put/Complete/Delete/Rename 路径；不同 key 完全并发；
-- **写-读冲突**：读旧对象期间发生覆盖写，rename 原子性保证读者拿到完整旧版或完整新版，
-  不会读到半个对象（tmp+rename 模式的核心收益）；
-- **multipart 并发**：同一 upload-id 的 part 上传并发安全（不同 part 不同文件）；
-  同一 part number 重复上传后者覆盖前者（S3 语义）；
-- **多网关实例**：MVP 不保证跨实例的 key 级串行化（依赖 rename/create 原子性兜底，
-  语义为 last-writer-wins）；跨实例分布式锁（`/.brewfs.sys/locks/` + meta flock）列入 M3；
-- **list 一致性**：以 meta 层 readdir 时点快照为准，分页遍历期间的并发增删不保证边界精确
-  （与 S3 实际一致：list 是弱一致）。
+- **写-写冲突**：单实例内使用固定数量的 `(bucket,key)` key-lock 分片，同一对象的
+  Put/Complete/Delete/Copy 发布串行化；COPY 涉及两个分片时按固定顺序加锁；
+- **bucket 生命周期**：固定 bucket-lock 分片串行化 Create/DeleteBucket 与 multipart 创建、
+  PUT/COPY/Complete 的最终发布；发布前重新验证 bucket，避免删桶后被在途写入重建；
+- **写-读冲突**：GET 在返回流前获取 VFS read guard，固定源 inode；覆盖写通过 staging + rename
+  发布，因此慢消费者读取完整旧版本或完整新版本，不会读到混合数据；
+- **multipart 并发**：操作以 upload ID + bucket + key 校验归属；同一 part number 的替换受 key
+  互斥保护；活动 multipart 会阻止 multi-bucket 模式删除对应 bucket；
+- **多网关实例**：M1 的 key-lock 与 bucket-lock 都是进程内固定分片，不保证跨实例串行化；
+  分布式锁、fencing 和失败恢复协议列入 M3，不能只增加远程 mutex 而缺少租约失效保护；
+- **list 一致性**：单次列表先按可见 S3 entry 排序再分页，但分页期间的并发增删仍不提供跨请求快照；
+  continuation token 只表示字典序位置。
 
 ## 8. 错误码映射
 
@@ -153,30 +171,86 @@ etag 不匹配的 part 校验 → 400 `InvalidPart`；upload-id 不存在 → 40
 brewfs gateway s3 \
   --listen 0.0.0.0:9000            # 监听地址
   --access-key / --secret-key      # 静态密钥（或 env）
-  [--bucket <name>]                # 单 bucket 名（默认 volume 名）
+  [--bucket <name>]                # 单 bucket 名（默认 brewfs）
   [--multi-buckets]                # 多 bucket 模式
   [--hide-dir-objects]             # list 隐藏目录对象
-  [--anonymous-read]               # 匿名只读
-  [--domain <base>]                # virtual-host 风格访问（后续）
   <与 mount 相同的后端参数>
 ```
 
-## 11. 测试计划
+`--anonymous-read`、virtual-host `--domain` 与原生 TLS 均为后续计划，不属于 M1 CLI。
 
-1. **单元测试**（`src/gateway/s3/` 内）：key→路径校验、目录对象判定、etag 计算、
-   分页遍历的 marker 边界、`.brewfs.sys` 过滤；
-2. **集成测试**（`tests/s3_gateway_test.rs`）：进程内 `VFS`（sqlite memory + 本地目录数据后端）
-   + 起 s3s 服务于随机端口，用 `aws-sdk-s3`（已在依赖树）做客户端断言全映射表；
-3. **端到端**（`scripts/` 或 compose）：真实二进制 + `aws s3 cp/ls/rm/mb/rb`、`mc cp/ls`，
-   含 multipart（>8 MiB 文件强制分片）、FUSE 交叉读写验证；
-4. **兼容性冒烟**：boto3、s3fs 挂载读、presigned URL 下载。
+## 11. 测试与后端验证矩阵
 
-## 12. 里程碑拆分
+### 11.1 当前结果（2026-09-09）
 
-- **M1（本 spec 首个实现）**：单 bucket；§4 全部 ★；静态密钥；流式 PUT/GET；
-  集成测试 + aws cli e2e。
-- **M3（完整化）**：多 bucket、tagging、GetObjectAttributes、条件头补全、
-  跨实例锁、CORS、rustls、mc 全功能回归。
+| Meta backend | Data backend | S3 gateway 结果 | 说明 |
+|---|---|---|---|
+| SQLite | LocalFS | 已验证 | fresh volume 上 boto3 E2E：76 passed / 0 failed；网关单元测试 22 passed；包含大对象慢速 GET、并发覆盖、路径边界、list 分页、multipart 和 bucket lifecycle 竞态 |
+| Redis | RustFS（S3 data backend） | **尚未验证** | 仓库已有该组合的 FUSE/POSIX、xfstests 与性能测试，但这些结果不经过 `brewfs gateway s3`，不能视为 S3 网关验证 |
+| 其他 MetaStore | LocalFS/S3-compatible | 尚未形成网关矩阵 | 编译和通用 VFS 测试通过不等价于真实协议 E2E |
+
+CI 中名为 Redis/TiKV workspace-overlay、pjdfstest、xfstests 或 stress-ng 的 job 验证的是 FUSE/VFS
+数据路径，而不是 S3 网关端点。报告 S3 网关兼容性时必须单独标明 gateway endpoint、meta backend、
+data backend 和客户端，不能用底层后端测试代替。
+
+### 11.2 Redis + RustFS 验收计划（M3）
+
+1. 通过 Docker Compose 或本地 WSL 启动 Redis 与 RustFS，为 RustFS 创建独立的数据 bucket；
+2. 使用不同端口启动 RustFS 和 BrewFS S3 gateway，避免二者默认 `9000` 端口冲突；
+3. 以 `--meta-backend redis --meta-url redis://... --data-backend s3` 和 RustFS endpoint 启动网关，
+   在 single-bucket fresh volume 上运行与 SQLite + LocalFS 相同的 76 项 boto3 E2E；
+4. 重启网关、Redis 和 RustFS 后复查对象、xattr metadata、ETag、目录对象和未完成 multipart 状态，
+   验证持久化与 stale-upload cleanup；
+5. 运行 multi-bucket 的 Create/DeleteBucket、active multipart、在途 PUT/COPY/Complete 与 namespace
+   边界测试；
+6. 同一 Redis + RustFS volume 同时由 FUSE 与 S3 gateway 访问，双向验证对象数据、rename、删除和
+   metadata 可见性；
+7. 将最小 boto3 smoke 纳入普通 CI；完整 76 项、重启与故障恢复场景可作为定时或手动 workflow，
+   并上传 gateway、Redis、RustFS 日志。
+
+验收门槛：功能断言 0 failure、服务重启后无数据/metadata 丢失、失败发布无泄漏可见对象、
+active multipart 不被 cleanup 或 DeleteBucket 误删。多网关实例并发不在本阶段宣称通过，须等 §12
+的分布式锁方案落地。
+
+### 11.3 客户端兼容性计划
+
+- 当前：boto3 端到端测试；
+- M3：AWS CLI、MinIO Client (`mc`)、presigned URL、s3fs 的核心读写/列表/multipart 冒烟；
+- 每个客户端记录版本、addressing style、签名模式与已知差异，避免仅以单一 SDK 代表 S3 兼容性。
+
+## 12. 后续里程碑
+
+### M1：核心 S3 网关（已完成，PR #83）
+
+- 单桶与多桶、核心对象 CRUD/COPY/LIST、multipart 全流程、静态 SigV4 密钥、流式 GET/PUT；
+- staging + rename 原子发布、固定 key/bucket lock 分片、内部 namespace 与 multipart ownership 防护；
+- SQLite + LocalFS 的 76 项 boto3 E2E、22 项单元测试和 CI 编译/Clippy/测试矩阵。
+
+### M3：兼容性与后端矩阵
+
+- 完成 Redis + RustFS 验收计划并接入 CI smoke；
+- Object Tagging、GetObjectAttributes、完整条件请求；
+- `encoding-type`、`fetch-owner`、V1 `NextMarker` 和 CopySource 扩展；
+- AWS CLI、`mc`、s3fs、presigned URL 兼容性矩阵；
+- 常用 CORS、bucket tagging 等桶级配置；
+- 设计并实现带租约/fencing 的跨实例 key/bucket 锁，增加双网关故障注入回归。
+
+### M5：安全与生产化
+
+- 多密钥、ACL/policy、IAM/STS 兼容层及其 BrewFS identity 映射；
+- 原生 rustls、证书轮换、请求审计、Prometheus 指标、限流与配额错误映射；
+- Redis + RustFS 大对象吞吐、10 万/100 万对象 list、multipart 并发和 24h soak 基线。
+
+### 远期：高级 S3 数据语义
+
+- Versioning 与 delete marker；
+- SSE-S3/SSE-KMS/SSE-C；
+- Object Lock / Retention / Legal Hold；
+- Lifecycle、Notification、Replication、Inventory；
+- SelectObjectContent 按实际需求再评估。
+
+这些能力必须先给出持久化布局、跨协议可见性、升级/回滚和故障恢复设计，不以返回静态成功响应
+冒充兼容支持。
 
 ## 13. 参考
 

--- a/doc/protocols/webdav.md
+++ b/doc/protocols/webdav.md
@@ -1,0 +1,155 @@
+# WebDAV Gateway Spec（网盘接入）
+
+状态：已立项
+依赖：`dav-server = "0.11"`（feature `gateway-webdav`）
+CLI：`brewfs gateway webdav --listen <addr> [--user u --password p] [后端参数...]`
+
+## 1. 目标与非目标
+
+### 目标
+
+- 以 WebDAV（RFC 4918）暴露 BrewFS volume，覆盖"网盘"核心场景：
+  - Windows「映射网络驱动器」/ `net use`；
+  - macOS Finder「连接服务器」；
+  - Linux `davfs2` 内核挂载；
+  - rclone、cadaver、各移动端 WebDAV 客户端；
+- 协议方法与文件系统语义忠实映射（§3），不丢数据、不产生半文件；
+- 与 S3 网关 / FUSE 挂载数据互通（路径即路径，xattr 约定见总设计 §3.2）。
+
+### 非目标
+
+- DeltaV / 版本控制（RFC 3253）、CalDAV/CardDAV；
+- 全文搜索（DASL）；
+- 多用户权限体系（MVP 单用户 Basic auth）；
+- Web 界面（网盘 UI 不属于协议层；console 模块是未来 Web 文件管理器的落点）。
+
+## 2. 架构
+
+```
+Windows 网络驱动器 / Finder / davfs2 / rclone
+      │ HTTP(S) WebDAV
+      ▼
+┌──────────────┐  DavFileSystem/DavFile traits  ┌───────────────┐  Client (path ops)
+│ dav-server    │ ─────────────────────────────▶ │ BrewFsDavFs    │ ──────────────▶ Client ─▶ VFS
+│ (axum 集成)   │                                │ (src/gateway/webdav)│
+└──────────────┘                                └───────────────┘
+        │ lock system: memls (MVP) → VFS plock (后续)
+        │ dead props: xattr brewfs.dav.deadprops
+```
+
+- dav-server 负责 HTTP 方法解析、PROPFIND XML、lock 语义框架；我们实现
+  `DavFileSystem`（路径级操作）与 `DavFile`（读写句柄）两个 trait；
+- 基于 SDK `Client`；句柄即 `Client::OpenOptions` 打开的 `File`；
+- axum 集成：dav-server 的 `DavHandler` 作为 axum service 挂载，认证走 axum middleware。
+
+## 3. 方法映射表
+
+| WebDAV 方法 | BrewFS 映射 | 说明 |
+|---|---|---|
+| `GET` / `HEAD` | `stat` + 流式 `read_at` | 支持 `Range`；目录 GET 返回 405（dav-server 行为） |
+| `PUT` | `create_file` + 流式写 + `flush` | MVP 直接写最终路径；`--atomic-put` 选项切换为 tmp+rename（总设计 §3.3），默认开启见 §5 |
+| `MKCOL` | `mkdir`（父不存在 → 409 `Conflict`；已存在 → 405） | |
+| `DELETE` | 文件 `unlink`；目录 `remove_dir_all`（递归，RFC 要求） | 递归删除限并发（默认 8，防大目录惊群） |
+| `PROPFIND` | depth=0 `stat`；depth=1 `readdir` + 逐条 stat | 属性集：`displayname/getcontentlength/getlastmodified/creationdate/resourcetype/getetag`（inode+mtime+size 合成弱 etag）+ dead props |
+| `PROPPATCH` | dead properties 读写 xattr `brewfs.dav.deadprops`（JSON map） | 活属性（getcontentlength 等）set → 409；xattr 不可用时整请求 507 |
+| `COPY` | 流式服务端复制（read→write），目录递归；`Overwrite: F` → create_new | 后续可用 chunk 级克隆优化 |
+| `MOVE` | `rename`（同 volume 内恒真）；`Overwrite: F` → `RENAME_NOREPLACE` | |
+| `LOCK` / `UNLOCK` | MVP：dav-server memls（进程内存） | 语义与限制见 §4 |
+| `OPTIONS` | dav-server 自动应答 | `DAV: 1,2` 头 |
+
+错误码映射（dav-server 已处理骨架，存储层错误按下表汇入）：
+
+| BrewFS 错误 | HTTP |
+|---|---|
+| NotFound | 404 |
+| PermissionDenied | 403 |
+| AlreadyExists | 412 / 405（MKCOL） |
+| DirectoryNotEmpty | 409（DELETE 非递归时）/ 424 |
+| 父路径不存在 | 409 Conflict |
+| 空间不足 | 507 Insufficient Storage |
+| 其他 | 500 |
+
+## 4. 锁语义
+
+- MVP：`memls`（进程内内存锁，等价 JuiceFS webdav 的 `webdav.NewMemLS()`）。
+  明示限制：锁只在单网关实例内有效，且与 FUSE 侧 POSIX lock / 其他网关互不感知；
+- 后续：实现 dav-server 的 `DavLockSystem` trait，落到 `/.brewfs.sys/locks/` + meta flock，
+  达成跨实例可见的 WebDAV 锁；**不**做 WebDAV lock ↔ POSIX lock 双向映射
+  （语义模型不同：WebDAV 锁是路径+token+超时，POSIX 是句柄+字节区间），
+  仅在文档中声明两者互不影响；
+- davfs2/Windows redirector 会先发 `LOCK`；不支持时部分客户端退化行为差，故 memls 必须可用
+  （不能返回 501），这是 dav-server 默认能力，直接启用。
+
+## 5. PUT 的原子性与"半文件"问题
+
+网盘客户端（尤其 Windows redirector 与部分同步工具）的行为特点：
+
+- 先 `PUT` 零字节占位、再 `LOCK`、再多次 `PUT` 覆盖写内容；
+- 大文件分段 `PUT`（Content-Range）或直接整传。
+
+约定：
+
+1. 默认 `--atomic-put=false`（直接写最终路径）：与多数客户端的分段/覆盖行为兼容最好，
+   也是 davfs2/rclone 期望的语义；
+2. `--atomic-put=true` 时启用 tmp+rename（整请求完成才可见）：适合归档类一次性写入，
+   但会破坏依赖"创建后分段写"的客户端 —— 文档中写明取舍；
+3. 无论哪种模式，`flush` 失败必须返回 507/500 而不是静默成功（写回缓存场景下的关键正确性）。
+
+## 6. 认证与安全
+
+- `--user/--password`（或 env `BREWFS_WEBDAV_USER/BREWFS_WEBDAV_PASSWORD`）启用 HTTP Basic；
+  未配置 = 匿名读写（仅限可信网络，启动时打 warning）；
+- **Windows 网盘映射的现实约束**：Windows WebClient 默认仅允许 HTTPS 上的 Basic auth
+  （否则需改注册表 `BasicAuthLevel=2`）。因此：
+  - MVP 提供 `--tls-cert/--tls-key`（rustls）原生 HTTPS —— 这是 Windows 免注册表映射的前提；
+  - 文档给出 `net use Z: https://host:port/` 与注册表两种路径的完整操作步骤；
+- 后续：Bearer token（复用 console `AuthConfig` 模式）、多用户。
+
+## 7. 各客户端兼容性注意点（写入部署文档）
+
+| 客户端 | 注意点 |
+|---|---|
+| Windows redirector | 大文件默认限 50MB（注册表 `FileSizeLimitInBytes`）；会先发 OPTIONS/PROPFIND 探测根路径；中文路径需 UTF-8 percent-encoding（dav-server 已处理） |
+| macOS Finder | 会创建 `.DS_Store`、`._*`（AppleDouble）文件；建议文档说明而非过滤 |
+| davfs2 | 依赖 LOCK 可用；`use_locks 1` 默认；大文件写入走内核页缓存，close 时才 flush——flush 错误必须如实返回 |
+| rclone | 默认 chunked 上传关闭，行为良好；`--vfs-cache-mode writes` 时接近本地盘语义 |
+
+## 8. 性能目标
+
+- GET/PUT 流式，单连接内存有界；
+- PROPFIND depth=1 在万级条目目录下 p99 < 500ms（sqlite meta）；
+- davfs2 挂载下顺序读写吞吐 ≥ 同机 FUSE 直挂的 70%。
+
+## 9. 测试计划
+
+1. **单元测试**：dead props xattr 编解码、路径解码（percent-encoding、尾斜杠归一）、
+   `.brewfs.sys` 在 PROPFIND 中的过滤；
+2. **集成测试**（`tests/webdav_gateway_test.rs`）：进程内起服务 + `reqwest` 手工构造
+   PROPFIND/PUT/MKCOL/MOVE/COPY/LOCK 请求断言；
+3. **litmus 测试**（e2e 脚本）：`litmus http://host:port/ user pass`，basic/copymove/props/locks 四组全过；
+4. **真实客户端冒烟**（WSL/手动）：davfs2 挂载读写、rclone copy、Windows 映射网络驱动器拖放文件；
+5. **交叉一致性**：WebDAV 写入 → S3 GET / FUSE 读取验证。
+
+## 10. CLI 参数
+
+```
+brewfs gateway webdav \
+  --listen 0.0.0.0:9001 \
+  [--user u --password p] \
+  [--tls-cert c.pem --tls-key k.pem] \
+  [--atomic-put] \
+  [--delete-concurrency 8] \
+  <与 mount 相同的后端参数>
+```
+
+## 11. 里程碑
+
+- **M2（首个实现）**：§3 全表 + memls + Basic auth + TLS + litmus 通过 + davfs2/Windows 冒烟。
+- **后续**：分布式锁、Bearer token、`--atomic-put` 默认值再评估、Web 文件管理器（console 侧）。
+
+## 12. 参考
+
+- JuiceFS webdav：`pkg/fs/http.go`（davFS over pkg/fs、MemLS、dead props in xattr、
+  Basic auth、litmus 兼容）；
+- dav-server crate：<https://crates.io/crates/dav-server>；
+- RFC 4918；litmus <http://www.webdav.org/neon/litmus/>。


### PR DESCRIPTION
## Summary

This PR adds and updates `doc/protocols/`, the design baseline and rolling roadmap for multi-protocol access to a BrewFS volume without going through a kernel FUSE mount:

- **README.md** — shared gateway architecture, hidden `.brewfs.sys/` namespace, xattr naming, atomic staging/rename publication, consistency rules and protocol/crate selection.
- **s3-gateway.md** — current M1 behavior from #83, operation mapping, namespace and concurrency guarantees, explicit unsupported capabilities, and staged M3/M5/long-term plans.
- **webdav.md** — WebDAV gateway spec for Windows mapped drives, Finder and davfs2, including method mapping, lock semantics, PUT atomicity and TLS requirements.
- **nfs.md** — NFSv3 gateway spec covering inode-backed file handles, identity/squash mapping, COMMIT semantics and the NLM gap.
- **ROADMAP.md** — milestones M1–M5 with updated status and acceptance criteria.

## S3 implementation and validation status

- M1 was implemented and merged in #83: single/multi bucket modes, core object operations, listing, copy, multipart, static SigV4 credentials, bounded streaming and process-local consistency/lifecycle locks.
- SQLite metadata + LocalFS data backend has passed 76 boto3 E2E assertions and 22 gateway unit tests, including slow GET, overwrite snapshots, multipart ownership, namespace boundaries and bucket lifecycle races.
- **Redis metadata + RustFS data backend has not yet run an S3 gateway endpoint E2E suite.** Existing Redis + RustFS FUSE/POSIX, xfstests and performance results exercise the storage stack but do not count as gateway protocol validation.
- The S3 spec now defines a dedicated Redis + RustFS plan: the same boto3 suite, service restart persistence, multi-bucket/lifecycle races, FUSE↔gateway visibility, CI smoke and longer fault/soak workflows.

## Future S3 plan

- **M3 compatibility/backend matrix:** Redis + RustFS validation, Object Tagging, GetObjectAttributes, conditional requests, list and CopySource extensions, CORS, AWS CLI/`mc`/s3fs/presigned URL compatibility, and a leased/fenced cross-instance lock design.
- **M5 security/production:** multi-key identity mapping, ACL/policy/IAM/STS, native TLS, auditing, metrics, limits, performance and soak baselines.
- **Long term:** Versioning, SSE, Object Lock/Retention, Lifecycle, Notification, Replication, Inventory and SelectObjectContent evaluation.

Unsupported operations must return an explicit protocol error; the spec does not allow static success responses that pretend an unimplemented capability exists.

## Testing

Docs-only change; Markdown/diff whitespace checks pass.