### PR TITLE
feat(gateway): S3-compatible gateway MVP (s3s-based)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,10 @@ on:
           - link-symlink-heavy
           - write-smallfile
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
@@ -82,9 +86,6 @@ jobs:
           bash docker/compose-xfstests/test_juicefs_direct_matrix.sh
           bash docker/compose-xfstests/test_juicefs_perf_report.sh
 
-      - name: Check workspace
-        run: cargo check --workspace
-
       - name: Build workspace
         run: cargo build --workspace
 
@@ -97,9 +98,6 @@ jobs:
 
       - name: Test workspace
         run: cargo test --workspace --lib --bins -- --test-threads=1
-
-      - name: Test workspace overlay
-        run: cargo test --workspace --features workspace-overlay -- --test-threads=1
 
       - name: Test all features
         run: cargo test --workspace --all-features -- --test-threads=1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array 0.14.7",
 ]
 
@@ -186,9 +186,9 @@ checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "arc-swap"
-version = "1.8.2"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
@@ -207,9 +207,9 @@ dependencies = [
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "async-lock"
@@ -279,13 +279,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -318,6 +318,15 @@ name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "atoi"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a8bbe9949e43a1edaa043038c68703b04774156afdfb62ba2cef5bf93d67be"
 dependencies = [
  "num-traits",
 ]
@@ -366,7 +375,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "hex",
- "http 1.4.0",
+ "http 1.5.0",
  "ring",
  "time",
  "tokio",
@@ -377,9 +386,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.12"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e26bbf46abc608f2dc61fd6cb3b7b0665497cc259a21520151ed98f8b37d2c79"
+checksum = "e93964ffdaf57857f544be3666a5f57570bb699e934700f11b49708f61bb556e"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -412,15 +421,15 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.7.0"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0f92058d22a46adf53ec57a6a96f34447daf02bff52e8fb956c66bcd5c6ac12"
+checksum = "ef47857a1d4488b528f4a5d5715fa7c3300820897824152234d3fa22b1426657"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.63.4",
+ "aws-smithy-http 0.64.0",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -429,9 +438,9 @@ dependencies = [
  "bytes-utils",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.5.0",
  "http-body 0.4.6",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "percent-encoding",
  "pin-project-lite",
  "tracing",
@@ -440,34 +449,37 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.119.0"
+version = "1.145.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d65fddc3844f902dfe1864acb8494db5f9342015ee3ab7890270d36fbd2e01c"
+checksum = "f0e6320417a37c8a62f78b443d0b4cf628b57cd340a09b0eb56173d47cc94e93"
 dependencies = [
+ "arc-swap",
  "aws-credential-types",
  "aws-runtime",
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-checksums",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.62.6",
- "aws-smithy-json 0.61.9",
+ "aws-smithy-http 0.64.0",
+ "aws-smithy-json 0.63.0",
+ "aws-smithy-observability 0.3.0",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
- "aws-smithy-xml",
+ "aws-smithy-xml 0.62.0",
  "aws-types",
  "bytes",
  "fastrand",
  "hex",
- "hmac",
+ "hmac 0.13.0",
  "http 0.2.12",
- "http 1.4.0",
- "http-body 0.4.6",
+ "http 1.5.0",
+ "http-body 1.1.0",
  "lru",
  "percent-encoding",
  "regex-lite",
- "sha2",
+ "sha2 0.11.0",
  "tracing",
  "url",
 ]
@@ -483,7 +495,7 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-http 0.63.4",
  "aws-smithy-json 0.62.4",
- "aws-smithy-observability",
+ "aws-smithy-observability 0.2.5",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -491,7 +503,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.5.0",
  "regex-lite",
  "tracing",
 ]
@@ -507,7 +519,7 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-http 0.63.4",
  "aws-smithy-json 0.62.4",
- "aws-smithy-observability",
+ "aws-smithy-observability 0.2.5",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -515,7 +527,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.5.0",
  "regex-lite",
  "tracing",
 ]
@@ -531,42 +543,41 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-http 0.63.4",
  "aws-smithy-json 0.62.4",
- "aws-smithy-observability",
+ "aws-smithy-observability 0.2.5",
  "aws-smithy-query",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "aws-smithy-xml",
+ "aws-smithy-xml 0.60.14",
  "aws-types",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.5.0",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sigv4"
-version = "1.4.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f6ae9b71597dc5fd115d52849d7a5556ad9265885ad3492ea8d73b93bbc46e"
+checksum = "723c2234ad7511ceef63eab016b7ba6ff7c55590fefb96fa8467af014a07309f"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.63.4",
+ "aws-smithy-http 0.64.0",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
- "crypto-bigint 0.5.5",
+ "crypto-bigint",
  "form_urlencoded",
  "hex",
- "hmac",
+ "hmac 0.13.0",
  "http 0.2.12",
- "http 1.4.0",
- "p256 0.11.1",
+ "http 1.5.0",
+ "p256",
  "percent-encoding",
- "ring",
- "sha2",
+ "sha2 0.11.0",
  "subtle",
  "time",
  "tracing",
@@ -575,9 +586,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.12"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cba48474f1d6807384d06fec085b909f5807e16653c5af5c45dfe89539f0b70"
+checksum = "f02e407fb3b54891734224b9ffac8a71fdd35f542500fa1af95754a6b2beb316"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -586,55 +597,34 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.63.12"
+version = "0.65.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87294a084b43d649d967efe58aa1f9e0adc260e13a6938eb904c0ae9b45824ae"
+checksum = "b67ecd999972b58e67cab052f5129906c08c25883bd0788ceefc55ef97d61307"
 dependencies = [
- "aws-smithy-http 0.62.6",
+ "aws-smithy-http 0.64.0",
  "aws-smithy-types",
  "bytes",
  "crc-fast",
  "hex",
- "http 0.2.12",
- "http-body 0.4.6",
- "md-5",
+ "http 1.5.0",
+ "http-body 1.1.0",
+ "http-body-util",
+ "md-5 0.11.0",
  "pin-project-lite",
- "sha1",
- "sha2",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
  "tracing",
 ]
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.19"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c0b3e587fbaa5d7f7e870544508af8ce82ea47cd30376e69e1e37c4ac746f79"
+checksum = "6de526c7b567420a31bc283657a7921b45c4cafe0827fdf2490713dcc770c28f"
 dependencies = [
  "aws-smithy-types",
  "bytes",
  "crc32fast",
-]
-
-[[package]]
-name = "aws-smithy-http"
-version = "0.62.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826141069295752372f8203c17f28e30c464d22899a43a0c9fd9c458d469c88b"
-dependencies = [
- "aws-smithy-eventstream",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "bytes",
- "bytes-utils",
- "futures-core",
- "futures-util",
- "http 0.2.12",
- "http 1.4.0",
- "http-body 0.4.6",
- "percent-encoding",
- "pin-project-lite",
- "pin-utils",
- "tracing",
 ]
 
 [[package]]
@@ -649,8 +639,30 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http 1.5.0",
+ "http-body 1.1.0",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.64.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37843d9add67c3aff5856f409c6dc315d3cdff60f9c0cb5b670dab1e9920306d"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.5.0",
+ "http-body 1.1.0",
  "http-body-util",
  "percent-encoding",
  "pin-project-lite",
@@ -660,20 +672,20 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.1.10"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0709f0083aa19b704132684bc26d3c868e06bd428ccc4373b0b55c3e8748a58b"
+checksum = "ebfd138fac0337cee7516c352757ea73b9f2266e57d0bcb5bc70e9547e45aef1"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "h2 0.3.27",
- "h2 0.4.13",
+ "h2 0.4.19",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.5.0",
  "http-body 0.4.6",
  "hyper 0.14.32",
- "hyper 1.8.1",
+ "hyper 1.11.1",
  "hyper-rustls 0.24.2",
  "hyper-rustls 0.27.7",
  "hyper-util",
@@ -690,15 +702,6 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.61.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49fa1213db31ac95288d981476f78d05d9cbb0353d22cdf3472cc05bb02f6551"
-dependencies = [
- "aws-smithy-types",
-]
-
-[[package]]
-name = "aws-smithy-json"
 version = "0.62.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b3a779093e18cad88bbae08dc4261e1d95018c4c5b9356a52bcae7c0b6e9bb"
@@ -707,10 +710,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-json"
+version = "0.63.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dc65a121adb4b33729919fcfa14fa36fb33c1555a8f06bb0e2188dbfdc1d9ef"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+]
+
+[[package]]
 name = "aws-smithy-observability"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3f39d5bb871aaf461d59144557f16d5927a5248a983a40654d9cf3b9ba183b"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e86338c869539a581bf161247762a6e87f92c5c075060057b5ed6d06632ed0c"
 dependencies = [
  "aws-smithy-runtime-api",
 ]
@@ -727,22 +750,23 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.10.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd3dfc18c1ce097cf81fced7192731e63809829c6cbf933c1ec47452d08e1aa"
+checksum = "b82e438d30e02a825d363bd639a9efaed68a8089d86101054b0081e7e0d3e606"
 dependencies = [
  "aws-smithy-async",
- "aws-smithy-http 0.63.4",
+ "aws-smithy-http 0.64.0",
  "aws-smithy-http-client",
- "aws-smithy-observability",
+ "aws-smithy-observability 0.3.0",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.5.0",
  "http-body 0.4.6",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
  "pin-project-lite",
  "pin-utils",
@@ -752,15 +776,16 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.11.4"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c55e0837e9b8526f49e0b9bfa9ee18ddee70e853f5bc09c5d11ebceddcb0fec"
+checksum = "9c054752dd9e4dc73d0b75748c99ac2d0feafbf2f25c7b0516f03a3534161223"
 dependencies = [
  "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.5.0",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -768,19 +793,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-types"
-version = "1.4.4"
+name = "aws-smithy-runtime-api-macros"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "576b0d6991c9c32bc14fc340582ef148311f924d41815f641a308b5d11e8e7cd"
+checksum = "221eaa237ddf1ca79b60d1372aad77e47f9c0ea5b3ce5099da8c61d027dc77b3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+]
+
+[[package]]
+name = "aws-smithy-schema"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56e0a4e53127a632224e43633b0fe045fa9e1e3cfc68b9830f1115e103f910"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http 1.5.0",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f94d16e797ec62cd999fc9d5942b48fa7050c3093ddadff48e4d7528d16fcb9"
 dependencies = [
  "base64-simd",
  "bytes",
  "bytes-utils",
  "futures-core",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.5.0",
  "http-body 0.4.6",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
  "itoa",
  "num-integer",
@@ -803,14 +850,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-types"
-version = "1.3.12"
+name = "aws-smithy-xml"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c50f3cdf47caa8d01f2be4a6663ea02418e892f9bbfd82c7b9a3a37eaccdd3a"
+checksum = "ce84f71c72fee2cbbadde6e7d082f5fb466e3a84733855295fa7aafd1b31b7d8"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "209f3a6d82a6e9e5f94abbed94c7a26e1c052341002bf57a5fb5481f625896fc"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "rustc_version",
  "tracing",
@@ -854,10 +914,10 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http 1.5.0",
+ "http-body 1.1.0",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.11.1",
  "hyper-util",
  "itoa",
  "matchit 0.8.4",
@@ -902,8 +962,8 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http 1.5.0",
+ "http-body 1.1.0",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -927,12 +987,6 @@ dependencies = [
  "rustc-demangle",
  "windows-link 0.2.1",
 ]
-
-[[package]]
-name = "base16ct"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
 name = "base16ct"
@@ -976,7 +1030,7 @@ checksum = "6aeac2e1fe888769f34f05ac343bbef98b14d1ffb292ab69d4608b3abc86f2a2"
 dependencies = [
  "blowfish",
  "pbkdf2",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1035,7 +1089,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1058,6 +1112,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array 0.14.7",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1149,12 +1212,13 @@ dependencies = [
  "rand 0.9.2",
  "redis",
  "rkyv 0.8.15",
+ "s3s",
  "sea-orm",
  "serde",
  "serde_json",
  "serde_yaml",
  "serial_test",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.18",
  "tikv-client",
@@ -1246,9 +1310,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "bytes-utils"
@@ -1258,6 +1322,15 @@ checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
 dependencies = [
  "bytes",
  "either",
+]
+
+[[package]]
+name = "bytestring"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86566c496f2f47d9b8147a4c8b02ffdb69c919fe0c2b2e7195d22cbba0e635c9"
+dependencies = [
+ "bytes",
 ]
 
 [[package]]
@@ -1318,9 +1391,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1363,7 +1436,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -1415,6 +1488,12 @@ checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "colorchoice"
@@ -1503,6 +1582,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const-random"
@@ -1611,15 +1696,12 @@ checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc-fast"
-version = "1.6.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ddc2d09feefeee8bd78101665bd8645637828fa9317f9f292496dbbd8c65ff3"
+checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
 dependencies = [
- "crc",
- "digest",
- "rand 0.9.2",
- "regex",
- "rustversion",
+ "digest 0.10.7",
+ "spin 0.10.0",
 ]
 
 [[package]]
@@ -1752,18 +1834,6 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
-dependencies = [
- "generic-array 0.14.7",
- "rand_core 0.6.4",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "crypto-bigint"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
@@ -1785,12 +1855,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -1802,7 +1890,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -1862,32 +1950,21 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
-dependencies = [
- "const-oid",
- "zeroize",
-]
-
-[[package]]
-name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
 
 [[package]]
 name = "deranged"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -1930,10 +2007,22 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -2008,28 +2097,16 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "ecdsa"
-version = "0.14.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
-dependencies = [
- "der 0.6.1",
- "elliptic-curve 0.12.3",
- "rfc6979 0.3.1",
- "signature 1.6.4",
-]
-
-[[package]]
-name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der 0.7.10",
- "digest",
- "elliptic-curve 0.13.8",
- "rfc6979 0.4.0",
- "signature 2.2.0",
- "spki 0.7.3",
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
 ]
 
 [[package]]
@@ -2038,8 +2115,8 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8 0.10.2",
- "signature 2.2.0",
+ "pkcs8",
+ "signature",
 ]
 
 [[package]]
@@ -2052,7 +2129,7 @@ dependencies = [
  "ed25519",
  "rand_core 0.6.4",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -2068,41 +2145,21 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
-dependencies = [
- "base16ct 0.1.1",
- "crypto-bigint 0.4.9",
- "der 0.6.1",
- "digest",
- "ff 0.12.1",
- "generic-array 0.14.7",
- "group 0.12.1",
- "pkcs8 0.9.0",
- "rand_core 0.6.4",
- "sec1 0.3.0",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "elliptic-curve"
 version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct 0.2.0",
- "crypto-bigint 0.5.5",
- "digest",
- "ff 0.13.1",
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
  "generic-array 0.14.7",
- "group 0.13.0",
+ "group",
  "hkdf",
  "pem-rfc7468",
- "pkcs8 0.10.2",
+ "pkcs8",
  "rand_core 0.6.4",
- "sec1 0.7.3",
+ "sec1",
  "subtle",
  "zeroize",
 ]
@@ -2199,7 +2256,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8acfe553027cd07fc5fafa81a84f19a7a87eaffaccd2162b6db05e8d6ce98084"
 dependencies = [
- "http 1.4.0",
+ "http 1.5.0",
  "prost 0.14.3",
  "tokio",
  "tokio-stream",
@@ -2259,16 +2316,6 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "ff"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
-dependencies = [
- "rand_core 0.6.4",
- "subtle",
-]
 
 [[package]]
 name = "ff"
@@ -2356,6 +2403,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2378,9 +2431,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2393,9 +2446,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2403,15 +2456,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2431,32 +2484,32 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 3.0.5",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-timer"
@@ -2466,9 +2519,9 @@ checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2478,7 +2531,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -2596,22 +2648,11 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
-dependencies = [
- "ff 0.12.1",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff 0.13.1",
+ "ff",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -2637,16 +2678,16 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
+ "http 1.5.0",
  "indexmap 2.13.0",
  "slab",
  "tokio",
@@ -2688,7 +2729,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -2696,6 +2737,17 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -2752,7 +2804,7 @@ dependencies = [
  "base64 0.21.7",
  "byteorder",
  "flate2",
- "nom",
+ "nom 7.1.3",
  "num-traits",
 ]
 
@@ -2765,10 +2817,10 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "headers-core",
- "http 1.4.0",
+ "http 1.5.0",
  "httpdate",
  "mime",
- "sha1",
+ "sha1 0.10.6",
 ]
 
 [[package]]
@@ -2777,7 +2829,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
- "http 1.4.0",
+ "http 1.5.0",
 ]
 
 [[package]]
@@ -2811,12 +2863,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
+name = "hex-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7685beb53fc20efc2605f32f5d51e9ba18b8ef237961d1760169d2290d3bee"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -2825,7 +2887,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2861,9 +2932,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -2882,24 +2953,24 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http 1.5.0",
 ]
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http 1.5.0",
+ "http-body 1.1.0",
  "pin-project-lite",
 ]
 
@@ -2928,6 +2999,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2953,22 +3033,21 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
- "http 1.4.0",
- "http-body 1.0.1",
+ "h2 0.4.19",
+ "http 1.5.0",
+ "http-body 1.1.0",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -2983,8 +3062,8 @@ dependencies = [
  "bytes",
  "futures-util",
  "headers",
- "http 1.4.0",
- "hyper 1.8.1",
+ "http 1.5.0",
+ "hyper 1.11.1",
  "hyper-rustls 0.27.7",
  "hyper-util",
  "pin-project-lite",
@@ -3015,8 +3094,8 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http 1.4.0",
- "hyper 1.8.1",
+ "http 1.5.0",
+ "hyper 1.11.1",
  "hyper-util",
  "log",
  "rustls 0.23.36",
@@ -3045,7 +3124,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.8.1",
+ "hyper 1.11.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -3062,14 +3141,14 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "hyper 1.8.1",
+ "http 1.5.0",
+ "http-body 1.1.0",
+ "hyper 1.11.1",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3265,7 +3344,7 @@ dependencies = [
  "log",
  "num-format",
  "once_cell",
- "quick-xml",
+ "quick-xml 0.26.0",
  "rgb",
  "str_stack",
 ]
@@ -3299,20 +3378,20 @@ checksum = "e0a77eae781ed6a7709fb15b64862fcca13d886b07c7e2786f5ed34e5e2b9187"
 dependencies = [
  "argon2",
  "bcrypt-pbkdf",
- "ecdsa 0.16.9",
+ "ecdsa",
  "ed25519-dalek",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "num-bigint-dig",
- "p256 0.13.2",
+ "p256",
  "p384",
  "p521",
  "rand_core 0.6.4",
  "rsa",
- "sec1 0.7.3",
- "sha1",
- "sha2",
- "signature 2.2.0",
+ "sec1",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
+ "signature",
  "ssh-cipher",
  "ssh-encoding",
  "subtle",
@@ -3392,9 +3471,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
@@ -3513,10 +3592,10 @@ dependencies = [
  "either",
  "futures",
  "home",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http 1.5.0",
+ "http-body 1.1.0",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.11.1",
  "hyper-http-proxy",
  "hyper-rustls 0.27.7",
  "hyper-timeout 0.5.2",
@@ -3547,7 +3626,7 @@ checksum = "f42346d30bb34d1d7adc5c549b691bce7aa3a1e60254e68fab7e2d7b26fe3d77"
 dependencies = [
  "chrono",
  "form_urlencoded",
- "http 1.4.0",
+ "http 1.5.0",
  "k8s-openapi",
  "serde",
  "serde-value",
@@ -3593,9 +3672,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libcrux-intrinsics"
@@ -3736,11 +3815,11 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "ff9840bcc50b71349309900da0ce7279aa336ae71d73250b07998932c7d97c25"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -3792,7 +3871,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3803,9 +3892,9 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memmap2"
@@ -3859,9 +3948,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
 dependencies = [
  "libc",
  "log",
@@ -3978,6 +4067,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nonzero_ext"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4030,9 +4128,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-format"
@@ -4083,6 +4181,12 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "numeric_cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3c00a0c9600379bd32f8972de90676a7672cba3bf4886986bc05902afc1e093"
 
 [[package]]
 name = "numtoa"
@@ -4210,25 +4314,14 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "p256"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
-dependencies = [
- "ecdsa 0.14.8",
- "elliptic-curve 0.12.3",
- "sha2",
-]
-
-[[package]]
-name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
- "ecdsa 0.16.9",
- "elliptic-curve 0.13.8",
+ "ecdsa",
+ "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4237,10 +4330,10 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
 dependencies = [
- "ecdsa 0.16.9",
- "elliptic-curve 0.13.8",
+ "ecdsa",
+ "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4249,12 +4342,12 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
 dependencies = [
- "base16ct 0.2.0",
- "ecdsa 0.16.9",
- "elliptic-curve 0.13.8",
+ "base16ct",
+ "ecdsa",
+ "elliptic-curve",
  "primeorder",
  "rand_core 0.6.4",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4269,7 +4362,7 @@ dependencies = [
  "futures",
  "log",
  "rand 0.8.5",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "tokio",
  "windows 0.62.2",
@@ -4328,8 +4421,8 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
- "hmac",
+ "digest 0.10.7",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -4397,7 +4490,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4442,9 +4535,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -4458,9 +4551,9 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der 0.7.10",
- "pkcs8 0.10.2",
- "spki 0.7.3",
+ "der",
+ "pkcs8",
+ "spki",
 ]
 
 [[package]]
@@ -4471,21 +4564,11 @@ checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
 dependencies = [
  "aes",
  "cbc",
- "der 0.7.10",
+ "der",
  "pbkdf2",
  "scrypt",
- "sha2",
- "spki 0.7.3",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
-dependencies = [
- "der 0.6.1",
- "spki 0.6.0",
+ "sha2 0.10.9",
+ "spki",
 ]
 
 [[package]]
@@ -4494,10 +4577,10 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der 0.7.10",
+ "der",
  "pkcs5",
  "rand_core 0.6.4",
- "spki 0.7.3",
+ "spki",
 ]
 
 [[package]]
@@ -4635,7 +4718,7 @@ version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
- "elliptic-curve 0.13.8",
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -4861,7 +4944,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yml",
- "sha2",
+ "sha2 0.10.9",
  "shell-escape",
  "termion",
  "tokio",
@@ -4897,6 +4980,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4909,7 +5002,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.36",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4947,7 +5040,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5167,9 +5260,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5179,9 +5272,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5196,9 +5289,9 @@ checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rend"
@@ -5229,11 +5322,11 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.4.13",
- "http 1.4.0",
- "http-body 1.0.1",
+ "h2 0.4.19",
+ "http 1.5.0",
+ "http-body 1.1.0",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.11.1",
  "hyper-rustls 0.27.7",
  "hyper-util",
  "js-sys",
@@ -5261,22 +5354,11 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
-dependencies = [
- "crypto-bigint 0.4.9",
- "hmac",
- "zeroize",
-]
-
-[[package]]
-name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -5368,17 +5450,17 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
  "pkcs1",
- "pkcs8 0.10.2",
+ "pkcs8",
  "rand_core 0.6.4",
- "sha2",
- "signature 2.2.0",
- "spki 0.7.3",
+ "sha2 0.10.9",
+ "signature",
+ "spki",
  "subtle",
  "zeroize",
 ]
@@ -5400,18 +5482,18 @@ dependencies = [
  "curve25519-dalek",
  "data-encoding",
  "delegate",
- "der 0.7.10",
- "digest",
- "ecdsa 0.16.9",
+ "der",
+ "digest 0.10.7",
+ "ecdsa",
  "ed25519-dalek",
- "elliptic-curve 0.13.8",
+ "elliptic-curve",
  "enum_dispatch",
  "flate2",
  "futures",
  "generic-array 1.3.5",
  "getrandom 0.2.17",
  "hex-literal",
- "hmac",
+ "hmac 0.12.1",
  "home",
  "inout",
  "internal-russh-forked-ssh-key",
@@ -5419,24 +5501,24 @@ dependencies = [
  "log",
  "md5",
  "num-bigint",
- "p256 0.13.2",
+ "p256",
  "p384",
  "p521",
  "pageant",
  "pbkdf2",
  "pkcs1",
  "pkcs5",
- "pkcs8 0.10.2",
+ "pkcs8",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "rsa",
  "russh-cryptovec",
  "russh-util",
- "sec1 0.7.3",
- "sha1",
- "sha2",
- "signature 2.2.0",
- "spki 0.7.3",
+ "sec1",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
+ "signature",
+ "spki",
  "ssh-encoding",
  "subtle",
  "thiserror 1.0.69",
@@ -5693,6 +5775,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "s3s"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "652451a66fefda01a13dc7df24aa2af9e70c7058f98bc08fe2f7c552eaa9f1e3"
+dependencies = [
+ "arc-swap",
+ "arrayvec",
+ "async-trait",
+ "atoi 3.1.0",
+ "base64-simd",
+ "bytes",
+ "bytestring",
+ "cfg-if",
+ "chrono",
+ "crc-fast",
+ "futures",
+ "hex-simd",
+ "hmac 0.13.0",
+ "http 1.5.0",
+ "http-body 1.1.0",
+ "http-body-util",
+ "httparse",
+ "hyper 1.11.1",
+ "itoa",
+ "md-5 0.11.0",
+ "memchr",
+ "mime",
+ "nom 8.0.0",
+ "numeric_cast",
+ "pin-project-lite",
+ "quick-xml 0.41.0",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
+ "smallvec",
+ "std-next",
+ "subtle",
+ "sync_wrapper 1.0.2",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tower 0.5.3",
+ "tracing",
+ "transform-stream",
+ "url",
+ "urlencoding",
+ "xxhash-rust",
+ "zeroize",
+]
+
+[[package]]
 name = "salsa20"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5742,7 +5878,7 @@ checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
 dependencies = [
  "pbkdf2",
  "salsa20",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -5858,28 +5994,14 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "sec1"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
-dependencies = [
- "base16ct 0.1.1",
- "der 0.6.1",
- "generic-array 0.14.7",
- "pkcs8 0.9.0",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct 0.2.0",
- "der 0.7.10",
+ "base16ct",
+ "der",
  "generic-array 0.14.7",
- "pkcs8 0.10.2",
+ "pkcs8",
  "subtle",
  "zeroize",
 ]
@@ -5983,9 +6105,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -6079,7 +6201,18 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -6096,7 +6229,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -6153,21 +6297,11 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
-dependencies = [
- "digest",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -6191,9 +6325,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 dependencies = [
  "serde",
 ]
@@ -6210,12 +6344,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6247,22 +6381,12 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
-dependencies = [
- "base64ct",
- "der 0.6.1",
-]
-
-[[package]]
-name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der 0.7.10",
+ "der",
 ]
 
 [[package]]
@@ -6307,7 +6431,7 @@ dependencies = [
  "rustls 0.23.36",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.18",
  "time",
@@ -6347,7 +6471,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
@@ -6363,7 +6487,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
- "atoi",
+ "atoi 2.0.0",
  "base64 0.22.1",
  "bigdecimal",
  "bitflags 2.11.0",
@@ -6371,7 +6495,7 @@ dependencies = [
  "bytes",
  "chrono",
  "crc",
- "digest",
+ "digest 0.10.7",
  "dotenvy",
  "either",
  "futures-channel",
@@ -6381,10 +6505,10 @@ dependencies = [
  "generic-array 0.14.7",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "itoa",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "memchr",
  "once_cell",
  "percent-encoding",
@@ -6392,8 +6516,8 @@ dependencies = [
  "rsa",
  "rust_decimal",
  "serde",
- "sha1",
- "sha2",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -6410,7 +6534,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
- "atoi",
+ "atoi 2.0.0",
  "base64 0.22.1",
  "bigdecimal",
  "bitflags 2.11.0",
@@ -6424,11 +6548,11 @@ dependencies = [
  "futures-util",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "home",
  "itoa",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "memchr",
  "num-bigint",
  "once_cell",
@@ -6436,7 +6560,7 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -6453,7 +6577,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
 dependencies = [
- "atoi",
+ "atoi 2.0.0",
  "chrono",
  "flume",
  "futures-channel",
@@ -6500,7 +6624,7 @@ dependencies = [
  "base64ct",
  "bytes",
  "pem-rfc7468",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -6514,6 +6638,16 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "std-next"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04082e93ed1a06debd9148c928234b46d2cf260bc65f44e1d1d3fa594c5beebc"
+dependencies = [
+ "simdutf8",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "str_stack"
@@ -6589,6 +6723,17 @@ name = "syn"
 version = "2.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e614ed320ac28113fa64972c4262d5dbc89deacdfd00c34a3e4cea073243c12"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6797,12 +6942,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -6812,15 +6956,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -6893,9 +7037,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -6903,7 +7047,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.2",
+ "socket2 0.6.5",
  "tokio-macros",
  "tracing",
  "windows-sys 0.61.2",
@@ -6931,13 +7075,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -7079,16 +7223,16 @@ dependencies = [
  "axum 0.8.8",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.13",
- "http 1.4.0",
- "http-body 1.0.1",
+ "h2 0.4.19",
+ "http 1.5.0",
+ "http-body 1.1.0",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.11.1",
  "hyper-timeout 0.5.2",
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "socket2 0.6.2",
+ "socket2 0.6.5",
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -7188,8 +7332,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http 1.5.0",
+ "http-body 1.1.0",
  "http-body-util",
  "http-range-header",
  "httpdate",
@@ -7326,6 +7470,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "transform-stream"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1a814d25437963577f6221d33a2aaa60bfb44acc3330cdc7c334644e9832022"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7400,7 +7553,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -8396,6 +8549,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
+name = "xxhash-rust"
+version = "0.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aee1b19627c7c60102ab80d3a9cbe18de90bfe03bfa6c3715447681f0e8c8af6"
+
+[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8467,18 +8626,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ blake3 = "1.8"
 builder-pattern = "0.4.2"
 bytes = "1.10.1"
 object_store = { version = "0.13", features = ["aws"] }
+s3s = "0.15"
 caps = "0.5.5"
 chrono = { version = "0.4.42", features = ["serde"] }
 clap = { version = "4.5.49", features = ["derive"] }
@@ -303,11 +304,14 @@ lz4_flex = { workspace = true }
 zstd = { workspace = true }
 governor = { workspace = true }
 blake3 = { workspace = true, optional = true }
+s3s = { workspace = true, optional = true }
+tower = { workspace = true, features = ["util"], optional = true }
 
 [features]
-default = ["fuse-io-uring-runtime"]
+default = ["fuse-io-uring-runtime", "gateway-s3"]
 fuse-io-uring-runtime = ["asyncfuse/io-uring-runtime"]
 fuse-tokio-runtime = ["asyncfuse/tokio-runtime"]
+gateway-s3 = ["dep:s3s", "dep:tower"]
 workspace-overlay = ["dep:bincode", "dep:blake3"]
 profiling = ["dep:tracing-flame", "dep:tracing-chrome", "dep:console-subscriber"]
 jemalloc = ["dep:tikv-jemallocator"]

--- a/doc/protocols/s3-gateway-verification.md
+++ b/doc/protocols/s3-gateway-verification.md
@@ -1,0 +1,85 @@
+# S3 Gateway 本地验证说明
+
+本文档描述如何在本地（WSL）验证 BrewFS S3 网关（`feat/s3-gateway-mvp` 分支）。
+对应的 spec 见 [doc/protocols/s3-gateway.md](s3-gateway.md)。
+
+## 1. 前置条件
+
+- Linux（WSL Ubuntu-22.04 已验证）+ Rust 工具链
+- Python 3 + `boto3`（端到端脚本使用；`pip3 install --user boto3`）
+- WSL 中代理变量若不可用，先 `unset http_proxy https_proxy all_proxy`
+
+## 2. 构建
+
+```bash
+cargo build --features gateway-s3
+```
+
+`gateway-s3` 在 `default` features 中，直接 `cargo build` 亦可。
+
+## 3. 启动网关（localfs + sqlite）
+
+```bash
+mkdir -p /tmp/brewfs-e2e/data
+cargo run --features gateway-s3 -- gateway s3 \
+  --listen 127.0.0.1:19101 \
+  --access-key testkey --secret-key testsecret \
+  --data-backend local-fs --data-dir /tmp/brewfs-e2e/data \
+  --meta-backend sqlx \
+  --meta-url "sqlite:///tmp/brewfs-e2e/meta.db?mode=rwc"
+```
+
+关键参数：
+
+| 参数 | 说明 |
+|---|---|
+| `--listen` | S3 端点监听地址（默认 `0.0.0.0:9000`） |
+| `--access-key/--secret-key` | SigV4 静态密钥（也可用环境变量 `BREWFS_S3_ACCESS_KEY/SECRET_KEY`，缺省则启动失败） |
+| `--bucket` | 单桶模式暴露的桶名（默认 `brewfs`） |
+| `--multi-buckets` | 多桶模式：顶层目录即桶 |
+| `--hide-dir-objects` | 列表时隐藏显式目录对象 |
+| 其余 | 与 `brewfs mount` 相同的后端参数（`--data-backend`、`--meta-url` 等） |
+
+启动成功的标志：日志出现 `brewfs s3 gateway listening`，端口开始监听。
+
+## 4. 运行端到端测试
+
+```bash
+python3 scripts/e2e_s3_gateway.py
+```
+
+默认连 `http://127.0.0.1:19101`（可用 `GW_ENDPOINT` 环境变量覆盖）。
+
+**预期结果：`RESULT: 27 passed, 0 failed`**（2026-09-08 在 WSL Ubuntu-22.04 实测）。
+
+覆盖内容：
+
+- 桶操作：list_buckets / head_bucket / 错误桶返回 404
+- 对象基本操作：put（ETag=MD5）、get、range 读、head、content-type、NoSuchKey
+- list_objects_v2：prefix、delimiter/common-prefixes、MaxKeys 截断与 ContinuationToken 分页
+- copy_object
+- 分段上传：create/upload_part/list_parts/complete（ETag 带 `-2` 后缀）、abort 后 NoSuchUpload
+- 目录对象：PUT `key/`、GET 为空体、列表中以 `key/` 呈现且 size=0
+- 删除：单删后 NoSuchKey、空目录自动收敛、批量 delete_objects
+
+## 5. 单元测试
+
+```bash
+cargo test --features gateway-s3 gateway::
+```
+
+11 个用例覆盖 path 映射（桶名校验、逃逸 key 拒绝）、list 语义（排序/max_keys/start_after/分隔符）、multipart 路径与合并 ETag 格式。
+
+## 6. 手工验证要点（可选）
+
+- **跨端可见**：网关写入的对象同时也是卷内普通文件，可再用 `brewfs mount`（FUSE）或 SDK Client 挂同一 meta/数据后端查看 `docs/readme.txt` 等路径。
+- **协议元数据**：`brewfs.s3.etag` / `brewfs.s3.meta` 存放在文件 xattr；multipart 状态位于 `/.brewfs.sys/s3/uploads/`，桶根下的 `.brewfs.sys` 在列表中被隐藏。
+- **坏凭据**：改错 access-key 后请求应返回 403（s3s SimpleAuth 拒绝）。
+- **mtime 语义**：VFS attr 的 mtime 为纳秒，网关负责转换为 S3 的 `LastModified`（此前实测曾因按秒解析导致 time crate panic，已修复——回归时留意）。
+
+## 7. 已知限制（MVP 范围外）
+
+- 不支持：ACL、版本、加密、CORS、生命周期、PUT bucket 策略、GET/PUT bucket location 以外的桶级配置接口
+- CopyObject 仅支持 `bucket/key` 形式的 `x-amz-copy-source`（不支持 ARN）
+- list 接口未实现 `encoding-type`、`fetch-owner`、V1 `NextMarker` 的完整语义（仅 truncation 时返回）
+- 多网关实例并发对同一 key 的写锁是进程内的（DashMap），跨实例不互斥

--- a/doc/protocols/s3-gateway-verification.md
+++ b/doc/protocols/s3-gateway-verification.md
@@ -50,16 +50,17 @@ python3 scripts/e2e_s3_gateway.py
 
 默认连 `http://127.0.0.1:19101`（可用 `GW_ENDPOINT` 环境变量覆盖）。
 
-**预期结果：`RESULT: 27 passed, 0 failed`**（2026-09-08 在 WSL Ubuntu-22.04 实测）。
+**2026-09-09 在 WSL Ubuntu-22.04 实测：`RESULT: 76 passed, 0 failed`**（single-bucket fresh LocalFS + SQLite 卷）。另以 multi-bucket fresh 卷完成 namespace/bucket 边界检查，验证 active multipart 会阻止删桶、Abort 后空桶可删除且不会复现，并验证非法单桶配置在监听前失败。
 
 覆盖内容：
 
-- 桶操作：list_buckets / head_bucket / 错误桶返回 404
-- 对象基本操作：put（ETag=MD5）、get、range 读、head、content-type、NoSuchKey
-- list_objects_v2：prefix、delimiter/common-prefixes、MaxKeys 截断与 ContinuationToken 分页
-- copy_object
-- 分段上传：create/upload_part/list_parts/complete（ETag 带 `-2` 后缀）、abort 后 NoSuchUpload
-- 目录对象：PUT `key/`、GET 为空体、列表中以 `key/` 呈现且 size=0
+- 桶操作：list_buckets / head_bucket / location，错误桶返回 NoSuchBucket
+- 对象基本操作：put（ETag=MD5）、get、range 读、head、content-type、user metadata、NoSuchKey，以及慢消费 GET 与并发覆盖时的完整性
+- 路径边界：拒绝单桶模式的 `/.brewfs.sys` 对象入口、前导/重复尾斜杠别名和非法单桶配置
+- list_objects_v2：prefix、delimiter/common-prefixes、MaxKeys 可见条目计数、零容量页与 ContinuationToken 分页
+- copy_object：普通复制与同源同目标覆盖
+- 分段上传：create/upload_part/list_parts/complete、abort、bucket/key ownership、零容量/多页 part listing、覆盖现有对象和目录目标拒绝
+- 目录对象：PUT/GET/HEAD/list、空体约束、`key`/`key/` 隔离与空对象 CopyObject
 - 删除：单删后 NoSuchKey、空目录自动收敛、批量 delete_objects
 
 ## 5. 单元测试
@@ -68,12 +69,12 @@ python3 scripts/e2e_s3_gateway.py
 cargo test --features gateway-s3 gateway::
 ```
 
-11 个用例覆盖 path 映射（桶名校验、逃逸 key 拒绝）、list 语义（排序/max_keys/start_after/分隔符）、multipart 路径与合并 ETag 格式。
+22 个用例覆盖 path 映射（桶名、保留命名空间、别名和逃逸 key 校验）、list 可见条目分页、零容量页与分隔符语义、multipart 路径与合并 ETag 格式，以及固定 key/bucket-lock 分片。
 
 ## 6. 手工验证要点（可选）
 
 - **跨端可见**：网关写入的对象同时也是卷内普通文件，可再用 `brewfs mount`（FUSE）或 SDK Client 挂同一 meta/数据后端查看 `docs/readme.txt` 等路径。
-- **协议元数据**：`brewfs.s3.etag` / `brewfs.s3.meta` 存放在文件 xattr；multipart 状态位于 `/.brewfs.sys/s3/uploads/`，桶根下的 `.brewfs.sys` 在列表中被隐藏。
+- **协议元数据**：`brewfs.s3.etag` / `brewfs.s3.meta` 存放在文件 xattr；multipart 状态位于 `/.brewfs.sys/s3/uploads/`，该卷级内部命名空间不会作为对象或 multi-bucket 暴露。
 - **坏凭据**：改错 access-key 后请求应返回 403（s3s SimpleAuth 拒绝）。
 - **mtime 语义**：VFS attr 的 mtime 为纳秒，网关负责转换为 S3 的 `LastModified`（此前实测曾因按秒解析导致 time crate panic，已修复——回归时留意）。
 
@@ -82,4 +83,4 @@ cargo test --features gateway-s3 gateway::
 - 不支持：ACL、版本、加密、CORS、生命周期、PUT bucket 策略、GET/PUT bucket location 以外的桶级配置接口
 - CopyObject 仅支持 `bucket/key` 形式的 `x-amz-copy-source`（不支持 ARN）
 - list 接口未实现 `encoding-type`、`fetch-owner`、V1 `NextMarker` 的完整语义（仅 truncation 时返回）
-- 多网关实例并发对同一 key 的写锁是进程内的（DashMap），跨实例不互斥
+- 多网关实例并发对同一 key 的写锁是进程内固定分片，跨实例不互斥

--- a/scripts/e2e_s3_gateway.py
+++ b/scripts/e2e_s3_gateway.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""End-to-end smoke test for the BrewFS S3 gateway.
+
+Covers: list_buckets, head_bucket, put/get/head/delete_object,
+list_objects_v2 (prefix/delimiter/pagination), copy_object,
+multipart upload, directory objects, and error codes.
+"""
+import io
+import os
+import sys
+
+import boto3
+from botocore.client import Config
+from botocore.exceptions import ClientError
+
+ENDPOINT = os.environ.get("GW_ENDPOINT", "http://127.0.0.1:19101")
+AK, SK = "testkey", "testsecret"
+BUCKET = "brewfs"
+
+s3 = boto3.client(
+    "s3",
+    endpoint_url=ENDPOINT,
+    aws_access_key_id=AK,
+    aws_secret_access_key=SK,
+    region_name="us-east-1",
+    config=Config(s3={"addressing_style": "path"}, retries={"max_attempts": 1}),
+)
+
+passed = failed = 0
+
+
+def check(name, cond, detail=""):
+    global passed, failed
+    if cond:
+        passed += 1
+        print(f"  PASS {name}")
+    else:
+        failed += 1
+        print(f"  FAIL {name} {detail}")
+
+
+def expect_error(name, code, fn):
+    try:
+        fn()
+        check(name, False, "(no error raised)")
+    except ClientError as e:
+        got = e.response["Error"]["Code"]
+        check(name, got == code, f"(got {got}, want {code})")
+
+
+print("== bucket ops ==")
+buckets = s3.list_buckets()["Buckets"]
+check("list_buckets contains default bucket", any(b["Name"] == BUCKET for b in buckets), str(buckets))
+s3.head_bucket(Bucket=BUCKET)
+print("  PASS head_bucket")
+expect_error("head_bucket wrong bucket -> 404/NoSuchBucket", "404", lambda: s3.head_bucket(Bucket="nope"))
+
+print("== object basic ops ==")
+body = b"hello brewfs s3 gateway\n" * 100
+resp = s3.put_object(Bucket=BUCKET, Key="docs/readme.txt", Body=body, ContentType="text/plain")
+etag = resp["ETag"].strip('"')
+import hashlib
+check("put_object etag = md5", etag == hashlib.md5(body).hexdigest(), etag)
+
+got = s3.get_object(Bucket=BUCKET, Key="docs/readme.txt")
+data = got["Body"].read()
+check("get_object roundtrip", data == body)
+check("get_object content-type", got.get("ContentType") == "text/plain", got.get("ContentType"))
+check("get_object content-length", got.get("ContentLength") == len(body))
+
+# ranged read
+r = s3.get_object(Bucket=BUCKET, Key="docs/readme.txt", Range="bytes=6-10")
+check("get_object range", r["Body"].read() == body[6:11], repr(r["Body"].read()))
+
+h = s3.head_object(Bucket=BUCKET, Key="docs/readme.txt")
+check("head_object size", h["ContentLength"] == len(body))
+check("head_object metadata xattr path", "LastModified" in h)
+
+expect_error("get_object missing key -> NoSuchKey", "NoSuchKey",
+             lambda: s3.get_object(Bucket=BUCKET, Key="no/such/key"))
+
+print("== list_objects_v2 ==")
+for i in range(5):
+    s3.put_object(Bucket=BUCKET, Key=f"logs/2026/day-{i}.log", Body=f"log line {i}".encode())
+resp = s3.list_objects_v2(Bucket=BUCKET, Prefix="logs/")
+keys = [o["Key"] for o in resp.get("Contents", [])]
+check("list prefix", keys == [f"logs/2026/day-{i}.log" for i in range(5)], str(keys))
+check("list etag present", all("ETag" in o for o in resp.get("Contents", [])))
+
+resp = s3.list_objects_v2(Bucket=BUCKET, Prefix="logs/2026/", Delimiter="/")
+check("list delimiter -> common prefix", resp.get("CommonPrefixes") is None, str(resp.get("CommonPrefixes")))
+resp = s3.list_objects_v2(Bucket=BUCKET, Prefix="logs/", Delimiter="/")
+cps = [p["Prefix"] for p in resp.get("CommonPrefixes", [])]
+check("list delimiter -> common prefix", cps == ["logs/2026/"], str(cps))
+
+# pagination
+resp1 = s3.list_objects_v2(Bucket=BUCKET, Prefix="logs/", MaxKeys=2)
+check("list truncated", resp1["IsTruncated"])
+resp2 = s3.list_objects_v2(Bucket=BUCKET, Prefix="logs/", MaxKeys=10,
+                           ContinuationToken=resp1["NextContinuationToken"])
+all_keys = [o["Key"] for o in resp1.get("Contents", [])] + [o["Key"] for o in resp2.get("Contents", [])]
+check("list pagination resumes", all_keys == [f"logs/2026/day-{i}.log" for i in range(5)], str(all_keys))
+
+print("== copy_object ==")
+s3.copy_object(Bucket=BUCKET, Key="docs/readme-copy.txt",
+               CopySource={"Bucket": BUCKET, "Key": "docs/readme.txt"})
+d = s3.get_object(Bucket=BUCKET, Key="docs/readme-copy.txt")["Body"].read()
+check("copy_object data", d == body)
+
+print("== multipart upload ==")
+mp = s3.create_multipart_upload(Bucket=BUCKET, Key="big/blob.bin", ContentType="application/x-blob")
+uid = mp["UploadId"]
+part_size = 5 * 1024 * 1024
+part1 = os.urandom(part_size)
+part2 = os.urandom(1024 * 1024)
+e1 = s3.upload_part(Bucket=BUCKET, Key="big/blob.bin", UploadId=uid, PartNumber=1, Body=part1)["ETag"]
+e2 = s3.upload_part(Bucket=BUCKET, Key="big/blob.bin", UploadId=uid, PartNumber=2, Body=part2)["ETag"]
+lp = s3.list_parts(Bucket=BUCKET, Key="big/blob.bin", UploadId=uid)
+check("list_parts count", len(lp.get("Parts", [])) == 2, str(lp.get("Parts")))
+resp = s3.complete_multipart_upload(
+    Bucket=BUCKET, Key="big/blob.bin", UploadId=uid,
+    MultipartUpload={"Parts": [
+        {"ETag": e1, "PartNumber": 1},
+        {"ETag": e2, "PartNumber": 2},
+    ]})
+etag = resp["ETag"].strip('"')
+check("multipart etag has -2 suffix", etag.endswith("-2"), etag)
+got = s3.get_object(Bucket=BUCKET, Key="big/blob.bin")
+data = got["Body"].read()
+check("multipart roundtrip", data == part1 + part2, f"len={len(data)}")
+check("multipart content-type", got.get("ContentType") == "application/x-blob")
+
+# abort flow
+mp = s3.create_multipart_upload(Bucket=BUCKET, Key="big/aborted.bin")
+uid2 = mp["UploadId"]
+s3.upload_part(Bucket=BUCKET, Key="big/aborted.bin", UploadId=uid2, PartNumber=1, Body=b"x" * 1024)
+s3.abort_multipart_upload(Bucket=BUCKET, Key="big/aborted.bin", UploadId=uid2)
+expect_error("aborted upload -> NoSuchUpload", "NoSuchUpload",
+             lambda: s3.list_parts(Bucket=BUCKET, Key="big/aborted.bin", UploadId=uid2))
+
+print("== directory objects ==")
+s3.put_object(Bucket=BUCKET, Key="empty-dir/", Body=b"")
+r = s3.list_objects_v2(Bucket=BUCKET, Prefix="empty-dir")
+check("dir object listed", any(o["Key"] == "empty-dir/" for o in r.get("Contents", [])), str(r.get("Contents")))
+g = s3.get_object(Bucket=BUCKET, Key="empty-dir/")
+check("dir object GET empty", g["Body"].read() == b"")
+s3.delete_object(Bucket=BUCKET, Key="empty-dir/")
+
+print("== delete ops ==")
+s3.delete_object(Bucket=BUCKET, Key="docs/readme-copy.txt")
+expect_error("deleted key gone", "NoSuchKey",
+             lambda: s3.get_object(Bucket=BUCKET, Key="docs/readme-copy.txt"))
+s3.delete_object(Bucket=BUCKET, Key="docs/readme.txt")
+s3.delete_object(Bucket=BUCKET, Key="big/blob.bin")
+for i in range(5):
+    s3.delete_object(Bucket=BUCKET, Key=f"logs/2026/day-{i}.log")
+r = s3.list_objects_v2(Bucket=BUCKET, Prefix="docs/")
+check("empty prefixes pruned from listing", not r.get("Contents") and not r.get("CommonPrefixes"),
+      str(r))
+
+print("== delete_objects (batch) ==")
+for i in range(3):
+    s3.put_object(Bucket=BUCKET, Key=f"batch/f{i}.txt", Body=b"batch")
+resp = s3.delete_objects(Bucket=BUCKET, Delete={
+    "Objects": [{"Key": f"batch/f{i}.txt"} for i in range(3)]})
+check("batch delete ok", len(resp.get("Deleted", [])) == 3 and not resp.get("Errors"),
+      str(resp))
+
+print(f"\nRESULT: {passed} passed, {failed} failed")
+sys.exit(1 if failed else 0)

--- a/scripts/e2e_s3_gateway.py
+++ b/scripts/e2e_s3_gateway.py
@@ -5,9 +5,10 @@ Covers: list_buckets, head_bucket, put/get/head/delete_object,
 list_objects_v2 (prefix/delimiter/pagination), copy_object,
 multipart upload, directory objects, and error codes.
 """
-import io
 import os
 import sys
+import threading
+import time
 
 import boto3
 from botocore.client import Config
@@ -52,12 +53,20 @@ print("== bucket ops ==")
 buckets = s3.list_buckets()["Buckets"]
 check("list_buckets contains default bucket", any(b["Name"] == BUCKET for b in buckets), str(buckets))
 s3.head_bucket(Bucket=BUCKET)
-print("  PASS head_bucket")
+check("head_bucket", True)
 expect_error("head_bucket wrong bucket -> 404/NoSuchBucket", "404", lambda: s3.head_bucket(Bucket="nope"))
+expect_error("get_bucket_location wrong bucket", "NoSuchBucket",
+             lambda: s3.get_bucket_location(Bucket="nope"))
 
 print("== object basic ops ==")
 body = b"hello brewfs s3 gateway\n" * 100
-resp = s3.put_object(Bucket=BUCKET, Key="docs/readme.txt", Body=body, ContentType="text/plain")
+resp = s3.put_object(
+    Bucket=BUCKET,
+    Key="docs/readme.txt",
+    Body=body,
+    ContentType="text/plain",
+    Metadata={"source": "e2e"},
+)
 etag = resp["ETag"].strip('"')
 import hashlib
 check("put_object etag = md5", etag == hashlib.md5(body).hexdigest(), etag)
@@ -66,18 +75,66 @@ got = s3.get_object(Bucket=BUCKET, Key="docs/readme.txt")
 data = got["Body"].read()
 check("get_object roundtrip", data == body)
 check("get_object content-type", got.get("ContentType") == "text/plain", got.get("ContentType"))
+check("get_object user metadata", got.get("Metadata") == {"source": "e2e"}, str(got.get("Metadata")))
 check("get_object content-length", got.get("ContentLength") == len(body))
 
 # ranged read
 r = s3.get_object(Bucket=BUCKET, Key="docs/readme.txt", Range="bytes=6-10")
-check("get_object range", r["Body"].read() == body[6:11], repr(r["Body"].read()))
+ranged_body = r["Body"].read()
+check("get_object range", ranged_body == body[6:11], repr(ranged_body))
+check("get_object range status", r["ResponseMetadata"]["HTTPStatusCode"] == 206, str(r["ResponseMetadata"]))
+check("get_object content-range", r.get("ContentRange") == f"bytes 6-10/{len(body)}", r.get("ContentRange"))
 
 h = s3.head_object(Bucket=BUCKET, Key="docs/readme.txt")
 check("head_object size", h["ContentLength"] == len(body))
+check("head_object user metadata", h.get("Metadata") == {"source": "e2e"}, str(h.get("Metadata")))
 check("head_object metadata xattr path", "LastModified" in h)
 
 expect_error("get_object missing key -> NoSuchKey", "NoSuchKey",
              lambda: s3.get_object(Bucket=BUCKET, Key="no/such/key"))
+s3.put_object(Bucket=BUCKET, Key="empty.bin", Body=b"")
+expect_error("empty object range -> InvalidRange", "InvalidRange",
+             lambda: s3.get_object(Bucket=BUCKET, Key="empty.bin", Range="bytes=-1"))
+
+large_body = bytes(range(251)) * 100_000
+large_etag = hashlib.md5(large_body).hexdigest()
+replacement_body = b"replacement after streaming get"
+s3.put_object(Bucket=BUCKET, Key="large/slow-read.bin", Body=large_body)
+large_response = s3.get_object(Bucket=BUCKET, Key="large/slow-read.bin")
+time.sleep(0.2)
+overwrite_errors = []
+
+
+def overwrite_large_object():
+    try:
+        s3.put_object(Bucket=BUCKET, Key="large/slow-read.bin", Body=replacement_body)
+    except Exception as error:
+        overwrite_errors.append(repr(error))
+
+
+overwrite_thread = threading.Thread(target=overwrite_large_object, daemon=True)
+overwrite_thread.start()
+large_download = bytearray()
+for chunk in large_response["Body"].iter_chunks(chunk_size=64 * 1024):
+    large_download.extend(chunk)
+    time.sleep(0.001)
+overwrite_thread.join(timeout=30)
+check("large slow get length", len(large_download) == len(large_body), str(len(large_download)))
+check("large slow get md5", hashlib.md5(large_download).hexdigest() == large_etag)
+current_large_body = None
+if not overwrite_thread.is_alive() and not overwrite_errors:
+    current_large_body = s3.get_object(Bucket=BUCKET, Key="large/slow-read.bin")["Body"].read()
+check("concurrent overwrite publishes replacement",
+      current_large_body == replacement_body,
+      str(overwrite_errors or ["overwrite still running"]))
+
+for operation, fn in [
+    ("put", lambda: s3.put_object(Bucket=BUCKET, Key=".brewfs.sys/s3/tmp/intruder", Body=b"x")),
+    ("get", lambda: s3.get_object(Bucket=BUCKET, Key=".brewfs.sys/s3/tmp/intruder")),
+    ("delete", lambda: s3.delete_object(Bucket=BUCKET, Key=".brewfs.sys/s3/tmp/intruder")),
+    ("list", lambda: s3.list_objects_v2(Bucket=BUCKET, Prefix=".brewfs.sys/")),
+]:
+    expect_error(f"reserved system path {operation}", "AccessDenied", fn)
 
 print("== list_objects_v2 ==")
 for i in range(5):
@@ -96,20 +153,97 @@ check("list delimiter -> common prefix", cps == ["logs/2026/"], str(cps))
 # pagination
 resp1 = s3.list_objects_v2(Bucket=BUCKET, Prefix="logs/", MaxKeys=2)
 check("list truncated", resp1["IsTruncated"])
+check("list page uses full visible capacity",
+      len(resp1.get("Contents", [])) == 2 and resp1.get("KeyCount") == 2,
+      str(resp1))
 resp2 = s3.list_objects_v2(Bucket=BUCKET, Prefix="logs/", MaxKeys=10,
                            ContinuationToken=resp1["NextContinuationToken"])
 all_keys = [o["Key"] for o in resp1.get("Contents", [])] + [o["Key"] for o in resp2.get("Contents", [])]
 check("list pagination resumes", all_keys == [f"logs/2026/day-{i}.log" for i in range(5)], str(all_keys))
+
+deep_key = "/".join(["deep"] + [f"d{i}" for i in range(70)] + ["file.txt"])
+s3.put_object(Bucket=BUCKET, Key=deep_key, Body=b"deep")
+deep_keys = [o["Key"] for o in s3.list_objects_v2(Bucket=BUCKET, Prefix="deep/").get("Contents", [])]
+check("list includes object deeper than 64 directories", deep_keys == [deep_key], str(deep_keys))
+
+wide_keys = [f"wide/entry-{i:03d}.txt" for i in range(260)]
+for wide_key in wide_keys:
+    s3.put_object(Bucket=BUCKET, Key=wide_key, Body=b"wide")
+listed_wide = [o["Key"] for o in s3.list_objects_v2(Bucket=BUCKET, Prefix="wide/").get("Contents", [])]
+check("list reads directories beyond one readdir page", listed_wide == wide_keys, str(len(listed_wide)))
+long_prefix_result = s3.list_objects_v2(Bucket=BUCKET, Prefix="x" * 1025)
+check("list accepts prefix longer than object key limit",
+      not long_prefix_result.get("Contents") and not long_prefix_result.get("CommonPrefixes"),
+      str(long_prefix_result))
+zero_page = s3.list_objects_v2(Bucket=BUCKET, Prefix="logs/", MaxKeys=0)
+check("list zero max-keys is empty and not truncated",
+      zero_page.get("KeyCount") == 0 and zero_page.get("IsTruncated") is False
+      and not zero_page.get("NextContinuationToken"),
+      str(zero_page))
+expect_error("multiple trailing slashes are rejected", "InvalidArgument",
+             lambda: s3.put_object(Bucket=BUCKET, Key="alias-dir//", Body=b""))
 
 print("== copy_object ==")
 s3.copy_object(Bucket=BUCKET, Key="docs/readme-copy.txt",
                CopySource={"Bucket": BUCKET, "Key": "docs/readme.txt"})
 d = s3.get_object(Bucket=BUCKET, Key="docs/readme-copy.txt")["Body"].read()
 check("copy_object data", d == body)
+s3.copy_object(Bucket=BUCKET, Key="docs/readme-copy.txt",
+               CopySource={"Bucket": BUCKET, "Key": "docs/readme-copy.txt"})
+d = s3.get_object(Bucket=BUCKET, Key="docs/readme-copy.txt")["Body"].read()
+check("copy_object self copy", d == body)
+replace_copy = s3.copy_object(
+    Bucket=BUCKET,
+    Key="docs/readme-copy.txt",
+    CopySource={"Bucket": BUCKET, "Key": "docs/readme-copy.txt"},
+    MetadataDirective="REPLACE",
+    Metadata={"copy-mode": "replace"},
+)
+check("copy metadata replace preserves body etag",
+      replace_copy["CopyObjectResult"]["ETag"].strip('"') == hashlib.md5(body).hexdigest(),
+      str(replace_copy))
 
 print("== multipart upload ==")
+expect_error("malformed unicode upload id -> NoSuchUpload", "NoSuchUpload",
+             lambda: s3.list_parts(Bucket=BUCKET, Key="big/blob.bin", UploadId="a😀"))
+listed_uploads = []
+for key in ["queued/a.bin", "queued/b.bin", "queued/c.bin"]:
+    created = s3.create_multipart_upload(Bucket=BUCKET, Key=key)
+    listed_uploads.append((key, created["UploadId"]))
+upload_page1 = s3.list_multipart_uploads(Bucket=BUCKET, Prefix="queued/", MaxUploads=2)
+check("list_multipart_uploads first page is truncated",
+      [upload["Key"] for upload in upload_page1.get("Uploads", [])]
+      == ["queued/a.bin", "queued/b.bin"]
+      and upload_page1.get("IsTruncated") is True,
+      str(upload_page1))
+upload_page2 = s3.list_multipart_uploads(
+    Bucket=BUCKET, Prefix="queued/", MaxUploads=2,
+    KeyMarker=upload_page1["NextKeyMarker"],
+    UploadIdMarker=upload_page1["NextUploadIdMarker"],
+)
+check("list_multipart_uploads pagination resumes",
+      [upload["Key"] for upload in upload_page2.get("Uploads", [])] == ["queued/c.bin"]
+      and upload_page2.get("IsTruncated") is False,
+      str(upload_page2))
+for key, upload_id in listed_uploads:
+    s3.abort_multipart_upload(Bucket=BUCKET, Key=key, UploadId=upload_id)
+s3.put_object(Bucket=BUCKET, Key="big/blob.bin", Body=b"old contents")
 mp = s3.create_multipart_upload(Bucket=BUCKET, Key="big/blob.bin", ContentType="application/x-blob")
 uid = mp["UploadId"]
+expect_error("upload_part wrong key -> NoSuchUpload", "NoSuchUpload",
+             lambda: s3.upload_part(Bucket=BUCKET, Key="big/wrong.bin", UploadId=uid,
+                                    PartNumber=1, Body=b"wrong"))
+expect_error("upload_part wrong bucket -> NoSuchUpload", "NoSuchUpload",
+             lambda: s3.upload_part(Bucket="other", Key="big/blob.bin", UploadId=uid,
+                                    PartNumber=1, Body=b"wrong"))
+expect_error("list_parts wrong key -> NoSuchUpload", "NoSuchUpload",
+             lambda: s3.list_parts(Bucket=BUCKET, Key="big/wrong.bin", UploadId=uid))
+expect_error("list_parts wrong bucket -> NoSuchUpload", "NoSuchUpload",
+             lambda: s3.list_parts(Bucket="other", Key="big/blob.bin", UploadId=uid))
+expect_error("abort multipart wrong key -> NoSuchUpload", "NoSuchUpload",
+             lambda: s3.abort_multipart_upload(Bucket=BUCKET, Key="big/wrong.bin", UploadId=uid))
+expect_error("abort multipart wrong bucket -> NoSuchUpload", "NoSuchUpload",
+             lambda: s3.abort_multipart_upload(Bucket="other", Key="big/blob.bin", UploadId=uid))
 part_size = 5 * 1024 * 1024
 part1 = os.urandom(part_size)
 part2 = os.urandom(1024 * 1024)
@@ -128,7 +262,26 @@ check("multipart etag has -2 suffix", etag.endswith("-2"), etag)
 got = s3.get_object(Bucket=BUCKET, Key="big/blob.bin")
 data = got["Body"].read()
 check("multipart roundtrip", data == part1 + part2, f"len={len(data)}")
+check("multipart overwrites existing object", data != b"old contents")
 check("multipart content-type", got.get("ContentType") == "application/x-blob")
+
+# S3 permits ascending, non-consecutive part numbers.
+mp_sparse = s3.create_multipart_upload(Bucket=BUCKET, Key="big/sparse.bin")
+uid_sparse = mp_sparse["UploadId"]
+sparse_part2 = os.urandom(part_size)
+sparse_part4 = os.urandom(1024 * 1024)
+e_sparse2 = s3.upload_part(Bucket=BUCKET, Key="big/sparse.bin", UploadId=uid_sparse,
+                            PartNumber=2, Body=sparse_part2)["ETag"]
+e_sparse4 = s3.upload_part(Bucket=BUCKET, Key="big/sparse.bin", UploadId=uid_sparse,
+                            PartNumber=4, Body=sparse_part4)["ETag"]
+s3.complete_multipart_upload(
+    Bucket=BUCKET, Key="big/sparse.bin", UploadId=uid_sparse,
+    MultipartUpload={"Parts": [
+        {"ETag": e_sparse2, "PartNumber": 2},
+        {"ETag": e_sparse4, "PartNumber": 4},
+    ]})
+sparse_data = s3.get_object(Bucket=BUCKET, Key="big/sparse.bin")["Body"].read()
+check("multipart non-consecutive parts", sparse_data == sparse_part2 + sparse_part4)
 
 # abort flow
 mp = s3.create_multipart_upload(Bucket=BUCKET, Key="big/aborted.bin")
@@ -138,12 +291,93 @@ s3.abort_multipart_upload(Bucket=BUCKET, Key="big/aborted.bin", UploadId=uid2)
 expect_error("aborted upload -> NoSuchUpload", "NoSuchUpload",
              lambda: s3.list_parts(Bucket=BUCKET, Key="big/aborted.bin", UploadId=uid2))
 
+many_parts = s3.create_multipart_upload(Bucket=BUCKET, Key="big/many-parts.bin")
+many_parts_uid = many_parts["UploadId"]
+for part_number in range(1, 261):
+    s3.upload_part(Bucket=BUCKET, Key="big/many-parts.bin", UploadId=many_parts_uid,
+                   PartNumber=part_number, Body=b"x")
+many_parts_zero = s3.list_parts(Bucket=BUCKET, Key="big/many-parts.bin",
+                                UploadId=many_parts_uid, MaxParts=0)
+check("list_parts zero max-parts is empty and not truncated",
+      not many_parts_zero.get("Parts") and many_parts_zero.get("IsTruncated") is False
+      and not many_parts_zero.get("NextPartNumberMarker"),
+      str(many_parts_zero))
+many_parts_page1 = s3.list_parts(Bucket=BUCKET, Key="big/many-parts.bin",
+                                 UploadId=many_parts_uid, MaxParts=100)
+check("list_parts first page is truncated",
+      len(many_parts_page1.get("Parts", [])) == 100
+      and many_parts_page1.get("IsTruncated") is True
+      and many_parts_page1.get("NextPartNumberMarker") == 100,
+      str(many_parts_page1))
+many_parts_page2 = s3.list_parts(
+    Bucket=BUCKET, Key="big/many-parts.bin", UploadId=many_parts_uid, MaxParts=200,
+    PartNumberMarker=many_parts_page1["NextPartNumberMarker"],
+)
+check("list_parts pagination resumes",
+      [part["PartNumber"] for part in many_parts_page2.get("Parts", [])]
+      == list(range(101, 261)) and many_parts_page2.get("IsTruncated") is False,
+      str(many_parts_page2))
+s3.abort_multipart_upload(Bucket=BUCKET, Key="big/many-parts.bin", UploadId=many_parts_uid)
+expect_error("abort removes upload with more than one readdir page", "NoSuchUpload",
+             lambda: s3.list_parts(Bucket=BUCKET, Key="big/many-parts.bin",
+                                   UploadId=many_parts_uid))
+
+s3.put_object(Bucket=BUCKET, Key="multipart-dir/", Body=b"")
+blocked = s3.create_multipart_upload(Bucket=BUCKET, Key="multipart-dir")
+blocked_uid = blocked["UploadId"]
+blocked_etag = s3.upload_part(Bucket=BUCKET, Key="multipart-dir", UploadId=blocked_uid,
+                              PartNumber=1, Body=b"blocked")["ETag"]
+expect_error(
+    "multipart target directory rejected", "InvalidArgument",
+    lambda: s3.complete_multipart_upload(
+        Bucket=BUCKET, Key="multipart-dir", UploadId=blocked_uid,
+        MultipartUpload={"Parts": [{"ETag": blocked_etag, "PartNumber": 1}]},
+    ),
+)
+s3.abort_multipart_upload(Bucket=BUCKET, Key="multipart-dir", UploadId=blocked_uid)
+s3.delete_object(Bucket=BUCKET, Key="multipart-dir/")
+
 print("== directory objects ==")
+s3.put_object(Bucket=BUCKET, Key="slash-alias", Body=b"ordinary object")
+expect_error("trailing slash PUT does not replace regular object", "InvalidArgument",
+             lambda: s3.put_object(Bucket=BUCKET, Key="slash-alias/", Body=b""))
+expect_error("trailing slash GET does not alias regular object", "NoSuchKey",
+             lambda: s3.get_object(Bucket=BUCKET, Key="slash-alias/"))
+s3.delete_object(Bucket=BUCKET, Key="slash-alias/")
+check("trailing slash DELETE preserves regular object",
+      s3.get_object(Bucket=BUCKET, Key="slash-alias")["Body"].read() == b"ordinary object")
+expect_error("non-empty directory object is rejected", "InvalidArgument",
+             lambda: s3.put_object(Bucket=BUCKET, Key="nonempty-dir/", Body=b"not empty"))
+expect_error("non-empty copy to directory object is rejected", "InvalidArgument",
+             lambda: s3.copy_object(Bucket=BUCKET, Key="copy-dir/",
+                                    CopySource={"Bucket": BUCKET, "Key": "slash-alias"}))
+s3.put_object(Bucket=BUCKET, Key="empty-source", Body=b"")
+s3.copy_object(Bucket=BUCKET, Key="copied-dir/",
+               CopySource={"Bucket": BUCKET, "Key": "empty-source"})
+check("empty copy creates directory object",
+      s3.get_object(Bucket=BUCKET, Key="copied-dir/")["Body"].read() == b"")
+s3.delete_object(Bucket=BUCKET, Key="slash-alias")
+s3.delete_object(Bucket=BUCKET, Key="empty-source")
+s3.delete_object(Bucket=BUCKET, Key="copied-dir/")
 s3.put_object(Bucket=BUCKET, Key="empty-dir/", Body=b"")
 r = s3.list_objects_v2(Bucket=BUCKET, Prefix="empty-dir")
 check("dir object listed", any(o["Key"] == "empty-dir/" for o in r.get("Contents", [])), str(r.get("Contents")))
+r = s3.list_objects_v2(Bucket=BUCKET, Prefix="empty-dir/")
+check("dir object listed with trailing-slash prefix",
+      [o["Key"] for o in r.get("Contents", [])] == ["empty-dir/"], str(r))
+r = s3.list_objects_v2(Bucket=BUCKET, Delimiter="/")
+check("dir object rolls up under root delimiter",
+      "empty-dir/" in [p["Prefix"] for p in r.get("CommonPrefixes", [])]
+      and "empty-dir/" not in [o["Key"] for o in r.get("Contents", [])], str(r))
+r = s3.list_objects_v2(Bucket=BUCKET, Prefix="empty-dir/", Delimiter="/")
+check("dir object prefix delimiter listing",
+      [o["Key"] for o in r.get("Contents", [])] == ["empty-dir/"], str(r))
+h = s3.head_object(Bucket=BUCKET, Key="empty-dir/")
+check("directory object HEAD size is zero", h["ContentLength"] == 0, str(h))
 g = s3.get_object(Bucket=BUCKET, Key="empty-dir/")
 check("dir object GET empty", g["Body"].read() == b"")
+expect_error("dir object range -> InvalidRange", "InvalidRange",
+             lambda: s3.get_object(Bucket=BUCKET, Key="empty-dir/", Range="bytes=0-0"))
 s3.delete_object(Bucket=BUCKET, Key="empty-dir/")
 
 print("== delete ops ==")
@@ -151,7 +385,13 @@ s3.delete_object(Bucket=BUCKET, Key="docs/readme-copy.txt")
 expect_error("deleted key gone", "NoSuchKey",
              lambda: s3.get_object(Bucket=BUCKET, Key="docs/readme-copy.txt"))
 s3.delete_object(Bucket=BUCKET, Key="docs/readme.txt")
+s3.delete_object(Bucket=BUCKET, Key=deep_key)
+for wide_key in wide_keys:
+    s3.delete_object(Bucket=BUCKET, Key=wide_key)
+s3.delete_object(Bucket=BUCKET, Key="empty.bin")
+s3.delete_object(Bucket=BUCKET, Key="large/slow-read.bin")
 s3.delete_object(Bucket=BUCKET, Key="big/blob.bin")
+s3.delete_object(Bucket=BUCKET, Key="big/sparse.bin")
 for i in range(5):
     s3.delete_object(Bucket=BUCKET, Key=f"logs/2026/day-{i}.log")
 r = s3.list_objects_v2(Bucket=BUCKET, Prefix="docs/")

--- a/src/config.rs
+++ b/src/config.rs
@@ -68,9 +68,57 @@ pub enum Command {
     /// Run the BrewFS web console.
     Console(ConsoleArgs),
 
+    /// Run protocol gateways that expose a BrewFS volume over S3/WebDAV/NFS
+    /// without a FUSE mount.
+    #[cfg(feature = "gateway-s3")]
+    Gateway(Box<GatewayArgs>),
+
     /// Run a direct S3 object PUT benchmark without going through FUSE.
     #[command(hide = true)]
     ObjectPutBench(ObjectPutBenchArgs),
+}
+
+#[derive(Subcommand, Debug)]
+pub enum GatewayProtocol {
+    /// S3-compatible gateway (see doc/protocols/s3-gateway.md).
+    S3(S3GatewayArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct GatewayArgs {
+    #[command(subcommand)]
+    pub protocol: GatewayProtocol,
+}
+
+#[derive(Args, Debug)]
+pub struct S3GatewayArgs {
+    /// HTTP listen address of the S3 endpoint.
+    #[arg(long, value_name = "ADDR", default_value = "0.0.0.0:9000")]
+    pub listen: std::net::SocketAddr,
+
+    /// Static access key for SigV4 (or env BREWFS_S3_ACCESS_KEY).
+    #[arg(long, value_name = "KEY", env = "BREWFS_S3_ACCESS_KEY")]
+    pub access_key: Option<String>,
+
+    /// Static secret key for SigV4 (or env BREWFS_S3_SECRET_KEY).
+    #[arg(long, value_name = "KEY", env = "BREWFS_S3_SECRET_KEY")]
+    pub secret_key: Option<String>,
+
+    /// Bucket name exposed in single-bucket mode (defaults to "brewfs").
+    #[arg(long, value_name = "NAME", default_value = "brewfs")]
+    pub bucket: String,
+
+    /// Expose top-level directories as buckets instead of a single bucket.
+    #[arg(long, default_value_t = false)]
+    pub multi_buckets: bool,
+
+    /// Hide directory objects in listings.
+    #[arg(long, default_value_t = false)]
+    pub hide_dir_objects: bool,
+
+    /// Volume backend options; the same set accepted by `brewfs mount`.
+    #[command(flatten)]
+    pub mount: MountArgs,
 }
 
 #[derive(Args, Debug, Clone)]

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -1,0 +1,22 @@
+//! Protocol gateways for BrewFS.
+//!
+//! Gateways expose a BrewFS volume over network protocols (S3, WebDAV, NFS)
+//! without going through the kernel FUSE mount. They sit beside `src/fuse/`
+//! on the same core stack (VFS over meta + object storage backends).
+//!
+//! See `doc/protocols/` for the design specs and the milestone roadmap.
+
+/// Hidden system directory that holds gateway-internal state
+/// (multipart uploads, staging files, distributed locks).
+///
+/// All protocol listing operations must filter this directory out at the
+/// volume root. See `doc/protocols/README.md` §3.1.
+pub const SYS_DIR: &str = "/.brewfs.sys";
+
+/// Returns the S3 gateway subsystem directory under [`SYS_DIR`].
+pub fn s3_sys_dir() -> String {
+    format!("{SYS_DIR}/s3")
+}
+
+#[cfg(feature = "gateway-s3")]
+pub mod s3;

--- a/src/gateway/s3/list.rs
+++ b/src/gateway/s3/list.rs
@@ -47,17 +47,6 @@ pub struct ListResult {
     pub next_marker: String,
 }
 
-impl ListResult {
-    /// Total number of returned entries (keys + common prefixes).
-    pub fn len(&self) -> usize {
-        self.objects.len() + self.common_prefixes.len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-}
-
 /// Collects entries during a directory walk, applying prefix/delimiter rules.
 #[derive(Debug, Default)]
 pub struct ListCollector {
@@ -79,6 +68,7 @@ impl ListCollector {
     ///
     /// `parent_key` is the parent path relative to the bucket root with a
     /// trailing `/` (empty for the root). `name` is the entry name.
+    #[allow(clippy::too_many_arguments)]
     pub fn push_entry(
         &mut self,
         parent_key: &str,
@@ -96,17 +86,16 @@ impl ListCollector {
             return;
         }
 
-        if let Some(delim) = self.query.delimiter.clone() {
-            if let Some(rel) = full.strip_prefix(&self.query.prefix) {
-                if let Some(idx) = rel.find(&delim) {
-                    let end = self.query.prefix.len() + idx + delim.len();
-                    let cp = full[..end].to_string();
-                    if cp > self.query.start_after || self.query.start_after.is_empty() {
-                        self.common_prefixes.insert(cp);
-                    }
-                    return;
-                }
+        if let Some(delim) = self.query.delimiter.clone()
+            && let Some(rel) = full.strip_prefix(&self.query.prefix)
+            && let Some(idx) = rel.find(&delim)
+        {
+            let end = self.query.prefix.len() + idx + delim.len();
+            let cp = full[..end].to_string();
+            if cp > self.query.start_after || self.query.start_after.is_empty() {
+                self.common_prefixes.insert(cp);
             }
+            return;
         }
 
         let key = if is_dir_object {

--- a/src/gateway/s3/list.rs
+++ b/src/gateway/s3/list.rs
@@ -109,7 +109,11 @@ impl ListCollector {
             }
         }
 
-        let key = if is_dir_object { format!("{full}/") } else { full };
+        let key = if is_dir_object {
+            format!("{full}/")
+        } else {
+            full
+        };
         self.objects.push(ListedObject {
             key,
             size,
@@ -253,8 +257,7 @@ mod tests {
             max_keys: 10,
             ..Default::default()
         });
-        c.common_prefixes
-            .insert("photos/".to_string());
+        c.common_prefixes.insert("photos/".to_string());
         c.objects = vec![obj("readme.txt")];
         let r = c.finish();
         assert_eq!(r.common_prefixes.len(), 1);

--- a/src/gateway/s3/list.rs
+++ b/src/gateway/s3/list.rs
@@ -1,0 +1,274 @@
+//! Flat-key listing over the hierarchical namespace.
+//!
+//! Emulates the S3 list semantics (prefix / delimiter / max-keys / marker)
+//! on top of a directory walk. See `doc/protocols/s3-gateway.md` §4/§5.
+
+use std::collections::BTreeSet;
+
+/// Parameters of a listing request.
+#[derive(Debug, Clone, Default)]
+pub struct ListQuery {
+    /// Only keys starting with this prefix are returned.
+    pub prefix: String,
+    /// Roll up keys sharing a prefix up to (and including) this delimiter
+    /// into common prefixes instead of listing them.
+    pub delimiter: Option<String>,
+    /// Exclusive start point; listing resumes after this key.
+    pub start_after: String,
+    /// Maximum number of keys + common prefixes returned.
+    pub max_keys: usize,
+}
+
+/// One listed object entry.
+#[derive(Debug, Clone)]
+pub struct ListedObject {
+    /// Full object key.
+    pub key: String,
+    /// Object size in bytes (0 for directory objects).
+    pub size: u64,
+    /// mtime in unix seconds.
+    pub mtime: i64,
+    /// The entry is an explicit directory object (key ends with `/`).
+    pub is_dir_object: bool,
+    /// The entry is a directory without the directory-object marker
+    /// (implicit directory; normally only used internally).
+    pub is_dir: bool,
+    /// Stored ETag xattr, if any.
+    pub etag: Option<String>,
+}
+
+/// Result of a listing.
+#[derive(Debug, Clone, Default)]
+pub struct ListResult {
+    pub objects: Vec<ListedObject>,
+    pub common_prefixes: BTreeSet<String>,
+    pub is_truncated: bool,
+    /// Key of the last returned entry (V1 `NextMarker`; V2 continuation token).
+    pub next_marker: String,
+}
+
+impl ListResult {
+    /// Total number of returned entries (keys + common prefixes).
+    pub fn len(&self) -> usize {
+        self.objects.len() + self.common_prefixes.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// Collects entries during a directory walk, applying prefix/delimiter rules.
+#[derive(Debug, Default)]
+pub struct ListCollector {
+    query: ListQuery,
+    objects: Vec<ListedObject>,
+    common_prefixes: BTreeSet<String>,
+}
+
+impl ListCollector {
+    pub fn new(query: ListQuery) -> Self {
+        Self {
+            query,
+            objects: Vec::new(),
+            common_prefixes: BTreeSet::new(),
+        }
+    }
+
+    /// Records one child entry found under a directory.
+    ///
+    /// `parent_key` is the parent path relative to the bucket root with a
+    /// trailing `/` (empty for the root). `name` is the entry name.
+    pub fn push_entry(
+        &mut self,
+        parent_key: &str,
+        name: &str,
+        is_dir: bool,
+        size: u64,
+        mtime: i64,
+        is_dir_object: bool,
+        etag: Option<String>,
+    ) {
+        let full = format!("{parent_key}{name}");
+        if !self.query.prefix.is_empty() && !full.starts_with(&self.query.prefix) {
+            // Not under the requested prefix. A child directory may still
+            // contain matching keys, so the caller decides whether to descend.
+            return;
+        }
+
+        if let Some(delim) = self.query.delimiter.clone() {
+            if let Some(rel) = full.strip_prefix(&self.query.prefix) {
+                if let Some(idx) = rel.find(&delim) {
+                    let end = self.query.prefix.len() + idx + delim.len();
+                    let cp = full[..end].to_string();
+                    if cp > self.query.start_after || self.query.start_after.is_empty() {
+                        self.common_prefixes.insert(cp);
+                    }
+                    return;
+                }
+            }
+        }
+
+        let key = if is_dir_object { format!("{full}/") } else { full };
+        self.objects.push(ListedObject {
+            key,
+            size,
+            mtime,
+            is_dir_object,
+            is_dir,
+            etag,
+        });
+    }
+
+    /// Whether the walk should descend into the child directory `name`
+    /// (only when the prefix could still match below it).
+    pub fn should_descend(&self, parent_key: &str, name: &str) -> bool {
+        if self.query.delimiter.is_some() {
+            // Delimited listings never report keys below a common prefix,
+            // but we must still descend far enough to detect the prefix itself
+            // (handled via common_prefixes above).
+            return true;
+        }
+        let full = format!("{parent_key}{name}");
+        if self.query.prefix.is_empty() {
+            return true;
+        }
+        if full.starts_with(&self.query.prefix) {
+            return true;
+        }
+        // Descend only if this directory can be a proper prefix of the target
+        // prefix (e.g. prefix "a/b" and directory "a").
+        self.query.prefix.starts_with(&full)
+    }
+
+    /// Finishes the listing: sorts entries, applies start-after and max-keys.
+    pub fn finish(mut self) -> ListResult {
+        // Merge objects and common prefixes into one lexically sorted stream
+        // (S3 returns keys and common prefixes interleaved in sorted order).
+        self.objects.sort_by(|a, b| a.key.cmp(&b.key));
+
+        let mut merged: Vec<MergedEntry> = Vec::new();
+        for cp in &self.common_prefixes {
+            merged.push(MergedEntry::Prefix(cp.clone()));
+        }
+        for o in self.objects.drain(..) {
+            merged.push(MergedEntry::Object(o));
+        }
+        merged.sort_by(|a, b| a.key().cmp(b.key()));
+
+        let mut objects = Vec::new();
+        let mut prefixes = BTreeSet::new();
+        let mut is_truncated = false;
+        let mut next_marker = String::new();
+
+        for entry in merged {
+            let key = entry.key().to_string();
+            if !self.query.start_after.is_empty() && key <= self.query.start_after {
+                continue;
+            }
+            if objects.len() + prefixes.len() >= self.query.max_keys {
+                is_truncated = true;
+                break;
+            }
+            match entry {
+                MergedEntry::Object(o) => objects.push(o),
+                MergedEntry::Prefix(p) => {
+                    prefixes.insert(p);
+                }
+            }
+            next_marker = key;
+        }
+
+        ListResult {
+            objects,
+            common_prefixes: prefixes,
+            is_truncated,
+            next_marker,
+        }
+    }
+}
+
+enum MergedEntry {
+    Object(ListedObject),
+    Prefix(String),
+}
+
+impl MergedEntry {
+    fn key(&self) -> &str {
+        match self {
+            MergedEntry::Object(o) => &o.key,
+            MergedEntry::Prefix(p) => p,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn obj(key: &str) -> ListedObject {
+        ListedObject {
+            key: key.to_string(),
+            size: 1,
+            mtime: 0,
+            is_dir_object: false,
+            is_dir: false,
+            etag: None,
+        }
+    }
+
+    #[test]
+    fn finish_sorts_and_limits() {
+        let mut c = ListCollector::new(ListQuery {
+            max_keys: 2,
+            ..Default::default()
+        });
+        c.objects = vec![obj("b"), obj("a"), obj("c")];
+        let r = c.finish();
+        assert_eq!(r.objects.len(), 2);
+        assert_eq!(r.objects[0].key, "a");
+        assert_eq!(r.objects[1].key, "b");
+        assert!(r.is_truncated);
+        assert_eq!(r.next_marker, "b");
+    }
+
+    #[test]
+    fn start_after_filters() {
+        let mut c = ListCollector::new(ListQuery {
+            start_after: "b".to_string(),
+            max_keys: 10,
+            ..Default::default()
+        });
+        c.objects = vec![obj("a"), obj("b"), obj("c")];
+        let r = c.finish();
+        assert_eq!(r.objects.len(), 1);
+        assert_eq!(r.objects[0].key, "c");
+        assert!(!r.is_truncated);
+    }
+
+    #[test]
+    fn delimiter_collects_common_prefixes() {
+        let mut c = ListCollector::new(ListQuery {
+            delimiter: Some("/".to_string()),
+            max_keys: 10,
+            ..Default::default()
+        });
+        c.common_prefixes
+            .insert("photos/".to_string());
+        c.objects = vec![obj("readme.txt")];
+        let r = c.finish();
+        assert_eq!(r.common_prefixes.len(), 1);
+        assert_eq!(r.objects.len(), 1);
+    }
+
+    #[test]
+    fn descend_rules() {
+        let c = ListCollector::new(ListQuery {
+            prefix: "a/b".to_string(),
+            ..Default::default()
+        });
+        assert!(c.should_descend("", "a"));
+        assert!(!c.should_descend("", "z"));
+        assert!(c.should_descend("a/", "b"));
+    }
+}

--- a/src/gateway/s3/list.rs
+++ b/src/gateway/s3/list.rs
@@ -17,6 +17,8 @@ pub struct ListQuery {
     pub start_after: String,
     /// Maximum number of keys + common prefixes returned.
     pub max_keys: usize,
+    /// Hide explicit directory objects from the object stream.
+    pub hide_dir_objects: bool,
 }
 
 /// One listed object entry.
@@ -30,9 +32,6 @@ pub struct ListedObject {
     pub mtime: i64,
     /// The entry is an explicit directory object (key ends with `/`).
     pub is_dir_object: bool,
-    /// The entry is a directory without the directory-object marker
-    /// (implicit directory; normally only used internally).
-    pub is_dir: bool,
     /// Stored ETag xattr, if any.
     pub etag: Option<String>,
 }
@@ -79,10 +78,18 @@ impl ListCollector {
         is_dir_object: bool,
         etag: Option<String>,
     ) {
-        let full = format!("{parent_key}{name}");
+        let full = if is_dir_object {
+            format!("{parent_key}{name}/")
+        } else {
+            format!("{parent_key}{name}")
+        };
         if !self.query.prefix.is_empty() && !full.starts_with(&self.query.prefix) {
             // Not under the requested prefix. A child directory may still
             // contain matching keys, so the caller decides whether to descend.
+            return;
+        }
+
+        if is_dir_object && self.query.hide_dir_objects {
             return;
         }
 
@@ -98,44 +105,43 @@ impl ListCollector {
             return;
         }
 
-        let key = if is_dir_object {
-            format!("{full}/")
-        } else {
-            full
-        };
+        if is_dir && !is_dir_object {
+            return;
+        }
+
         self.objects.push(ListedObject {
-            key,
+            key: full,
             size,
             mtime,
             is_dir_object,
-            is_dir,
             etag,
         });
     }
 
     /// Whether the walk should descend into the child directory `name`
     /// (only when the prefix could still match below it).
-    pub fn should_descend(&self, parent_key: &str, name: &str) -> bool {
-        if self.query.delimiter.is_some() {
-            // Delimited listings never report keys below a common prefix,
-            // but we must still descend far enough to detect the prefix itself
-            // (handled via common_prefixes above).
+    pub fn should_descend(&self, parent_key: &str, name: &str, is_dir_object: bool) -> bool {
+        let subtree = format!("{parent_key}{name}/");
+        if self.query.prefix.starts_with(&subtree) {
             return true;
         }
-        let full = format!("{parent_key}{name}");
-        if self.query.prefix.is_empty() {
-            return true;
+        let Some(relative) = subtree.strip_prefix(&self.query.prefix) else {
+            return false;
+        };
+        match self.query.delimiter.as_deref() {
+            Some(delimiter) if relative.contains(delimiter) => {
+                !is_dir_object || self.query.hide_dir_objects
+            }
+            _ => true,
         }
-        if full.starts_with(&self.query.prefix) {
-            return true;
-        }
-        // Descend only if this directory can be a proper prefix of the target
-        // prefix (e.g. prefix "a/b" and directory "a").
-        self.query.prefix.starts_with(&full)
     }
 
     /// Finishes the listing: sorts entries, applies start-after and max-keys.
     pub fn finish(mut self) -> ListResult {
+        if self.query.max_keys == 0 {
+            return ListResult::default();
+        }
+
         // Merge objects and common prefixes into one lexically sorted stream
         // (S3 returns keys and common prefixes interleaved in sorted order).
         self.objects.sort_by(|a, b| a.key.cmp(&b.key));
@@ -205,7 +211,6 @@ mod tests {
             size: 1,
             mtime: 0,
             is_dir_object: false,
-            is_dir: false,
             etag: None,
         }
     }
@@ -223,6 +228,20 @@ mod tests {
         assert_eq!(r.objects[1].key, "b");
         assert!(r.is_truncated);
         assert_eq!(r.next_marker, "b");
+    }
+
+    #[test]
+    fn zero_limit_is_not_truncated() {
+        let mut c = ListCollector::new(ListQuery {
+            max_keys: 0,
+            ..Default::default()
+        });
+        c.objects = vec![obj("a")];
+
+        let r = c.finish();
+        assert!(r.objects.is_empty());
+        assert!(!r.is_truncated);
+        assert!(r.next_marker.is_empty());
     }
 
     #[test]
@@ -254,13 +273,118 @@ mod tests {
     }
 
     #[test]
+    fn invisible_directories_do_not_consume_page_slots() {
+        let mut c = ListCollector::new(ListQuery {
+            max_keys: 2,
+            ..Default::default()
+        });
+        c.push_entry("", "implicit", true, 0, 0, false, None);
+        c.push_entry("implicit/", "a.txt", false, 1, 0, false, None);
+        c.push_entry("", "z.txt", false, 1, 0, false, None);
+        c.push_entry("", "zz.txt", false, 1, 0, false, None);
+
+        let r = c.finish();
+        let keys: Vec<_> = r.objects.iter().map(|o| o.key.as_str()).collect();
+        assert_eq!(keys, ["implicit/a.txt", "z.txt"]);
+        assert!(r.is_truncated);
+        assert_eq!(r.next_marker, "z.txt");
+    }
+
+    #[test]
+    fn hidden_directory_objects_do_not_consume_page_slots() {
+        let mut c = ListCollector::new(ListQuery {
+            max_keys: 1,
+            hide_dir_objects: true,
+            ..Default::default()
+        });
+        c.push_entry("", "a-dir", true, 0, 0, true, None);
+        c.push_entry("", "b.txt", false, 1, 0, false, None);
+        c.push_entry("", "c.txt", false, 1, 0, false, None);
+
+        let r = c.finish();
+        assert_eq!(r.objects.len(), 1);
+        assert_eq!(r.objects[0].key, "b.txt");
+        assert!(r.is_truncated);
+        assert_eq!(r.next_marker, "b.txt");
+    }
+
+    #[test]
+    fn invisible_directories_still_produce_common_prefixes() {
+        let mut c = ListCollector::new(ListQuery {
+            delimiter: Some("/".to_string()),
+            max_keys: 10,
+            hide_dir_objects: true,
+            ..Default::default()
+        });
+        c.push_entry("", "photos", true, 0, 0, false, None);
+        c.push_entry("photos/", "image.jpg", false, 1, 0, false, None);
+
+        let r = c.finish();
+        assert!(r.objects.is_empty());
+        assert_eq!(
+            r.common_prefixes.into_iter().collect::<Vec<_>>(),
+            ["photos/"]
+        );
+    }
+
+    #[test]
+    fn directory_object_uses_its_trailing_slash_for_matching() {
+        let mut prefixed = ListCollector::new(ListQuery {
+            prefix: "empty-dir/".to_string(),
+            max_keys: 10,
+            ..Default::default()
+        });
+        prefixed.push_entry("", "empty-dir", true, 0, 0, true, None);
+        let prefixed = prefixed.finish();
+        assert_eq!(prefixed.objects[0].key, "empty-dir/");
+
+        let mut delimited = ListCollector::new(ListQuery {
+            delimiter: Some("/".to_string()),
+            max_keys: 10,
+            ..Default::default()
+        });
+        delimited.push_entry("", "empty-dir", true, 0, 0, true, None);
+        let delimited = delimited.finish();
+        assert!(delimited.objects.is_empty());
+        assert_eq!(
+            delimited.common_prefixes.into_iter().collect::<Vec<_>>(),
+            ["empty-dir/"]
+        );
+
+        let mut hidden_delimited = ListCollector::new(ListQuery {
+            delimiter: Some("/".to_string()),
+            max_keys: 10,
+            hide_dir_objects: true,
+            ..Default::default()
+        });
+        hidden_delimited.push_entry("", "empty-dir", true, 0, 0, true, None);
+        let hidden_delimited = hidden_delimited.finish();
+        assert!(hidden_delimited.objects.is_empty());
+        assert!(hidden_delimited.common_prefixes.is_empty());
+    }
+
+    #[test]
     fn descend_rules() {
         let c = ListCollector::new(ListQuery {
             prefix: "a/b".to_string(),
             ..Default::default()
         });
-        assert!(c.should_descend("", "a"));
-        assert!(!c.should_descend("", "z"));
-        assert!(c.should_descend("a/", "b"));
+        assert!(c.should_descend("", "a", false));
+        assert!(!c.should_descend("", "z", false));
+        assert!(c.should_descend("a/", "b", false));
+
+        let delimited = ListCollector::new(ListQuery {
+            delimiter: Some("/".to_string()),
+            ..Default::default()
+        });
+        assert!(!delimited.should_descend("", "visible", true));
+        assert!(delimited.should_descend("", "implicit", false));
+
+        let hidden = ListCollector::new(ListQuery {
+            delimiter: Some("/".to_string()),
+            hide_dir_objects: true,
+            ..Default::default()
+        });
+        assert!(hidden.should_descend("", "hidden", true));
     }
 }

--- a/src/gateway/s3/mod.rs
+++ b/src/gateway/s3/mod.rs
@@ -15,8 +15,8 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
-use s3s::service::S3ServiceBuilder;
 use s3s::auth::SimpleAuth;
+use s3s::service::S3ServiceBuilder;
 use tower::Service;
 
 use crate::chunk::store::BlockStore;
@@ -138,9 +138,7 @@ where
 }
 
 /// Removes multipart uploads older than 24h and staging files older than 24h.
-async fn cleanup_stale_uploads<S>(
-    vfs: &VFS<S, MetaClient<dyn MetaStore>>,
-) -> anyhow::Result<()>
+async fn cleanup_stale_uploads<S>(vfs: &VFS<S, MetaClient<dyn MetaStore>>) -> anyhow::Result<()>
 where
     S: BlockStore + Send + Sync + 'static,
 {

--- a/src/gateway/s3/mod.rs
+++ b/src/gateway/s3/mod.rs
@@ -1,0 +1,265 @@
+//! S3-compatible protocol gateway.
+//!
+//! Serves one BrewFS volume over the S3 API on top of the `s3s` service
+//! framework. See `doc/protocols/s3-gateway.md`.
+
+pub mod list;
+pub mod multipart;
+pub mod path;
+mod store;
+
+pub use path::BucketMode;
+pub use store::{BrewFsS3, S3Options};
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use s3s::service::S3ServiceBuilder;
+use s3s::auth::SimpleAuth;
+use tower::Service;
+
+use crate::chunk::store::BlockStore;
+use crate::meta::MetaStore;
+use crate::meta::client::MetaClient;
+use crate::meta::config::{CompactConfig, MetaClientConfig};
+use crate::meta::layer::MetaLayer;
+use crate::vfs::cache::config::CacheConfig as VfsCacheConfig;
+use crate::vfs::fs::VFS;
+
+/// Options for the S3 gateway server.
+#[derive(Debug, Clone)]
+pub struct S3GatewayOptions {
+    /// Listen address of the S3 endpoint.
+    pub listen_addr: SocketAddr,
+    /// Static access key for SigV4 authentication.
+    pub access_key: String,
+    /// Static secret key for SigV4 authentication.
+    pub secret_key: String,
+    /// Bucket exposure model.
+    pub bucket_mode: BucketMode,
+    /// Hide explicit directory objects in listings.
+    pub hide_dir_objects: bool,
+}
+
+/// Runs the S3 gateway until the process is stopped.
+///
+/// `store` is the block store of the volume (same construction as a FUSE
+/// mount), `meta` the metadata store. The gateway builds its own `VFS` stack
+/// on top of them and registers a control-plane instance so `brewfs info`
+/// can see it.
+pub async fn serve<S>(
+    store: S,
+    meta: Arc<dyn MetaStore>,
+    layout: crate::chunk::ChunkLayout,
+    compact: CompactConfig,
+    cache: VfsCacheConfig,
+    opts: S3GatewayOptions,
+) -> anyhow::Result<()>
+where
+    S: BlockStore + Send + Sync + 'static,
+{
+    let mut config = MetaClientConfig::default();
+    config.options.mount_point = Some("brewfs-gateway-s3".to_string());
+    let meta_client = MetaClient::with_options(
+        meta,
+        config.capacity.clone(),
+        config.effective_ttl(),
+        config.options,
+    );
+    meta_client
+        .initialize()
+        .await
+        .map_err(anyhow::Error::from)?;
+    meta_client
+        .start_control_plane()
+        .await
+        .map_err(anyhow::Error::from)?;
+
+    let vfs = VFS::with_meta_layer_with_cache_config(
+        layout,
+        Arc::new(store),
+        meta_client,
+        compact,
+        cache,
+    )
+    .map_err(|e| anyhow::anyhow!("create VFS: {e}"))?;
+
+    let s3_options = S3Options {
+        bucket_mode: opts.bucket_mode.clone(),
+        hide_dir_objects: opts.hide_dir_objects,
+    };
+
+    // Hidden system directories.
+    {
+        let probe = BrewFsS3::new(vfs.clone(), s3_options.clone());
+        probe
+            .vfs()
+            .mkdir_p(&multipart::uploads_dir())
+            .await
+            .map_err(|e| anyhow::anyhow!("create uploads dir: {e}"))?;
+        probe
+            .vfs()
+            .mkdir_p(&multipart::tmp_dir())
+            .await
+            .map_err(|e| anyhow::anyhow!("create tmp dir: {e}"))?;
+    }
+
+    // Periodic cleanup of stale multipart state (best effort).
+    {
+        let cleanup_vfs = vfs.clone();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(3600));
+            loop {
+                interval.tick().await;
+                if let Err(e) = cleanup_stale_uploads(&cleanup_vfs).await {
+                    tracing::warn!(error = %e, "s3 gateway cleanup task failed");
+                }
+            }
+        });
+    }
+
+    let mut builder = S3ServiceBuilder::new(BrewFsS3::new(vfs, s3_options));
+    builder.set_auth(SimpleAuth::from_single(
+        opts.access_key.clone(),
+        opts.secret_key.clone(),
+    ));
+    let service = builder.build();
+
+    let app = axum::Router::new().fallback_service(S3Fallback(service));
+    let listener = tokio::net::TcpListener::bind(opts.listen_addr).await?;
+    tracing::info!(
+        listen = %opts.listen_addr,
+        bucket_mode = %opts.bucket_mode,
+        "brewfs s3 gateway listening"
+    );
+    axum::serve(listener, app).await?;
+    Ok(())
+}
+
+/// Removes multipart uploads older than 24h and staging files older than 24h.
+async fn cleanup_stale_uploads<S>(
+    vfs: &VFS<S, MetaClient<dyn MetaStore>>,
+) -> anyhow::Result<()>
+where
+    S: BlockStore + Send + Sync + 'static,
+{
+    let cutoff = chrono::Utc::now().timestamp() - 24 * 3600;
+    let cutoff_ns = cutoff * 1_000_000_000; // VFS attrs carry mtime in nanos.
+    let uploads = multipart::uploads_dir();
+    for hh in read_children(vfs, &uploads).await {
+        let hh_dir = format!("{uploads}/{}", hh.name);
+        for upload in read_children(vfs, &hh_dir).await {
+            let dir = format!("{hh_dir}/{}", upload.name);
+            let target = format!("{dir}/.target");
+            if let Ok(attr) = vfs.stat(&target).await {
+                if attr.mtime < cutoff_ns {
+                    let _ = remove_dir_all_rec(vfs, &dir).await;
+                    tracing::info!(dir = %dir, "cleaned stale multipart upload");
+                }
+            }
+        }
+    }
+    let tmp = multipart::tmp_dir();
+    for entry in read_children(vfs, &tmp).await {
+        let path = format!("{tmp}/{}", entry.name);
+        if let Ok(attr) = vfs.stat(&path).await {
+            if attr.mtime < cutoff_ns {
+                let _ = vfs.unlink(&path).await;
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn read_children<S>(
+    vfs: &VFS<S, MetaClient<dyn MetaStore>>,
+    dir: &str,
+) -> Vec<crate::meta::store::DirEntry>
+where
+    S: BlockStore + Send + Sync + 'static,
+{
+    let Ok(attr) = vfs.stat(dir).await else {
+        return Vec::new();
+    };
+    if attr.kind != crate::meta::store::FileType::Dir {
+        return Vec::new();
+    }
+    let Ok(fh) = vfs.opendir(attr.ino).await else {
+        return Vec::new();
+    };
+    let entries = vfs.readdir(fh, 0).unwrap_or_default();
+    let _ = vfs.closedir(fh);
+    entries
+}
+
+/// Recursively removes a directory tree over the VFS (VFS has no native
+/// `remove_dir_all`).
+#[async_recursion::async_recursion]
+pub(crate) async fn remove_dir_all_rec<S>(
+    vfs: &VFS<S, MetaClient<dyn MetaStore>>,
+    path: &str,
+) -> Result<(), crate::vfs::error::VfsError>
+where
+    S: BlockStore + Send + Sync + 'static,
+{
+    let attr = vfs.stat(path).await?;
+    if attr.kind == crate::meta::store::FileType::Dir {
+        if let Ok(fh) = vfs.opendir(attr.ino).await {
+            if let Some(entries) = vfs.readdir(fh, 0) {
+                for entry in entries {
+                    let child = format!("{path}/{}", entry.name);
+                    let _ = remove_dir_all_rec(vfs, &child).await;
+                }
+            }
+            let _ = vfs.closedir(fh);
+        }
+        vfs.rmdir(path).await
+    } else {
+        vfs.unlink(path).await
+    }
+}
+
+/// axum adapter: `S3Service` fails with `HttpError`, but axum routers require
+/// infallible services. Errors are converted into plain 500 responses here.
+#[derive(Clone)]
+struct S3Fallback(s3s::service::S3Service);
+
+impl Service<axum::http::Request<axum::body::Body>> for S3Fallback {
+    type Response = axum::http::Response<axum::body::Body>;
+    type Error = std::convert::Infallible;
+    type Future = std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<Self::Response, Self::Error>> + Send>,
+    >;
+
+    fn poll_ready(
+        &mut self,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        // `S3Service` is always ready; its own poll_ready reports an
+        // `HttpError` which cannot cross the infallible axum boundary.
+        std::task::Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: axum::http::Request<axum::body::Body>) -> Self::Future {
+        let mut service = self.0.clone();
+        Box::pin(async move {
+            match tower::Service::call(&mut service, req).await {
+                Ok(resp) => {
+                    let (parts, body) = resp.into_parts();
+                    Ok(axum::http::Response::from_parts(
+                        parts,
+                        axum::body::Body::new(body),
+                    ))
+                }
+                Err(e) => {
+                    let err: Box<dyn std::error::Error + Send + Sync> = e.into();
+                    Ok(axum::http::Response::builder()
+                        .status(axum::http::StatusCode::INTERNAL_SERVER_ERROR)
+                        .body(axum::body::Body::from(format!("s3 gateway error: {err}")))
+                        .unwrap())
+                }
+            }
+        })
+    }
+}

--- a/src/gateway/s3/mod.rs
+++ b/src/gateway/s3/mod.rs
@@ -90,36 +90,31 @@ where
         hide_dir_objects: opts.hide_dir_objects,
     };
 
-    // Hidden system directories.
-    {
-        let probe = BrewFsS3::new(vfs.clone(), s3_options.clone());
-        probe
-            .vfs()
-            .mkdir_p(&multipart::uploads_dir())
-            .await
-            .map_err(|e| anyhow::anyhow!("create uploads dir: {e}"))?;
-        probe
-            .vfs()
-            .mkdir_p(&multipart::tmp_dir())
-            .await
-            .map_err(|e| anyhow::anyhow!("create tmp dir: {e}"))?;
-    }
+    let s3 = BrewFsS3::new(vfs, s3_options);
+    s3.vfs()
+        .mkdir_p(&multipart::uploads_dir())
+        .await
+        .map_err(|e| anyhow::anyhow!("create uploads dir: {e}"))?;
+    s3.vfs()
+        .mkdir_p(&multipart::tmp_dir())
+        .await
+        .map_err(|e| anyhow::anyhow!("create tmp dir: {e}"))?;
 
     // Periodic cleanup of stale multipart state (best effort).
     {
-        let cleanup_vfs = vfs.clone();
+        let cleanup_s3 = s3.clone();
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(Duration::from_secs(3600));
             loop {
                 interval.tick().await;
-                if let Err(e) = cleanup_stale_uploads(&cleanup_vfs).await {
+                if let Err(e) = cleanup_stale_uploads(&cleanup_s3).await {
                     tracing::warn!(error = %e, "s3 gateway cleanup task failed");
                 }
             }
         });
     }
 
-    let mut builder = S3ServiceBuilder::new(BrewFsS3::new(vfs, s3_options));
+    let mut builder = S3ServiceBuilder::new(s3);
     builder.set_auth(SimpleAuth::from_single(
         opts.access_key.clone(),
         opts.secret_key.clone(),
@@ -138,29 +133,50 @@ where
 }
 
 /// Removes multipart uploads older than 24h and staging files older than 24h.
-async fn cleanup_stale_uploads<S>(vfs: &VFS<S, MetaClient<dyn MetaStore>>) -> anyhow::Result<()>
+async fn cleanup_stale_uploads<S>(s3: &BrewFsS3<S>) -> anyhow::Result<()>
 where
     S: BlockStore + Send + Sync + 'static,
 {
+    let vfs = s3.vfs();
     let cutoff = chrono::Utc::now().timestamp() - 24 * 3600;
     let cutoff_ns = cutoff * 1_000_000_000; // VFS attrs carry mtime in nanos.
     let uploads = multipart::uploads_dir();
     for hh in read_children(vfs, &uploads).await {
         let hh_dir = format!("{uploads}/{}", hh.name);
         for upload in read_children(vfs, &hh_dir).await {
-            let dir = format!("{hh_dir}/{}", upload.name);
-            let target = format!("{dir}/.target");
-            if let Ok(attr) = vfs.stat(&target).await
-                && attr.mtime < cutoff_ns
-            {
-                let _ = remove_dir_all_rec(vfs, &dir).await;
-                tracing::info!(dir = %dir, "cleaned stale multipart upload");
+            let upload_id = upload.name;
+            let dir = format!("{hh_dir}/{upload_id}");
+            let Ok(meta) = s3.read_upload_meta(&upload_id).await else {
+                if let Ok(attr) = vfs.stat(&dir).await
+                    && attr.mtime < cutoff_ns
+                    && remove_dir_all_rec(vfs, &dir).await.is_ok()
+                {
+                    tracing::info!(dir = %dir, "cleaned unreadable stale multipart upload");
+                }
+                continue;
+            };
+            if meta.initiated >= cutoff {
+                continue;
+            }
+            let lock = s3.lock_for(&meta.bucket, &meta.key);
+            let _guard = lock.lock().await;
+            let Ok(meta) = s3.read_upload_meta(&upload_id).await else {
+                continue;
+            };
+            if meta.initiated < cutoff {
+                let dir = multipart::upload_dir(&upload_id);
+                if remove_dir_all_rec(vfs, &dir).await.is_ok() {
+                    tracing::info!(dir = %dir, "cleaned stale multipart upload");
+                }
             }
         }
     }
     let tmp = multipart::tmp_dir();
     for entry in read_children(vfs, &tmp).await {
         let path = format!("{tmp}/{}", entry.name);
+        if s3.staging_path_is_active(&path) {
+            continue;
+        }
         if let Ok(attr) = vfs.stat(&path).await
             && attr.mtime < cutoff_ns
         {
@@ -186,7 +202,15 @@ where
     let Ok(fh) = vfs.opendir(attr.ino).await else {
         return Vec::new();
     };
-    let entries = vfs.readdir(fh, 0).unwrap_or_default();
+    let mut entries = Vec::new();
+    let mut offset = 0;
+    while let Some(page) = vfs.readdir(fh, offset) {
+        if page.is_empty() {
+            break;
+        }
+        offset += page.len() as u64;
+        entries.extend(page);
+    }
     let _ = vfs.closedir(fh);
     entries
 }
@@ -204,13 +228,20 @@ where
     let attr = vfs.stat(path).await?;
     if attr.kind == crate::meta::store::FileType::Dir {
         if let Ok(fh) = vfs.opendir(attr.ino).await {
-            if let Some(entries) = vfs.readdir(fh, 0) {
-                for entry in entries {
-                    let child = format!("{path}/{}", entry.name);
-                    let _ = remove_dir_all_rec(vfs, &child).await;
+            let mut entries = Vec::new();
+            let mut offset = 0;
+            while let Some(page) = vfs.readdir(fh, offset) {
+                if page.is_empty() {
+                    break;
                 }
+                offset += page.len() as u64;
+                entries.extend(page);
             }
             let _ = vfs.closedir(fh);
+            for entry in entries {
+                let child = format!("{path}/{}", entry.name);
+                remove_dir_all_rec(vfs, &child).await?;
+            }
         }
         vfs.rmdir(path).await
     } else {

--- a/src/gateway/s3/mod.rs
+++ b/src/gateway/s3/mod.rs
@@ -150,21 +150,21 @@ where
         for upload in read_children(vfs, &hh_dir).await {
             let dir = format!("{hh_dir}/{}", upload.name);
             let target = format!("{dir}/.target");
-            if let Ok(attr) = vfs.stat(&target).await {
-                if attr.mtime < cutoff_ns {
-                    let _ = remove_dir_all_rec(vfs, &dir).await;
-                    tracing::info!(dir = %dir, "cleaned stale multipart upload");
-                }
+            if let Ok(attr) = vfs.stat(&target).await
+                && attr.mtime < cutoff_ns
+            {
+                let _ = remove_dir_all_rec(vfs, &dir).await;
+                tracing::info!(dir = %dir, "cleaned stale multipart upload");
             }
         }
     }
     let tmp = multipart::tmp_dir();
     for entry in read_children(vfs, &tmp).await {
         let path = format!("{tmp}/{}", entry.name);
-        if let Ok(attr) = vfs.stat(&path).await {
-            if attr.mtime < cutoff_ns {
-                let _ = vfs.unlink(&path).await;
-            }
+        if let Ok(attr) = vfs.stat(&path).await
+            && attr.mtime < cutoff_ns
+        {
+            let _ = vfs.unlink(&path).await;
         }
     }
     Ok(())

--- a/src/gateway/s3/multipart.rs
+++ b/src/gateway/s3/multipart.rs
@@ -1,0 +1,122 @@
+//! Multipart upload state stored in the hidden system directory.
+//!
+//! Layout (see `doc/protocols/README.md` §3.1):
+//!
+//! ```text
+//! /.brewfs.sys/s3/uploads/<hh>/<upload-id>/
+//!     .target      # JSON `UploadMeta` describing the target object
+//!     part-1       # part data, xattr `brewfs.s3.etag` carries the part MD5
+//!     part-2
+//! ...
+//! ```
+//!
+//! `<hh>` is the first byte of the upload id in hex (256-way fan-out).
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Directory holding all multipart upload state.
+pub fn uploads_dir() -> String {
+    format!("{}/uploads", crate::gateway::s3_sys_dir())
+}
+
+/// Directory holding staging files for atomic publishes.
+pub fn tmp_dir() -> String {
+    format!("{}/tmp", crate::gateway::s3_sys_dir())
+}
+
+/// Directory of one multipart upload.
+pub fn upload_dir(upload_id: &str) -> String {
+    // Fan out by the first two characters of the upload id so a flat
+    // directory never holds unbounded entries.
+    let hh: String = if upload_id.len() >= 2 {
+        upload_id[..2].to_string()
+    } else {
+        "00".to_string()
+    };
+    format!("{}/{}", uploads_dir(), hh)
+        + "/"
+        + upload_id
+}
+
+/// Path of a part file inside an upload directory.
+pub fn part_path(upload_id: &str, part_number: i64) -> String {
+    format!("{}/part-{part_number}", upload_dir(upload_id))
+}
+
+/// Marker file storing the upload metadata.
+pub const TARGET_FILE: &str = ".target";
+
+/// Metadata of one in-flight multipart upload.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UploadMeta {
+    pub bucket: String,
+    pub key: String,
+    pub content_type: Option<String>,
+    pub metadata: Option<HashMap<String, String>>,
+    /// Unix seconds when the upload was initiated (used by the cleanup task).
+    pub initiated: i64,
+}
+
+impl UploadMeta {
+    pub fn target_path(upload_id: &str) -> String {
+        format!("{}/{}", upload_dir(upload_id), TARGET_FILE)
+    }
+}
+
+/// Generates a new opaque upload id.
+pub fn new_upload_id() -> String {
+    uuid::Uuid::now_v7().simple().to_string()
+}
+
+/// Parses a part file name (`part-<n>`) back into its part number.
+pub fn parse_part_name(name: &str) -> Option<i64> {
+    name.strip_prefix("part-")?.parse().ok()
+}
+
+/// Computes the S3 multipart ETag: MD5 over the concatenated binary part
+/// MD5 digests, suffixed with `-<count>`.
+pub fn multipart_etag(part_etags: &[String]) -> String {
+    let mut ctx = md5::Context::new();
+    for etag in part_etags {
+        let hex = etag.trim_matches('"');
+        if let Ok(bytes) = hex::decode(hex) {
+            ctx.consume(&bytes);
+        }
+    }
+    let digest = ctx.compute();
+    format!("{digest:x}-{}", part_etags.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn upload_paths() {
+        let id = "0123456789abcdef";
+        assert_eq!(
+            upload_dir(id),
+            "/.brewfs.sys/s3/uploads/01/0123456789abcdef"
+        );
+        assert_eq!(
+            part_path(id, 3),
+            "/.brewfs.sys/s3/uploads/01/0123456789abcdef/part-3"
+        );
+    }
+
+    #[test]
+    fn part_names() {
+        assert_eq!(parse_part_name("part-12"), Some(12));
+        assert_eq!(parse_part_name(".target"), None);
+        assert_eq!(parse_part_name("part-x"), None);
+    }
+
+    #[test]
+    fn multipart_etag_format() {
+        // Two part md5s (of "a" and "b") -> md5(md5a||md5b)-2
+        let etag = multipart_etag(&["0cc175b9c0f1b6a831c399e269772661".to_string()]);
+        assert!(etag.ends_with("-1"));
+        assert_eq!(etag.len(), 32 + 2);
+    }
+}

--- a/src/gateway/s3/multipart.rs
+++ b/src/gateway/s3/multipart.rs
@@ -25,16 +25,17 @@ pub fn tmp_dir() -> String {
     format!("{}/tmp", crate::gateway::s3_sys_dir())
 }
 
+/// Returns whether an upload id uses the gateway's generated on-disk format.
+pub fn is_valid_upload_id(upload_id: &str) -> bool {
+    upload_id.len() == 32 && upload_id.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
 /// Directory of one multipart upload.
 pub fn upload_dir(upload_id: &str) -> String {
-    // Fan out by the first two characters of the upload id so a flat
-    // directory never holds unbounded entries.
-    let hh: String = if upload_id.len() >= 2 {
-        upload_id[..2].to_string()
-    } else {
-        "00".to_string()
-    };
-    format!("{}/{}", uploads_dir(), hh) + "/" + upload_id
+    // Generated upload ids are ASCII hex. `get` keeps this helper total for
+    // malformed ids supplied at the protocol boundary.
+    let hh = upload_id.get(..2).unwrap_or("00");
+    format!("{}/{hh}/{upload_id}", uploads_dir())
 }
 
 /// Path of a part file inside an upload directory.
@@ -92,15 +93,18 @@ mod tests {
 
     #[test]
     fn upload_paths() {
-        let id = "0123456789abcdef";
+        let id = "0123456789abcdef0123456789abcdef";
         assert_eq!(
             upload_dir(id),
-            "/.brewfs.sys/s3/uploads/01/0123456789abcdef"
+            "/.brewfs.sys/s3/uploads/01/0123456789abcdef0123456789abcdef"
         );
         assert_eq!(
             part_path(id, 3),
-            "/.brewfs.sys/s3/uploads/01/0123456789abcdef/part-3"
+            "/.brewfs.sys/s3/uploads/01/0123456789abcdef0123456789abcdef/part-3"
         );
+        assert!(is_valid_upload_id(id));
+        assert!(!is_valid_upload_id("a😀"));
+        assert_eq!(upload_dir("a😀"), "/.brewfs.sys/s3/uploads/00/a😀");
     }
 
     #[test]

--- a/src/gateway/s3/multipart.rs
+++ b/src/gateway/s3/multipart.rs
@@ -34,9 +34,7 @@ pub fn upload_dir(upload_id: &str) -> String {
     } else {
         "00".to_string()
     };
-    format!("{}/{}", uploads_dir(), hh)
-        + "/"
-        + upload_id
+    format!("{}/{}", uploads_dir(), hh) + "/" + upload_id
 }
 
 /// Path of a part file inside an upload directory.

--- a/src/gateway/s3/path.rs
+++ b/src/gateway/s3/path.rs
@@ -1,0 +1,194 @@
+//! Bucket/key to filesystem path mapping.
+//!
+//! See `doc/protocols/s3-gateway.md` §3 (bucket models) and §5 (directory
+//! semantics).
+
+use std::fmt;
+
+/// How buckets map onto the volume namespace.
+#[derive(Debug, Clone)]
+pub enum BucketMode {
+    /// The whole volume is exposed as a single bucket.
+    Single { bucket: String },
+    /// Top-level directories of the volume are exposed as buckets.
+    Multi,
+}
+
+impl fmt::Display for BucketMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BucketMode::Single { bucket } => write!(f, "single:{bucket}"),
+            BucketMode::Multi => write!(f, "multi"),
+        }
+    }
+}
+
+/// Errors produced while mapping an S3 bucket/key pair onto a path.
+#[derive(Debug)]
+pub enum PathError {
+    /// Bucket name is not a valid S3 bucket name, or is not served by this gateway.
+    InvalidBucket(String),
+    /// Object key cannot be represented as a path (empty, escapes the bucket root, ...).
+    InvalidKey(String),
+}
+
+impl fmt::Display for PathError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PathError::InvalidBucket(b) => write!(f, "invalid bucket name: {b}"),
+            PathError::InvalidKey(k) => write!(f, "invalid object key: {k}"),
+        }
+    }
+}
+
+impl std::error::Error for PathError {}
+
+/// Validates a name against the S3 bucket naming rules.
+pub fn is_valid_bucket_name(name: &str) -> bool {
+    let len = name.len();
+    if !(3..=63).contains(&len) {
+        return false;
+    }
+    let bytes = name.as_bytes();
+    if !bytes[0].is_ascii_lowercase() && !bytes[0].is_ascii_digit() {
+        return false;
+    }
+    if !bytes[len - 1].is_ascii_lowercase() && !bytes[len - 1].is_ascii_digit() {
+        return false;
+    }
+    let mut prev_dot = false;
+    for &b in bytes {
+        let ok = b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-' || b == b'.';
+        if !ok {
+            return false;
+        }
+        if b == b'.' {
+            if prev_dot {
+                return false; // ".." is not allowed
+            }
+            prev_dot = true;
+        } else {
+            prev_dot = false;
+        }
+    }
+    // Reject IPv4-address-like names (not allowed for S3 buckets).
+    let looks_like_ip = name
+        .split('.')
+        .all(|part| part.parse::<u16>().is_ok() && !part.is_empty())
+        && name.split('.').count() == 4;
+    !looks_like_ip
+}
+
+/// Validates one key component (directory or file name).
+fn valid_component(comp: &str) -> bool {
+    if comp.is_empty() || comp == "." || comp == ".." {
+        return false;
+    }
+    if comp.len() > 255 {
+        return false;
+    }
+    !comp.contains('\0')
+}
+
+/// Maps a bucket name to the volume path of the bucket root.
+///
+/// In single-bucket mode this is always `/`; the bucket name itself is only
+/// validated, not mapped. In multi-bucket mode it is `/<bucket>`.
+pub fn bucket_root(mode: &BucketMode, bucket: &str) -> Result<String, PathError> {
+    match mode {
+        BucketMode::Single { bucket: expected } => {
+            if bucket == expected {
+                Ok("/".to_string())
+            } else {
+                Err(PathError::InvalidBucket(bucket.to_string()))
+            }
+        }
+        BucketMode::Multi => {
+            if !is_valid_bucket_name(bucket) {
+                return Err(PathError::InvalidBucket(bucket.to_string()));
+            }
+            Ok(format!("/{bucket}"))
+        }
+    }
+}
+
+/// Maps a bucket + object key onto an absolute volume path.
+///
+/// `key` may end with `/` to denote an explicit directory object; the returned
+/// path then points at the directory itself.
+pub fn object_path(mode: &BucketMode, bucket: &str, key: &str) -> Result<String, PathError> {
+    let root = bucket_root(mode, bucket)?;
+    let key = key.strip_prefix('/').unwrap_or(key);
+    if key.is_empty() {
+        // An empty key addresses the bucket root itself.
+        return Ok(root);
+    }
+    let _is_dir_object = key.ends_with('/');
+    let trimmed = key.trim_end_matches('/');
+    if trimmed.is_empty() {
+        return Err(PathError::InvalidKey(key.to_string()));
+    }
+    for comp in trimmed.split('/') {
+        if !valid_component(comp) {
+            return Err(PathError::InvalidKey(key.to_string()));
+        }
+    }
+    if trimmed.is_empty() {
+        return Ok(root);
+    }
+    if root.ends_with('/') {
+        Ok(format!("{root}{trimmed}"))
+    } else {
+        Ok(format!("{root}/{trimmed}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bucket_name_rules() {
+        assert!(is_valid_bucket_name("abc"));
+        assert!(is_valid_bucket_name("my-bucket-1"));
+        assert!(is_valid_bucket_name("a.b.c"));
+        assert!(!is_valid_bucket_name("ab"));
+        assert!(!is_valid_bucket_name("UPPER"));
+        assert!(!is_valid_bucket_name("a..b"));
+        assert!(!is_valid_bucket_name("-abc"));
+        assert!(!is_valid_bucket_name("abc-"));
+        assert!(!is_valid_bucket_name("192.168.1.1"));
+    }
+
+    #[test]
+    fn single_bucket_mode() {
+        let mode = BucketMode::Single {
+            bucket: "vol".to_string(),
+        };
+        assert_eq!(object_path(&mode, "vol", "a/b.txt").unwrap(), "/a/b.txt");
+        assert_eq!(object_path(&mode, "vol", "a/").unwrap(), "/a");
+        assert_eq!(object_path(&mode, "vol", "a").unwrap(), "/a");
+        assert_eq!(object_path(&mode, "vol", "").unwrap(), "/");
+        assert!(object_path(&mode, "other", "a").is_err());
+    }
+
+    #[test]
+    fn multi_bucket_mode() {
+        let mode = BucketMode::Multi;
+        assert_eq!(
+            object_path(&mode, "data", "a/b.txt").unwrap(),
+            "/data/a/b.txt"
+        );
+        assert_eq!(bucket_root(&mode, "UP").is_err(), true);
+    }
+
+    #[test]
+    fn rejects_escaping_keys() {
+        let mode = BucketMode::Single {
+            bucket: "vol".to_string(),
+        };
+        assert!(object_path(&mode, "vol", "../etc").is_err());
+        assert!(object_path(&mode, "vol", "a/../b").is_err());
+        assert!(object_path(&mode, "vol", "a//b").is_err());
+    }
+}

--- a/src/gateway/s3/path.rs
+++ b/src/gateway/s3/path.rs
@@ -5,6 +5,10 @@
 
 use std::fmt;
 
+use crate::posix::NAME_MAX;
+
+const SYS_DIR_NAME: &str = ".brewfs.sys";
+
 /// How buckets map onto the volume namespace.
 #[derive(Debug, Clone)]
 pub enum BucketMode {
@@ -30,6 +34,8 @@ pub enum PathError {
     InvalidBucket(String),
     /// Object key cannot be represented as a path (empty, escapes the bucket root, ...).
     InvalidKey(String),
+    /// Object key overlaps the gateway's internal namespace.
+    ReservedKey(String),
 }
 
 impl fmt::Display for PathError {
@@ -37,6 +43,7 @@ impl fmt::Display for PathError {
         match self {
             PathError::InvalidBucket(b) => write!(f, "invalid bucket name: {b}"),
             PathError::InvalidKey(k) => write!(f, "invalid object key: {k}"),
+            PathError::ReservedKey(k) => write!(f, "reserved object key: {k}"),
         }
     }
 }
@@ -45,38 +52,7 @@ impl std::error::Error for PathError {}
 
 /// Validates a name against the S3 bucket naming rules.
 pub fn is_valid_bucket_name(name: &str) -> bool {
-    let len = name.len();
-    if !(3..=63).contains(&len) {
-        return false;
-    }
-    let bytes = name.as_bytes();
-    if !bytes[0].is_ascii_lowercase() && !bytes[0].is_ascii_digit() {
-        return false;
-    }
-    if !bytes[len - 1].is_ascii_lowercase() && !bytes[len - 1].is_ascii_digit() {
-        return false;
-    }
-    let mut prev_dot = false;
-    for &b in bytes {
-        let ok = b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-' || b == b'.';
-        if !ok {
-            return false;
-        }
-        if b == b'.' {
-            if prev_dot {
-                return false; // ".." is not allowed
-            }
-            prev_dot = true;
-        } else {
-            prev_dot = false;
-        }
-    }
-    // Reject IPv4-address-like names (not allowed for S3 buckets).
-    let looks_like_ip = name
-        .split('.')
-        .all(|part| part.parse::<u16>().is_ok() && !part.is_empty())
-        && name.split('.').count() == 4;
-    !looks_like_ip
+    s3s::path::check_bucket_name(name)
 }
 
 /// Validates one key component (directory or file name).
@@ -84,7 +60,7 @@ fn valid_component(comp: &str) -> bool {
     if comp.is_empty() || comp == "." || comp == ".." {
         return false;
     }
-    if comp.len() > 255 {
+    if comp.len() > NAME_MAX {
         return false;
     }
     !comp.contains('\0')
@@ -104,12 +80,26 @@ pub fn bucket_root(mode: &BucketMode, bucket: &str) -> Result<String, PathError>
             }
         }
         BucketMode::Multi => {
-            if !is_valid_bucket_name(bucket) {
+            if !is_valid_bucket_name(bucket) || bucket == SYS_DIR_NAME {
                 return Err(PathError::InvalidBucket(bucket.to_string()));
             }
             Ok(format!("/{bucket}"))
         }
     }
+}
+
+/// Validates the gateway namespace boundary shared by object keys and list prefixes.
+pub fn validate_key_namespace(mode: &BucketMode, key: &str) -> Result<(), PathError> {
+    if matches!(mode, BucketMode::Single { .. })
+        && key
+            .trim_end_matches('/')
+            .split('/')
+            .next()
+            .is_some_and(|component| component == SYS_DIR_NAME)
+    {
+        return Err(PathError::ReservedKey(key.to_string()));
+    }
+    Ok(())
 }
 
 /// Maps a bucket + object key onto an absolute volume path.
@@ -118,13 +108,18 @@ pub fn bucket_root(mode: &BucketMode, bucket: &str) -> Result<String, PathError>
 /// path then points at the directory itself.
 pub fn object_path(mode: &BucketMode, bucket: &str, key: &str) -> Result<String, PathError> {
     let root = bucket_root(mode, bucket)?;
-    let key = key.strip_prefix('/').unwrap_or(key);
+    if !s3s::path::check_key(key) {
+        return Err(PathError::InvalidKey(key.to_string()));
+    }
+    validate_key_namespace(mode, key)?;
+    if key.starts_with('/') {
+        return Err(PathError::InvalidKey(key.to_string()));
+    }
     if key.is_empty() {
         // An empty key addresses the bucket root itself.
         return Ok(root);
     }
-    let _is_dir_object = key.ends_with('/');
-    let trimmed = key.trim_end_matches('/');
+    let trimmed = key.strip_suffix('/').unwrap_or(key);
     if trimmed.is_empty() {
         return Err(PathError::InvalidKey(key.to_string()));
     }
@@ -132,9 +127,6 @@ pub fn object_path(mode: &BucketMode, bucket: &str, key: &str) -> Result<String,
         if !valid_component(comp) {
             return Err(PathError::InvalidKey(key.to_string()));
         }
-    }
-    if trimmed.is_empty() {
-        return Ok(root);
     }
     if root.ends_with('/') {
         Ok(format!("{root}{trimmed}"))
@@ -158,6 +150,17 @@ mod tests {
         assert!(!is_valid_bucket_name("-abc"));
         assert!(!is_valid_bucket_name("abc-"));
         assert!(!is_valid_bucket_name("192.168.1.1"));
+        assert!(!is_valid_bucket_name("xn--bucket"));
+    }
+
+    #[test]
+    fn internal_system_bucket_is_reserved_in_multi_mode() {
+        assert!(matches!(
+            bucket_root(&BucketMode::Multi, ".brewfs.sys"),
+            Err(PathError::InvalidBucket(_))
+        ));
+        assert!(object_path(&BucketMode::Multi, ".brewfs.sys", "file").is_err());
+        assert!(bucket_root(&BucketMode::Multi, "..").is_err());
     }
 
     #[test]
@@ -183,6 +186,36 @@ mod tests {
     }
 
     #[test]
+    fn rejects_leading_slash_and_reserved_system_keys() {
+        let single = BucketMode::Single {
+            bucket: "vol".to_string(),
+        };
+        assert!(matches!(
+            object_path(&single, "vol", "/a"),
+            Err(PathError::InvalidKey(_))
+        ));
+        assert!(matches!(
+            object_path(&single, "vol", ".brewfs.sys/s3/tmp/file"),
+            Err(PathError::ReservedKey(_))
+        ));
+        assert!(object_path(&BucketMode::Multi, "data", ".brewfs.sys/file").is_ok());
+    }
+
+    #[test]
+    fn listing_prefix_validation_allows_unrepresentable_paths() {
+        let mode = BucketMode::Single {
+            bucket: "vol".to_string(),
+        };
+        assert!(validate_key_namespace(&mode, "/a//../b").is_ok());
+        assert!(matches!(
+            validate_key_namespace(&mode, ".brewfs.sys/"),
+            Err(PathError::ReservedKey(_))
+        ));
+        assert!(validate_key_namespace(&mode, &"x".repeat(1025)).is_ok());
+        assert!(object_path(&mode, "vol", &"x".repeat(1025)).is_err());
+    }
+
+    #[test]
     fn rejects_escaping_keys() {
         let mode = BucketMode::Single {
             bucket: "vol".to_string(),
@@ -190,5 +223,6 @@ mod tests {
         assert!(object_path(&mode, "vol", "../etc").is_err());
         assert!(object_path(&mode, "vol", "a/../b").is_err());
         assert!(object_path(&mode, "vol", "a//b").is_err());
+        assert!(object_path(&mode, "vol", "a//").is_err());
     }
 }

--- a/src/gateway/s3/path.rs
+++ b/src/gateway/s3/path.rs
@@ -179,7 +179,7 @@ mod tests {
             object_path(&mode, "data", "a/b.txt").unwrap(),
             "/data/a/b.txt"
         );
-        assert_eq!(bucket_root(&mode, "UP").is_err(), true);
+        assert!(bucket_root(&mode, "UP").is_err());
     }
 
     #[test]

--- a/src/gateway/s3/store.rs
+++ b/src/gateway/s3/store.rs
@@ -732,8 +732,7 @@ where
                 content_type: Some(
                     meta.content_type
                         .clone()
-                        .map(ContentType::from)
-                        .unwrap_or_else(|| ContentType::from(DEFAULT_CONTENT_TYPE)),
+                        .unwrap_or_else(|| DEFAULT_CONTENT_TYPE.to_string()),
                 ),
                 last_modified: Self::mtime_timestamp(&attr),
                 accept_ranges: Some(AcceptRanges::from("bytes")),
@@ -759,8 +758,7 @@ where
             e_tag: Some(ETag::Strong(etag)),
             content_type: Some(
                 meta.content_type
-                    .map(ContentType::from)
-                    .unwrap_or_else(|| ContentType::from(DEFAULT_CONTENT_TYPE)),
+                    .unwrap_or_else(|| DEFAULT_CONTENT_TYPE.to_string()),
             ),
             last_modified: Self::mtime_timestamp(&attr),
             accept_ranges: Some(AcceptRanges::from("bytes")),
@@ -794,8 +792,7 @@ where
             e_tag: Some(ETag::Strong(etag)),
             content_type: Some(
                 meta.content_type
-                    .map(ContentType::from)
-                    .unwrap_or_else(|| ContentType::from(DEFAULT_CONTENT_TYPE)),
+                    .unwrap_or_else(|| DEFAULT_CONTENT_TYPE.to_string()),
             ),
             last_modified: Self::mtime_timestamp(&attr),
             metadata,
@@ -1184,11 +1181,11 @@ where
         let dir = multipart::upload_dir(&upload_id);
         let mut parts: Vec<(i64, u64, i64, Option<String>)> = Vec::new();
         for entry in self.read_dir_entries(&dir).await? {
-            if let Some(n) = parse_part_name(&entry.name) {
-                if let Some(attr) = self.vfs.stat_ino(entry.ino).await {
-                    let etag = self.read_etag(entry.ino).await;
-                    parts.push((n, attr.size, attr.mtime, etag));
-                }
+            if let Some(n) = parse_part_name(&entry.name)
+                && let Some(attr) = self.vfs.stat_ino(entry.ino).await
+            {
+                let etag = self.read_etag(entry.ino).await;
+                parts.push((n, attr.size, attr.mtime, etag));
             }
         }
         parts.sort_by_key(|p| p.0);
@@ -1238,10 +1235,9 @@ where
         let _guard = lock.lock().await;
 
         // Validate part ordering and etags.
-        let mut expected = 1i32;
         let mut part_etags: Vec<String> = Vec::with_capacity(completed.len());
         let mut part_files: Vec<(i64, String)> = Vec::with_capacity(completed.len());
-        for part in &completed {
+        for (expected, part) in (1i32..).zip(&completed) {
             let n = part.part_number.unwrap_or(0);
             if n != expected {
                 return Err(s3_error!(
@@ -1249,7 +1245,6 @@ where
                     "parts must be ascending starting at 1 (got {n}, expected {expected})"
                 ));
             }
-            expected += 1;
             let src = multipart::part_path(&upload_id, i64::from(n));
             let attr = match self.vfs.stat(&src).await {
                 Ok(a) => a,
@@ -1261,10 +1256,10 @@ where
                 return Err(s3_error!(EntityTooSmall, "part {n} is smaller than 5 MiB"));
             }
             let stored = self.read_etag(attr.ino).await;
-            if let (Some(want), Some(have)) = (part.e_tag.as_ref(), stored.as_ref()) {
-                if want.value() != have {
-                    return Err(s3_error!(InvalidPart, "etag mismatch on part {n}"));
-                }
+            if let (Some(want), Some(have)) = (part.e_tag.as_ref(), stored.as_ref())
+                && want.value() != have
+            {
+                return Err(s3_error!(InvalidPart, "etag mismatch on part {n}"));
             }
             part_etags.push(stored.unwrap_or_default());
             part_files.push((i64::from(n), src));
@@ -1375,24 +1370,21 @@ where
         for hh in self.read_dir_entries(&multipart::uploads_dir()).await? {
             let hh_dir = format!("{}/{}", multipart::uploads_dir(), hh.name);
             for upload in self.read_dir_entries(&hh_dir).await? {
-                let target = format!("{}/{}", hh_dir, upload.name);
-                // Reconstruct the upload id from the directory name.
                 let upload_id = upload.name.clone();
-                if let Ok(meta) = self.read_upload_meta(&upload_id).await {
-                    if meta.bucket == bucket && (prefix.is_empty() || meta.key.starts_with(&prefix))
-                    {
-                        uploads.push(MultipartUpload {
-                            key: Some(ObjectKey::from(meta.key)),
-                            upload_id: Some(MultipartUploadId::from(upload_id)),
-                            initiated: Some(Timestamp::from(
-                                UNIX_EPOCH + Duration::from_secs(meta.initiated.max(0) as u64),
-                            )),
-                            storage_class: Some(StorageClass::from_static(StorageClass::STANDARD)),
-                            ..Default::default()
-                        });
-                    }
+                if let Ok(meta) = self.read_upload_meta(&upload_id).await
+                    && meta.bucket == bucket
+                    && (prefix.is_empty() || meta.key.starts_with(&prefix))
+                {
+                    uploads.push(MultipartUpload {
+                        key: Some(ObjectKey::from(meta.key)),
+                        upload_id: Some(MultipartUploadId::from(upload_id)),
+                        initiated: Some(Timestamp::from(
+                            UNIX_EPOCH + Duration::from_secs(meta.initiated.max(0) as u64),
+                        )),
+                        storage_class: Some(StorageClass::from_static(StorageClass::STANDARD)),
+                        ..Default::default()
+                    });
                 }
-                let _ = target;
             }
         }
         uploads.sort_by(|a, b| a.key.cmp(&b.key));

--- a/src/gateway/s3/store.rs
+++ b/src/gateway/s3/store.rs
@@ -125,8 +125,7 @@ where
     // ---- helpers ------------------------------------------------------------
 
     async fn stat_bucket_root(&self, bucket: &str) -> S3Result<FileAttr> {
-        let root = path::bucket_root(&self.opts.bucket_mode, bucket)
-            .map_err(Self::path_err)?;
+        let root = path::bucket_root(&self.opts.bucket_mode, bucket).map_err(Self::path_err)?;
         let attr = self.vfs.stat(&root).await.map_err(Self::err)?;
         if attr.kind != FileType::Dir {
             return Err(s3_error!(NoSuchBucket, "bucket not found: {bucket}"));
@@ -185,17 +184,13 @@ where
 
     fn mtime_timestamp(attr: &FileAttr) -> Option<Timestamp> {
         // VFS file attrs carry mtime in nanoseconds.
-        Some(Timestamp::from(UNIX_EPOCH + Duration::from_nanos(
-            attr.mtime.max(0) as u64,
-        )))
+        Some(Timestamp::from(
+            UNIX_EPOCH + Duration::from_nanos(attr.mtime.max(0) as u64),
+        ))
     }
 
     /// Streams a blob into `dst` (created/truncated), returning size and MD5.
-    async fn write_blob(
-        &self,
-        dst: &str,
-        body: &mut StreamingBlob,
-    ) -> S3Result<(u64, String)> {
+    async fn write_blob(&self, dst: &str, body: &mut StreamingBlob) -> S3Result<(u64, String)> {
         if self.vfs.exists(dst).await {
             self.vfs.unlink(dst).await.map_err(Self::err)?;
         }
@@ -212,10 +207,7 @@ where
         while let Some(chunk) = body.next().await {
             let chunk = chunk.map_err(|e| s3_error!(InternalError, "body read: {e}"))?;
             if !chunk.is_empty() {
-                guard
-                    .write(offset, &chunk)
-                    .await
-                    .map_err(Self::err)?;
+                guard.write(offset, &chunk).await.map_err(Self::err)?;
                 md.consume(&chunk);
                 offset += chunk.len() as u64;
             }
@@ -228,17 +220,11 @@ where
     /// Reads a byte range of a file as a streaming blob. Chunks are produced
     /// by a spawned task and forwarded through an mpsc channel (the channel
     /// receiver is `Send + Sync`, as required by `StreamingBlob::wrap`).
-    fn read_stream(
-        &self,
-        attr: FileAttr,
-        offset: u64,
-        length: u64,
-    ) -> S3Result<StreamingBlob> {
+    fn read_stream(&self, attr: FileAttr, offset: u64, length: u64) -> S3Result<StreamingBlob> {
         let ino = attr.ino;
         let vfs = self.vfs.clone();
-        let (mut tx, rx) = futures::channel::mpsc::channel::<
-            Result<bytes::Bytes, std::io::Error>,
-        >(4);
+        let (mut tx, rx) =
+            futures::channel::mpsc::channel::<Result<bytes::Bytes, std::io::Error>>(4);
         tokio::spawn(async move {
             let mut offset = offset;
             let mut remaining = length;
@@ -249,18 +235,15 @@ where
                 let guard = match vfs.stat_ino(ino).await {
                     Some(a) => vfs.open_guard(ino, a, true, false).await,
                     None => {
-                        let _ = tx
-                            .try_send(Err(std::io::Error::other(
-                                "object deleted during read",
-                            )));
+                        let _ =
+                            tx.try_send(Err(std::io::Error::other("object deleted during read")));
                         break;
                     }
                 };
                 let guard = match guard {
                     Ok(g) => g,
                     Err(e) => {
-                        let _ = tx
-                            .try_send(Err(std::io::Error::other(format!("open: {e}"))));
+                        let _ = tx.try_send(Err(std::io::Error::other(format!("open: {e}"))));
                         break;
                     }
                 };
@@ -268,10 +251,7 @@ where
                     Ok(data) => {
                         let n = data.len() as u64;
                         drop(guard);
-                        if tx
-                            .try_send(Ok(bytes::Bytes::from(data)))
-                            .is_err()
-                        {
+                        if tx.try_send(Ok(bytes::Bytes::from(data))).is_err() {
                             break;
                         }
                         offset += n;
@@ -279,8 +259,7 @@ where
                     }
                     Err(e) => {
                         drop(guard);
-                        let _ = tx
-                            .try_send(Err(std::io::Error::other(format!("read: {e}"))));
+                        let _ = tx.try_send(Err(std::io::Error::other(format!("read: {e}"))));
                         break;
                     }
                 }
@@ -479,7 +458,11 @@ where
         Ok(())
     }
 
-    async fn list_keys(&self, bucket: &str, query: ListQuery) -> S3Result<crate::gateway::s3::list::ListResult> {
+    async fn list_keys(
+        &self,
+        bucket: &str,
+        query: ListQuery,
+    ) -> S3Result<crate::gateway::s3::list::ListResult> {
         let mode = &self.opts.bucket_mode;
         let root = path::bucket_root(mode, bucket).map_err(Self::path_err)?;
         self.stat_bucket_root(bucket).await?;
@@ -518,7 +501,10 @@ impl<S> S3 for BrewFsS3<S>
 where
     S: BlockStore + Send + Sync + 'static,
 {
-    async fn create_bucket(&self, req: S3Request<CreateBucketInput>) -> S3Result<S3Response<CreateBucketOutput>> {
+    async fn create_bucket(
+        &self,
+        req: S3Request<CreateBucketInput>,
+    ) -> S3Result<S3Response<CreateBucketOutput>> {
         let input = req.input;
         let bucket = input.bucket.as_str().to_string();
         match &self.opts.bucket_mode {
@@ -538,17 +524,19 @@ where
                 let dir = format!("/{bucket}");
                 match self.vfs.mkdir_err(&dir).await {
                     Ok(_) => Ok(S3Response::new(CreateBucketOutput::default())),
-                    Err(crate::vfs::error::VfsError::AlreadyExists { .. }) => Err(s3_error!(
-                        BucketAlreadyOwnedByYou,
-                        "bucket already exists"
-                    )),
+                    Err(crate::vfs::error::VfsError::AlreadyExists { .. }) => {
+                        Err(s3_error!(BucketAlreadyOwnedByYou, "bucket already exists"))
+                    }
                     Err(e) => Err(Self::err(e)),
                 }
             }
         }
     }
 
-    async fn delete_bucket(&self, req: S3Request<DeleteBucketInput>) -> S3Result<S3Response<DeleteBucketOutput>> {
+    async fn delete_bucket(
+        &self,
+        req: S3Request<DeleteBucketInput>,
+    ) -> S3Result<S3Response<DeleteBucketOutput>> {
         let input = req.input;
         let bucket = input.bucket.as_str().to_string();
         match &self.opts.bucket_mode {
@@ -572,12 +560,18 @@ where
         }
     }
 
-    async fn head_bucket(&self, req: S3Request<HeadBucketInput>) -> S3Result<S3Response<HeadBucketOutput>> {
+    async fn head_bucket(
+        &self,
+        req: S3Request<HeadBucketInput>,
+    ) -> S3Result<S3Response<HeadBucketOutput>> {
         self.stat_bucket_root(req.input.bucket.as_str()).await?;
         Ok(S3Response::new(HeadBucketOutput::default()))
     }
 
-    async fn list_buckets(&self, _req: S3Request<ListBucketsInput>) -> S3Result<S3Response<ListBucketsOutput>> {
+    async fn list_buckets(
+        &self,
+        _req: S3Request<ListBucketsInput>,
+    ) -> S3Result<S3Response<ListBucketsOutput>> {
         let owner = Owner::default();
         let buckets = match &self.opts.bucket_mode {
             BucketMode::Single { bucket } => vec![Bucket {
@@ -616,7 +610,10 @@ where
         Ok(S3Response::new(GetBucketLocationOutput::default()))
     }
 
-    async fn put_object(&self, mut req: S3Request<PutObjectInput>) -> S3Result<S3Response<PutObjectOutput>> {
+    async fn put_object(
+        &self,
+        mut req: S3Request<PutObjectInput>,
+    ) -> S3Result<S3Response<PutObjectOutput>> {
         let input = &mut req.input;
         let bucket = input.bucket.as_str().to_string();
         let key = input.key.as_str().to_string();
@@ -710,7 +707,10 @@ where
         }))
     }
 
-    async fn get_object(&self, req: S3Request<GetObjectInput>) -> S3Result<S3Response<GetObjectOutput>> {
+    async fn get_object(
+        &self,
+        req: S3Request<GetObjectInput>,
+    ) -> S3Result<S3Response<GetObjectOutput>> {
         let input = req.input;
         let bucket = input.bucket.as_str().to_string();
         let key = input.key.as_str().to_string();
@@ -729,7 +729,12 @@ where
                 body: Some(StreamingBlob::from_bytes(Default::default())),
                 content_length: Some(0),
                 e_tag: Some(ETag::Strong(etag)),
-                content_type: Some(meta.content_type.clone().map(ContentType::from).unwrap_or_else(|| ContentType::from(DEFAULT_CONTENT_TYPE))),
+                content_type: Some(
+                    meta.content_type
+                        .clone()
+                        .map(ContentType::from)
+                        .unwrap_or_else(|| ContentType::from(DEFAULT_CONTENT_TYPE)),
+                ),
                 last_modified: Self::mtime_timestamp(&attr),
                 accept_ranges: Some(AcceptRanges::from("bytes")),
                 ..Default::default()
@@ -752,14 +757,21 @@ where
             body: Some(body),
             content_length: Some(length as i64),
             e_tag: Some(ETag::Strong(etag)),
-            content_type: Some(meta.content_type.map(ContentType::from).unwrap_or_else(|| ContentType::from(DEFAULT_CONTENT_TYPE))),
+            content_type: Some(
+                meta.content_type
+                    .map(ContentType::from)
+                    .unwrap_or_else(|| ContentType::from(DEFAULT_CONTENT_TYPE)),
+            ),
             last_modified: Self::mtime_timestamp(&attr),
             accept_ranges: Some(AcceptRanges::from("bytes")),
             ..Default::default()
         }))
     }
 
-    async fn head_object(&self, req: S3Request<HeadObjectInput>) -> S3Result<S3Response<HeadObjectOutput>> {
+    async fn head_object(
+        &self,
+        req: S3Request<HeadObjectInput>,
+    ) -> S3Result<S3Response<HeadObjectOutput>> {
         let input = req.input;
         let bucket = input.bucket.as_str().to_string();
         let key = input.key.as_str().to_string();
@@ -780,7 +792,11 @@ where
         Ok(S3Response::new(HeadObjectOutput {
             content_length: Some(attr.size as i64),
             e_tag: Some(ETag::Strong(etag)),
-            content_type: Some(meta.content_type.map(ContentType::from).unwrap_or_else(|| ContentType::from(DEFAULT_CONTENT_TYPE))),
+            content_type: Some(
+                meta.content_type
+                    .map(ContentType::from)
+                    .unwrap_or_else(|| ContentType::from(DEFAULT_CONTENT_TYPE)),
+            ),
             last_modified: Self::mtime_timestamp(&attr),
             metadata,
             accept_ranges: Some(AcceptRanges::from("bytes")),
@@ -788,7 +804,10 @@ where
         }))
     }
 
-    async fn delete_object(&self, req: S3Request<DeleteObjectInput>) -> S3Result<S3Response<DeleteObjectOutput>> {
+    async fn delete_object(
+        &self,
+        req: S3Request<DeleteObjectInput>,
+    ) -> S3Result<S3Response<DeleteObjectOutput>> {
         let input = req.input;
         let bucket = input.bucket.as_str().to_string();
         let key = input.key.as_str().to_string();
@@ -801,7 +820,10 @@ where
         ))
     }
 
-    async fn delete_objects(&self, req: S3Request<DeleteObjectsInput>) -> S3Result<S3Response<DeleteObjectsOutput>> {
+    async fn delete_objects(
+        &self,
+        req: S3Request<DeleteObjectsInput>,
+    ) -> S3Result<S3Response<DeleteObjectsOutput>> {
         let input = req.input;
         let bucket = input.bucket.as_str().to_string();
         let objects = input.delete.objects;
@@ -811,7 +833,7 @@ where
         for obj in objects {
             let key = obj.key.as_str().to_string();
             let lock = self.lock_for(&bucket, &key);
-        let _guard = lock.lock().await;
+            let _guard = lock.lock().await;
             match self.delete_object_internal(&bucket, &key).await {
                 Ok(()) => deleted.push(DeletedObject {
                     key: Some(obj.key),
@@ -826,13 +848,24 @@ where
             }
         }
         Ok(S3Response::new(DeleteObjectsOutput {
-            deleted: if deleted.is_empty() { None } else { Some(deleted) },
-            errors: if errors.is_empty() { None } else { Some(errors) },
+            deleted: if deleted.is_empty() {
+                None
+            } else {
+                Some(deleted)
+            },
+            errors: if errors.is_empty() {
+                None
+            } else {
+                Some(errors)
+            },
             ..Default::default()
         }))
     }
 
-    async fn copy_object(&self, req: S3Request<CopyObjectInput>) -> S3Result<S3Response<CopyObjectOutput>> {
+    async fn copy_object(
+        &self,
+        req: S3Request<CopyObjectInput>,
+    ) -> S3Result<S3Response<CopyObjectOutput>> {
         let input = req.input;
         let dst_bucket = input.bucket.as_str().to_string();
         let dst_key = input.key.as_str().to_string();
@@ -845,7 +878,7 @@ where
                 return Err(s3_error!(
                     NotImplemented,
                     "only bucket/key copy sources are supported"
-                ))
+                ));
             }
         };
 
@@ -872,9 +905,14 @@ where
         );
         let meta = if replace {
             ObjectMeta {
-                content_type: input.content_type.as_ref().map(|ct| ct.as_str().to_string()),
+                content_type: input
+                    .content_type
+                    .as_ref()
+                    .map(|ct| ct.as_str().to_string()),
                 metadata: input.metadata.as_ref().map(|m| {
-                    m.iter().map(|(k, v)| (k.to_string(), v.to_string())).collect()
+                    m.iter()
+                        .map(|(k, v)| (k.to_string(), v.to_string()))
+                        .collect()
                 }),
             }
         } else {
@@ -888,8 +926,12 @@ where
         let etag = etag.unwrap_or_else(|| Self::fallback_etag(&final_attr));
 
         self.set_xattr(final_attr.ino, XATTR_ETAG, &etag).await?;
-        self.set_xattr(final_attr.ino, XATTR_META, &serde_json::to_string(&meta).unwrap())
-            .await?;
+        self.set_xattr(
+            final_attr.ino,
+            XATTR_META,
+            &serde_json::to_string(&meta).unwrap(),
+        )
+        .await?;
 
         let last_modified = Self::mtime_timestamp(&final_attr);
         tracing::debug!(bucket = %dst_bucket, key = %dst_key, size, "s3 copy_object");
@@ -903,13 +945,24 @@ where
         }))
     }
 
-    async fn list_objects(&self, req: S3Request<ListObjectsInput>) -> S3Result<S3Response<ListObjectsOutput>> {
+    async fn list_objects(
+        &self,
+        req: S3Request<ListObjectsInput>,
+    ) -> S3Result<S3Response<ListObjectsOutput>> {
         let input = req.input;
         let bucket = input.bucket.as_str().to_string();
         let query = ListQuery {
-            prefix: input.prefix.as_ref().map(|p| p.as_str().to_string()).unwrap_or_default(),
+            prefix: input
+                .prefix
+                .as_ref()
+                .map(|p| p.as_str().to_string())
+                .unwrap_or_default(),
             delimiter: input.delimiter.as_ref().map(|d| d.as_str().to_string()),
-            start_after: input.marker.as_ref().map(|m| m.as_str().to_string()).unwrap_or_default(),
+            start_after: input
+                .marker
+                .as_ref()
+                .map(|m| m.as_str().to_string())
+                .unwrap_or_default(),
             max_keys: input
                 .max_keys
                 .map(|m| usize::try_from(m).unwrap_or(1000))
@@ -944,13 +997,20 @@ where
             } else {
                 None
             },
-            contents: if contents.is_empty() { None } else { Some(contents) },
+            contents: if contents.is_empty() {
+                None
+            } else {
+                Some(contents)
+            },
             common_prefixes: prefixes_to_dto(&result.common_prefixes),
             ..Default::default()
         }))
     }
 
-    async fn list_objects_v2(&self, req: S3Request<ListObjectsV2Input>) -> S3Result<S3Response<ListObjectsV2Output>> {
+    async fn list_objects_v2(
+        &self,
+        req: S3Request<ListObjectsV2Input>,
+    ) -> S3Result<S3Response<ListObjectsV2Output>> {
         let input = req.input;
         let bucket = input.bucket.as_str().to_string();
         let start_after = input
@@ -964,7 +1024,11 @@ where
             .map(|t| t.as_str().to_string())
             .unwrap_or_default();
         let query = ListQuery {
-            prefix: input.prefix.as_ref().map(|p| p.as_str().to_string()).unwrap_or_default(),
+            prefix: input
+                .prefix
+                .as_ref()
+                .map(|p| p.as_str().to_string())
+                .unwrap_or_default(),
             delimiter: input.delimiter.as_ref().map(|d| d.as_str().to_string()),
             start_after: if continuation.is_empty() {
                 start_after
@@ -1008,7 +1072,11 @@ where
             } else {
                 None
             },
-            contents: if contents.is_empty() { None } else { Some(contents) },
+            contents: if contents.is_empty() {
+                None
+            } else {
+                Some(contents)
+            },
             common_prefixes: prefixes_to_dto(&result.common_prefixes),
             ..Default::default()
         }))
@@ -1022,7 +1090,10 @@ where
         let bucket = input.bucket.as_str().to_string();
         let key = input.key.as_str().to_string();
         if key.ends_with('/') {
-            return Err(s3_error!(InvalidArgument, "multipart key must not end with '/'"));
+            return Err(s3_error!(
+                InvalidArgument,
+                "multipart key must not end with '/'"
+            ));
         }
         self.stat_bucket_root(&bucket).await?;
         path::object_path(&self.opts.bucket_mode, &bucket, &key).map_err(Self::path_err)?;
@@ -1039,7 +1110,9 @@ where
                 .as_ref()
                 .map(|ct| ct.as_str().to_string()),
             metadata: input.metadata.as_ref().map(|m| {
-                m.iter().map(|(k, v)| (k.to_string(), v.to_string())).collect()
+                m.iter()
+                    .map(|(k, v)| (k.to_string(), v.to_string()))
+                    .collect()
             }),
             initiated: SystemTime::now()
                 .duration_since(UNIX_EPOCH)
@@ -1047,7 +1120,11 @@ where
                 .unwrap_or(0),
         };
         let target_path = UploadMeta::target_path(&upload_id);
-        let ino = self.vfs.create_file(&target_path).await.map_err(Self::err)?;
+        let ino = self
+            .vfs
+            .create_file(&target_path)
+            .await
+            .map_err(Self::err)?;
         let attr = self.vfs.stat(&target_path).await.map_err(Self::err)?;
         let guard = self
             .vfs
@@ -1068,7 +1145,10 @@ where
         }))
     }
 
-    async fn upload_part(&self, mut req: S3Request<UploadPartInput>) -> S3Result<S3Response<UploadPartOutput>> {
+    async fn upload_part(
+        &self,
+        mut req: S3Request<UploadPartInput>,
+    ) -> S3Result<S3Response<UploadPartOutput>> {
         let upload_id = req.input.upload_id.clone();
         let part_number = req.input.part_number;
 
@@ -1093,7 +1173,10 @@ where
         }))
     }
 
-    async fn list_parts(&self, req: S3Request<ListPartsInput>) -> S3Result<S3Response<ListPartsOutput>> {
+    async fn list_parts(
+        &self,
+        req: S3Request<ListPartsInput>,
+    ) -> S3Result<S3Response<ListPartsOutput>> {
         let input = req.input;
         let upload_id = input.upload_id.clone();
         let meta = self.read_upload_meta(&upload_id).await?;
@@ -1224,8 +1307,8 @@ where
         }
         out_guard.close().await.map_err(Self::err)?;
 
-        let target = path::object_path(&self.opts.bucket_mode, &bucket, &key)
-            .map_err(Self::path_err)?;
+        let target =
+            path::object_path(&self.opts.bucket_mode, &bucket, &key).map_err(Self::path_err)?;
         if let Some(parent) = std::path::Path::new(&target).parent() {
             let parent = parent.to_string_lossy().to_string();
             if !parent.is_empty() {
@@ -1296,8 +1379,7 @@ where
                 // Reconstruct the upload id from the directory name.
                 let upload_id = upload.name.clone();
                 if let Ok(meta) = self.read_upload_meta(&upload_id).await {
-                    if meta.bucket == bucket
-                        && (prefix.is_empty() || meta.key.starts_with(&prefix))
+                    if meta.bucket == bucket && (prefix.is_empty() || meta.key.starts_with(&prefix))
                     {
                         uploads.push(MultipartUpload {
                             key: Some(ObjectKey::from(meta.key)),
@@ -1305,9 +1387,7 @@ where
                             initiated: Some(Timestamp::from(
                                 UNIX_EPOCH + Duration::from_secs(meta.initiated.max(0) as u64),
                             )),
-                            storage_class: Some(StorageClass::from_static(
-                                StorageClass::STANDARD,
-                            )),
+                            storage_class: Some(StorageClass::from_static(StorageClass::STANDARD)),
                             ..Default::default()
                         });
                     }
@@ -1319,7 +1399,11 @@ where
 
         Ok(S3Response::new(ListMultipartUploadsOutput {
             bucket: Some(input.bucket),
-            uploads: if uploads.is_empty() { None } else { Some(uploads) },
+            uploads: if uploads.is_empty() {
+                None
+            } else {
+                Some(uploads)
+            },
             ..Default::default()
         }))
     }

--- a/src/gateway/s3/store.rs
+++ b/src/gateway/s3/store.rs
@@ -6,13 +6,14 @@
 //! markers) lives in xattrs; multipart state lives under
 //! `/.brewfs.sys/s3/`.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, hash_map::DefaultHasher};
+use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
-use dashmap::DashMap;
-use futures::StreamExt;
+use dashmap::DashSet;
+use futures::{SinkExt, StreamExt};
 use s3s::dto::*;
 use s3s::{S3, S3Error, S3Request, S3Response, S3Result, s3_error};
 use serde::{Deserialize, Serialize};
@@ -42,8 +43,29 @@ pub const XATTR_DIROBJ: &str = "brewfs.s3.dirobj";
 /// Read chunk size for streaming copies and GET bodies.
 const STREAM_CHUNK: u64 = 4 * 1024 * 1024;
 
-/// Maximum directory recursion depth during listings (defensive bound).
-const MAX_WALK_DEPTH: usize = 64;
+/// Number of fixed shards used to serialize writes to the same object key.
+const KEY_LOCK_SHARDS: usize = 256;
+/// Number of fixed shards used to serialize bucket lifecycle changes.
+const BUCKET_LOCK_SHARDS: usize = 64;
+const MAX_MULTIPART_PART_NUMBER: i32 = 10_000;
+
+fn valid_part_number(part_number: i32) -> bool {
+    (1..=MAX_MULTIPART_PART_NUMBER).contains(&part_number)
+}
+
+fn key_lock_shard(bucket: &str, key: &str) -> usize {
+    let mut hasher = DefaultHasher::new();
+    bucket.hash(&mut hasher);
+    0u8.hash(&mut hasher);
+    key.trim_end_matches('/').hash(&mut hasher);
+    hasher.finish() as usize % KEY_LOCK_SHARDS
+}
+
+fn bucket_lock_shard(bucket: &str) -> usize {
+    let mut hasher = DefaultHasher::new();
+    bucket.hash(&mut hasher);
+    hasher.finish() as usize % BUCKET_LOCK_SHARDS
+}
 
 /// Name of the hidden system directory at the volume root.
 const SYS_DIR_NAME: &str = ".brewfs.sys";
@@ -68,8 +90,51 @@ pub struct S3Options {
 pub struct BrewFsS3<S: BlockStore + Send + Sync + 'static> {
     vfs: VFS<S, MetaClient<dyn MetaStore>>,
     opts: S3Options,
-    /// Per-(bucket,key) write serialization within this gateway instance.
-    locks: DashMap<String, Arc<Mutex<()>>>,
+    /// Fixed-size write serialization shards within this gateway instance.
+    locks: Arc<[Mutex<()>; KEY_LOCK_SHARDS]>,
+    /// Fixed-size bucket lifecycle serialization shards within this gateway instance.
+    bucket_locks: Arc<[Mutex<()>; BUCKET_LOCK_SHARDS]>,
+    active_staging: Arc<DashSet<String>>,
+}
+
+impl<S> Clone for BrewFsS3<S>
+where
+    S: BlockStore + Send + Sync + 'static,
+{
+    fn clone(&self) -> Self {
+        Self {
+            vfs: self.vfs.clone(),
+            opts: self.opts.clone(),
+            locks: self.locks.clone(),
+            bucket_locks: self.bucket_locks.clone(),
+            active_staging: self.active_staging.clone(),
+        }
+    }
+}
+
+struct ActiveStagingPath {
+    path: String,
+    active: Arc<DashSet<String>>,
+}
+
+impl ActiveStagingPath {
+    fn path(&self) -> &str {
+        &self.path
+    }
+}
+
+impl std::ops::Deref for ActiveStagingPath {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.path
+    }
+}
+
+impl Drop for ActiveStagingPath {
+    fn drop(&mut self) {
+        self.active.remove(&self.path);
+    }
 }
 
 impl<S> BrewFsS3<S>
@@ -80,7 +145,9 @@ where
         Self {
             vfs,
             opts,
-            locks: DashMap::new(),
+            locks: Arc::new(std::array::from_fn(|_| Mutex::new(()))),
+            bucket_locks: Arc::new(std::array::from_fn(|_| Mutex::new(()))),
+            active_staging: Arc::new(DashSet::new()),
         }
     }
 
@@ -89,9 +156,25 @@ where
         &self.vfs
     }
 
-    fn lock_for(&self, bucket: &str, key: &str) -> Arc<Mutex<()>> {
-        let id = format!("{bucket}/{key}");
-        Arc::clone(self.locks.entry(id).or_default().value())
+    pub(crate) fn lock_for(&self, bucket: &str, key: &str) -> &Mutex<()> {
+        &self.locks[key_lock_shard(bucket, key)]
+    }
+
+    fn bucket_lock_for(&self, bucket: &str) -> &Mutex<()> {
+        &self.bucket_locks[bucket_lock_shard(bucket)]
+    }
+
+    pub(crate) fn staging_path_is_active(&self, path: &str) -> bool {
+        self.active_staging.contains(path)
+    }
+
+    fn reserve_staging_path(&self) -> ActiveStagingPath {
+        let path = format!("{}/{}", multipart::tmp_dir(), new_upload_id());
+        self.active_staging.insert(path.clone());
+        ActiveStagingPath {
+            path,
+            active: self.active_staging.clone(),
+        }
     }
 
     // ---- error mapping ----------------------------------------------------
@@ -119,6 +202,7 @@ where
         match e {
             PathError::InvalidBucket(b) => s3_error!(NoSuchBucket, "bucket not found: {b}"),
             PathError::InvalidKey(k) => s3_error!(InvalidArgument, "invalid object key: {k}"),
+            PathError::ReservedKey(k) => s3_error!(AccessDenied, "reserved object key: {k}"),
         }
     }
 
@@ -126,7 +210,13 @@ where
 
     async fn stat_bucket_root(&self, bucket: &str) -> S3Result<FileAttr> {
         let root = path::bucket_root(&self.opts.bucket_mode, bucket).map_err(Self::path_err)?;
-        let attr = self.vfs.stat(&root).await.map_err(Self::err)?;
+        let attr = match self.vfs.stat(&root).await {
+            Ok(attr) => attr,
+            Err(crate::vfs::error::VfsError::NotFound { .. }) => {
+                return Err(s3_error!(NoSuchBucket, "bucket not found: {bucket}"));
+            }
+            Err(e) => return Err(Self::err(e)),
+        };
         if attr.kind != FileType::Dir {
             return Err(s3_error!(NoSuchBucket, "bucket not found: {bucket}"));
         }
@@ -143,7 +233,19 @@ where
             return Ok(Vec::new());
         }
         let fh = self.vfs.opendir(attr.ino).await.map_err(Self::err)?;
-        let entries = self.vfs.readdir(fh, 0).unwrap_or_default();
+        let mut entries = Vec::new();
+        let mut offset = 0;
+        loop {
+            let page = self
+                .vfs
+                .readdir(fh, offset)
+                .ok_or_else(|| s3_error!(InternalError, "directory handle became unavailable"))?;
+            if page.is_empty() {
+                break;
+            }
+            offset += page.len() as u64;
+            entries.extend(page);
+        }
         self.vfs.closedir(fh).map_err(Self::err)?;
         Ok(entries)
     }
@@ -195,128 +297,171 @@ where
             self.vfs.unlink(dst).await.map_err(Self::err)?;
         }
         let ino = self.vfs.create_file(dst).await.map_err(Self::err)?;
-        let attr = self.vfs.stat(dst).await.map_err(Self::err)?;
-        let guard = self
-            .vfs
-            .open_guard(ino, attr, false, true)
-            .await
-            .map_err(Self::err)?;
+        let result: S3Result<(u64, String)> = async {
+            let attr = self.vfs.stat(dst).await.map_err(Self::err)?;
+            let guard = self
+                .vfs
+                .open_guard(ino, attr, false, true)
+                .await
+                .map_err(Self::err)?;
 
-        let mut offset: u64 = 0;
-        let mut md = md5::Context::new();
-        while let Some(chunk) = body.next().await {
-            let chunk = chunk.map_err(|e| s3_error!(InternalError, "body read: {e}"))?;
-            if !chunk.is_empty() {
-                guard.write(offset, &chunk).await.map_err(Self::err)?;
-                md.consume(&chunk);
-                offset += chunk.len() as u64;
+            let mut offset: u64 = 0;
+            let mut md = md5::Context::new();
+            while let Some(chunk) = body.next().await {
+                let chunk = chunk.map_err(|e| s3_error!(InternalError, "body read: {e}"))?;
+                if !chunk.is_empty() {
+                    guard.write(offset, &chunk).await.map_err(Self::err)?;
+                    md.consume(&chunk);
+                    offset += chunk.len() as u64;
+                }
             }
+            guard.close().await.map_err(Self::err)?;
+            let etag = format!("{:x}", md.compute());
+            Ok((offset, etag))
         }
-        guard.close().await.map_err(Self::err)?;
-        let etag = format!("{:x}", md.compute());
-        Ok((offset, etag))
+        .await;
+        if result.is_err() {
+            let _ = self.vfs.unlink(dst).await;
+        }
+        result
     }
 
     /// Reads a byte range of a file as a streaming blob. Chunks are produced
     /// by a spawned task and forwarded through an mpsc channel (the channel
     /// receiver is `Send + Sync`, as required by `StreamingBlob::wrap`).
-    fn read_stream(&self, attr: FileAttr, offset: u64, length: u64) -> S3Result<StreamingBlob> {
-        let ino = attr.ino;
-        let vfs = self.vfs.clone();
+    async fn read_stream(
+        &self,
+        attr: FileAttr,
+        offset: u64,
+        length: u64,
+    ) -> S3Result<StreamingBlob> {
+        let guard = self
+            .vfs
+            .open_guard(attr.ino, attr, true, false)
+            .await
+            .map_err(Self::err)?;
         let (mut tx, rx) =
             futures::channel::mpsc::channel::<Result<bytes::Bytes, std::io::Error>>(4);
         tokio::spawn(async move {
             let mut offset = offset;
             let mut remaining = length;
+            let mut read_error = None;
             while remaining > 0 {
                 let len = remaining.min(STREAM_CHUNK) as usize;
-                // Open a short-lived read guard per chunk; the VFS read path
-                // caches open handles, so this stays cheap.
-                let guard = match vfs.stat_ino(ino).await {
-                    Some(a) => vfs.open_guard(ino, a, true, false).await,
-                    None => {
-                        let _ =
-                            tx.try_send(Err(std::io::Error::other("object deleted during read")));
-                        break;
-                    }
-                };
-                let guard = match guard {
-                    Ok(g) => g,
-                    Err(e) => {
-                        let _ = tx.try_send(Err(std::io::Error::other(format!("open: {e}"))));
-                        break;
-                    }
-                };
                 match guard.read(offset, len).await {
+                    Ok(data) if data.is_empty() => {
+                        read_error = Some(std::io::Error::new(
+                            std::io::ErrorKind::UnexpectedEof,
+                            "object ended before the requested range",
+                        ));
+                        break;
+                    }
                     Ok(data) => {
                         let n = data.len() as u64;
-                        drop(guard);
-                        if tx.try_send(Ok(bytes::Bytes::from(data))).is_err() {
+                        if tx.send(Ok(bytes::Bytes::from(data))).await.is_err() {
                             break;
                         }
                         offset += n;
                         remaining -= n;
                     }
                     Err(e) => {
-                        drop(guard);
-                        let _ = tx.try_send(Err(std::io::Error::other(format!("read: {e}"))));
+                        read_error = Some(std::io::Error::other(format!("read: {e}")));
                         break;
                     }
                 }
+            }
+
+            let close_error = guard
+                .close()
+                .await
+                .err()
+                .map(|e| std::io::Error::other(format!("close: {e}")));
+            if let Some(error) = read_error.or(close_error) {
+                let _ = tx.send(Err(error)).await;
             }
         });
         Ok(StreamingBlob::wrap(rx))
     }
 
-    /// Copies `src` into a fresh tmp file and renames it to `dst` (atomic publish).
-    async fn copy_object_data(&self, src: &str, dst: &str) -> S3Result<(u64, FileAttr)> {
-        let src_attr = self.vfs.stat(src).await.map_err(Self::err)?;
-        let tmp = format!("{}/{}", multipart::tmp_dir(), new_upload_id());
-        if self.vfs.exists(&tmp).await {
-            self.vfs.unlink(&tmp).await.map_err(Self::err)?;
-        }
-        let tmp_ino = self.vfs.create_file(&tmp).await.map_err(Self::err)?;
-        let tmp_attr = self.vfs.stat(&tmp).await.map_err(Self::err)?;
-        let dst_guard = self
-            .vfs
-            .open_guard(tmp_ino, tmp_attr, false, true)
-            .await
-            .map_err(Self::err)?;
-        let src_guard = self
-            .vfs
-            .open_guard(src_attr.ino, src_attr.clone(), true, false)
-            .await
-            .map_err(Self::err)?;
-
-        let mut offset: u64 = 0;
-        while offset < src_attr.size {
-            let len = (src_attr.size - offset).min(STREAM_CHUNK) as usize;
-            let chunk = src_guard.read(offset, len).await.map_err(Self::err)?;
-            if chunk.is_empty() {
-                break;
+    async fn copy_range_exact(
+        &self,
+        src_ino: i64,
+        src_offset: u64,
+        dst_ino: i64,
+        dst_offset: u64,
+        length: u64,
+    ) -> S3Result<()> {
+        let mut copied = 0;
+        while copied < length {
+            let chunk_len = (length - copied).min(STREAM_CHUNK);
+            let written = self
+                .vfs
+                .copy_file_range_inodes(
+                    src_ino,
+                    src_offset + copied,
+                    dst_ino,
+                    dst_offset + copied,
+                    chunk_len,
+                )
+                .await
+                .map_err(Self::err)?;
+            if written as u64 != chunk_len {
+                return Err(s3_error!(
+                    InternalError,
+                    "short copy: wrote {written} of {chunk_len} bytes"
+                ));
             }
-            dst_guard.write(offset, &chunk).await.map_err(Self::err)?;
-            offset += chunk.len() as u64;
+            copied += chunk_len;
         }
-        src_guard.close().await.map_err(Self::err)?;
-        dst_guard.close().await.map_err(Self::err)?;
+        Ok(())
+    }
 
-        if let Some(parent) = std::path::Path::new(dst).parent() {
-            let parent = parent.to_string_lossy().to_string();
-            if !parent.is_empty() {
-                self.vfs.mkdir_p(&parent).await.map_err(Self::err)?;
-            }
+    /// Copies one inode into a fresh tmp file and renames it to `dst`.
+    async fn copy_object_data(
+        &self,
+        src_attr: &FileAttr,
+        dst: &str,
+        etag: Option<String>,
+        meta: &ObjectMeta,
+    ) -> S3Result<(u64, FileAttr, String)> {
+        let tmp = self.reserve_staging_path();
+        if self.vfs.exists(tmp.path()).await {
+            self.vfs.unlink(tmp.path()).await.map_err(Self::err)?;
         }
-        if self.vfs.exists(dst).await {
-            let attr = self.vfs.stat(dst).await.map_err(Self::err)?;
-            if attr.kind == FileType::Dir {
+        let tmp_ino = self.vfs.create_file(tmp.path()).await.map_err(Self::err)?;
+        let result: S3Result<(FileAttr, String)> = async {
+            self.copy_range_exact(src_attr.ino, 0, tmp_ino, 0, src_attr.size)
+                .await?;
+            let tmp_attr = self.vfs.stat(&tmp).await.map_err(Self::err)?;
+            let etag = etag.unwrap_or_else(|| Self::fallback_etag(&tmp_attr));
+            self.set_xattr(tmp_ino, XATTR_ETAG, &etag).await?;
+            self.set_xattr(tmp_ino, XATTR_META, &serde_json::to_string(meta).unwrap())
+                .await?;
+
+            if let Some(parent) = std::path::Path::new(dst).parent() {
+                let parent = parent.to_string_lossy().to_string();
+                if !parent.is_empty() {
+                    self.vfs.mkdir_p(&parent).await.map_err(Self::err)?;
+                }
+            }
+            if self.vfs.exists(dst).await {
+                let attr = self.vfs.stat(dst).await.map_err(Self::err)?;
+                if attr.kind == FileType::Dir {
+                    return Err(s3_error!(InvalidArgument, "target is a directory"));
+                }
+            }
+            self.vfs.rename(&tmp, dst).await.map_err(Self::err)?;
+            Ok((tmp_attr, etag))
+        }
+        .await;
+
+        match result {
+            Ok((final_attr, etag)) => Ok((final_attr.size, final_attr, etag)),
+            Err(e) => {
                 let _ = self.vfs.unlink(&tmp).await;
-                return Err(s3_error!(InvalidArgument, "target is a directory"));
+                Err(e)
             }
         }
-        self.vfs.rename(&tmp, dst).await.map_err(Self::err)?;
-        let final_attr = self.vfs.stat(dst).await.map_err(Self::err)?;
-        Ok((final_attr.size, final_attr))
     }
 
     /// Removes empty implicit parent directories left behind after a delete,
@@ -331,7 +476,7 @@ where
             if parent.is_empty() || parent == "/" || parent == bucket_root {
                 return;
             }
-            if parent.ends_with(SYS_DIR_NAME) || parent.contains(SYS_DIR_NAME) {
+            if parent == "/.brewfs.sys" || parent.starts_with("/.brewfs.sys/") {
                 return;
             }
             let Ok(attr) = self.vfs.stat(&parent).await else {
@@ -374,13 +519,17 @@ where
         };
 
         if attr.kind == FileType::Dir {
-            // Directory object delete: drop the marker; remove the directory
-            // itself only if it is empty.
+            if !key.ends_with('/') || !self.is_dir_object(attr.ino).await {
+                return Ok(());
+            }
             let _ = self.vfs.remove_xattr_ino(attr.ino, XATTR_DIROBJ).await;
             let entries = self.read_dir_entries(&target).await?;
             if entries.is_empty() {
                 self.vfs.rmdir(&target).await.map_err(Self::err)?;
             }
+            return Ok(());
+        }
+        if key.ends_with('/') {
             return Ok(());
         }
 
@@ -413,46 +562,45 @@ where
             }
             return Ok((target, attr, true));
         }
+        if key.ends_with('/') {
+            return Err(s3_error!(NoSuchKey, "no such object"));
+        }
         Ok((target, attr, false))
     }
 
     // ---- listing ------------------------------------------------------------
 
-    #[async_recursion::async_recursion]
     async fn walk_dir(
         &self,
-        dir_path: &str,
-        parent_key: &str,
-        at_root: bool,
+        root_path: &str,
+        root_key: &str,
         collector: &mut ListCollector,
-        depth: usize,
     ) -> S3Result<()> {
-        if depth > MAX_WALK_DEPTH {
-            return Ok(());
-        }
-        let entries = self.read_dir_entries(dir_path).await?;
-        for entry in entries {
-            if at_root && entry.name == SYS_DIR_NAME {
-                continue;
-            }
-            let child_path = format!("{dir_path}/{}", entry.name);
-            let is_dir = entry.kind == FileType::Dir;
-            let mut dirobj = false;
-            let mut etag = None;
-            let (size, mtime) = match self.vfs.stat_ino(entry.ino).await {
-                Some(a) => (a.size, a.mtime),
-                None => (0, 0),
-            };
-            if is_dir {
-                dirobj = self.is_dir_object(entry.ino).await;
-            } else {
-                etag = self.read_etag(entry.ino).await;
-            }
-            collector.push_entry(parent_key, &entry.name, is_dir, size, mtime, dirobj, etag);
-            if is_dir && collector.should_descend(parent_key, &entry.name) {
-                let child_key = format!("{parent_key}{}/", entry.name);
-                self.walk_dir(&child_path, &child_key, false, collector, depth + 1)
-                    .await?;
+        let mut pending = vec![(root_path.to_string(), root_key.to_string())];
+        while let Some((dir_path, parent_key)) = pending.pop() {
+            let entries = self.read_dir_entries(&dir_path).await?;
+            for entry in entries {
+                if dir_path == "/" && entry.name == SYS_DIR_NAME {
+                    continue;
+                }
+                let child_path = format!("{dir_path}/{}", entry.name);
+                let is_dir = entry.kind == FileType::Dir;
+                let mut dirobj = false;
+                let mut etag = None;
+                let (size, mtime) = match self.vfs.stat_ino(entry.ino).await {
+                    Some(a) => (a.size, a.mtime),
+                    None => (0, 0),
+                };
+                if is_dir {
+                    dirobj = self.is_dir_object(entry.ino).await;
+                } else {
+                    etag = self.read_etag(entry.ino).await;
+                }
+                collector.push_entry(&parent_key, &entry.name, is_dir, size, mtime, dirobj, etag);
+                if is_dir && collector.should_descend(&parent_key, &entry.name, dirobj) {
+                    let child_key = format!("{parent_key}{}/", entry.name);
+                    pending.push((child_path, child_key));
+                }
             }
         }
         Ok(())
@@ -465,15 +613,19 @@ where
     ) -> S3Result<crate::gateway::s3::list::ListResult> {
         let mode = &self.opts.bucket_mode;
         let root = path::bucket_root(mode, bucket).map_err(Self::path_err)?;
+        path::validate_key_namespace(mode, &query.prefix).map_err(Self::path_err)?;
         self.stat_bucket_root(bucket).await?;
         let mut collector = ListCollector::new(query);
-        self.walk_dir(&root, "", true, &mut collector, 0).await?;
+        self.walk_dir(&root, "", &mut collector).await?;
         Ok(collector.finish())
     }
 
     // ---- multipart ------------------------------------------------------------
 
-    async fn read_upload_meta(&self, upload_id: &str) -> S3Result<UploadMeta> {
+    pub(crate) async fn read_upload_meta(&self, upload_id: &str) -> S3Result<UploadMeta> {
+        if !multipart::is_valid_upload_id(upload_id) {
+            return Err(s3_error!(NoSuchUpload, "no such upload"));
+        }
         let target = UploadMeta::target_path(upload_id);
         match self.vfs.stat(&target).await {
             Ok(attr) => {
@@ -494,6 +646,35 @@ where
             Err(e) => Err(Self::err(e)),
         }
     }
+
+    async fn read_matching_upload_meta(
+        &self,
+        upload_id: &str,
+        bucket: &str,
+        key: &str,
+    ) -> S3Result<UploadMeta> {
+        let meta = self.read_upload_meta(upload_id).await?;
+        if meta.bucket != bucket || meta.key != key {
+            return Err(s3_error!(NoSuchUpload, "upload does not match bucket/key"));
+        }
+        path::object_path(&self.opts.bucket_mode, bucket, key).map_err(Self::path_err)?;
+        self.stat_bucket_root(bucket).await?;
+        Ok(meta)
+    }
+
+    async fn bucket_has_multipart_uploads(&self, bucket: &str) -> S3Result<bool> {
+        for hh in self.read_dir_entries(&multipart::uploads_dir()).await? {
+            let hh_dir = format!("{}/{}", multipart::uploads_dir(), hh.name);
+            for upload in self.read_dir_entries(&hh_dir).await? {
+                if let Ok(meta) = self.read_upload_meta(&upload.name).await
+                    && meta.bucket == bucket
+                {
+                    return Ok(true);
+                }
+            }
+        }
+        Ok(false)
+    }
 }
 
 #[async_trait]
@@ -507,6 +688,8 @@ where
     ) -> S3Result<S3Response<CreateBucketOutput>> {
         let input = req.input;
         let bucket = input.bucket.as_str().to_string();
+        let bucket_lock = self.bucket_lock_for(&bucket);
+        let _bucket_guard = bucket_lock.lock().await;
         match &self.opts.bucket_mode {
             BucketMode::Single { bucket: expected } => {
                 if bucket == *expected {
@@ -518,10 +701,8 @@ where
                 ))
             }
             BucketMode::Multi => {
-                if !path::is_valid_bucket_name(&bucket) {
-                    return Err(s3_error!(InvalidBucketName, "invalid bucket name"));
-                }
-                let dir = format!("/{bucket}");
+                let dir = path::bucket_root(&self.opts.bucket_mode, &bucket)
+                    .map_err(|_| s3_error!(InvalidBucketName, "invalid bucket name"))?;
                 match self.vfs.mkdir_err(&dir).await {
                     Ok(_) => Ok(S3Response::new(CreateBucketOutput::default())),
                     Err(crate::vfs::error::VfsError::AlreadyExists { .. }) => {
@@ -539,13 +720,23 @@ where
     ) -> S3Result<S3Response<DeleteBucketOutput>> {
         let input = req.input;
         let bucket = input.bucket.as_str().to_string();
+        let bucket_lock = self.bucket_lock_for(&bucket);
+        let _bucket_guard = bucket_lock.lock().await;
         match &self.opts.bucket_mode {
             BucketMode::Single { .. } => Err(s3_error!(
                 MethodNotAllowed,
                 "cannot delete the volume bucket in single-bucket mode"
             )),
             BucketMode::Multi => {
-                let dir = format!("/{bucket}");
+                let dir =
+                    path::bucket_root(&self.opts.bucket_mode, &bucket).map_err(Self::path_err)?;
+                self.stat_bucket_root(&bucket).await?;
+                if self.bucket_has_multipart_uploads(&bucket).await? {
+                    return Err(s3_error!(
+                        BucketNotEmpty,
+                        "bucket has active multipart uploads"
+                    ));
+                }
                 match self.vfs.rmdir(&dir).await {
                     Ok(_) => Ok(S3Response::new(DeleteBucketOutput::default())),
                     Err(crate::vfs::error::VfsError::NotFound { .. }) => {
@@ -605,8 +796,9 @@ where
 
     async fn get_bucket_location(
         &self,
-        _req: S3Request<GetBucketLocationInput>,
+        req: S3Request<GetBucketLocationInput>,
     ) -> S3Result<S3Response<GetBucketLocationOutput>> {
+        self.stat_bucket_root(req.input.bucket.as_str()).await?;
         Ok(S3Response::new(GetBucketLocationOutput::default()))
     }
 
@@ -637,15 +829,37 @@ where
                     .collect()
             })
             .unwrap_or_default();
+        let body = input
+            .body
+            .take()
+            .ok_or_else(|| s3_error!(InvalidArgument, "missing body"))?;
+        let mut body = body;
 
         let lock = self.lock_for(&bucket, &key);
         let _guard = lock.lock().await;
 
         // Explicit directory object: PUT with a key ending in '/'.
         if key.ends_with('/') {
+            while let Some(chunk) = body.next().await {
+                let chunk = chunk.map_err(|e| s3_error!(InternalError, "body read: {e}"))?;
+                if !chunk.is_empty() {
+                    return Err(s3_error!(
+                        InvalidArgument,
+                        "directory object body must be empty"
+                    ));
+                }
+            }
+            let bucket_lock = self.bucket_lock_for(&bucket);
+            let _bucket_guard = bucket_lock.lock().await;
+            self.stat_bucket_root(&bucket).await?;
+            if self.vfs.exists(&target).await {
+                let attr = self.vfs.stat(&target).await.map_err(Self::err)?;
+                if attr.kind != FileType::Dir {
+                    return Err(s3_error!(InvalidArgument, "target is not a directory"));
+                }
+            }
             self.vfs.mkdir_p(&target).await.map_err(Self::err)?;
             let attr = self.vfs.stat(&target).await.map_err(Self::err)?;
-            self.set_xattr(attr.ino, XATTR_DIROBJ, "").await?;
             let meta = ObjectMeta {
                 content_type,
                 metadata: if metadata.is_empty() {
@@ -658,37 +872,15 @@ where
                 .await?;
             let etag = format!("{:x}", md5::Context::new().compute());
             self.set_xattr(attr.ino, XATTR_ETAG, &etag).await?;
+            self.set_xattr(attr.ino, XATTR_DIROBJ, "").await?;
             return Ok(S3Response::new(PutObjectOutput {
                 e_tag: Some(ETag::Strong(etag)),
                 ..Default::default()
             }));
         }
 
-        let body = input
-            .body
-            .take()
-            .ok_or_else(|| s3_error!(InvalidArgument, "missing body"))?;
-        let mut body = body;
-
-        let tmp = format!("{}/{}", multipart::tmp_dir(), new_upload_id());
-        let (size, etag) = self.write_blob(&tmp, &mut body).await?;
-
-        if let Some(parent) = std::path::Path::new(&target).parent() {
-            let parent = parent.to_string_lossy().to_string();
-            if !parent.is_empty() {
-                self.vfs.mkdir_p(&parent).await.map_err(Self::err)?;
-            }
-        }
-        if self.vfs.exists(&target).await {
-            let attr = self.vfs.stat(&target).await.map_err(Self::err)?;
-            if attr.kind == FileType::Dir {
-                let _ = self.vfs.unlink(&tmp).await;
-                return Err(s3_error!(InvalidArgument, "key maps to a directory"));
-            }
-        }
-        self.vfs.rename(&tmp, &target).await.map_err(Self::err)?;
-        let attr = self.vfs.stat(&target).await.map_err(Self::err)?;
-        self.set_xattr(attr.ino, XATTR_ETAG, &etag).await?;
+        let tmp = self.reserve_staging_path();
+        let (size, etag) = self.write_blob(tmp.path(), &mut body).await?;
         let meta = ObjectMeta {
             content_type,
             metadata: if metadata.is_empty() {
@@ -697,8 +889,34 @@ where
                 Some(metadata)
             },
         };
-        self.set_xattr(attr.ino, XATTR_META, &serde_json::to_string(&meta).unwrap())
-            .await?;
+        let bucket_lock = self.bucket_lock_for(&bucket);
+        let _bucket_guard = bucket_lock.lock().await;
+        let publish_result: S3Result<()> = async {
+            self.stat_bucket_root(&bucket).await?;
+            let attr = self.vfs.stat(&tmp).await.map_err(Self::err)?;
+            self.set_xattr(attr.ino, XATTR_ETAG, &etag).await?;
+            self.set_xattr(attr.ino, XATTR_META, &serde_json::to_string(&meta).unwrap())
+                .await?;
+
+            if let Some(parent) = std::path::Path::new(&target).parent() {
+                let parent = parent.to_string_lossy().to_string();
+                if !parent.is_empty() {
+                    self.vfs.mkdir_p(&parent).await.map_err(Self::err)?;
+                }
+            }
+            if self.vfs.exists(&target).await {
+                let attr = self.vfs.stat(&target).await.map_err(Self::err)?;
+                if attr.kind == FileType::Dir {
+                    return Err(s3_error!(InvalidArgument, "key maps to a directory"));
+                }
+            }
+            self.vfs.rename(&tmp, &target).await.map_err(Self::err)
+        }
+        .await;
+        if let Err(e) = publish_result {
+            let _ = self.vfs.unlink(&tmp).await;
+            return Err(e);
+        }
 
         tracing::debug!(bucket = %bucket, key = %key, size, "s3 put_object");
         Ok(S3Response::new(PutObjectOutput {
@@ -714,10 +932,17 @@ where
         let input = req.input;
         let bucket = input.bucket.as_str().to_string();
         let key = input.key.as_str().to_string();
+        let lock = self.lock_for(&bucket, &key);
+        let _guard = lock.lock().await;
         let mode = &self.opts.bucket_mode;
         let (_target, attr, is_dir_obj) = self.resolve_object(mode, &bucket, &key).await?;
 
         let meta = self.read_object_meta(attr.ino).await;
+        let metadata = meta.metadata.clone().map(|m| {
+            m.into_iter()
+                .map(|(k, v)| (k, MetadataValue::from(v)))
+                .collect::<HashMap<String, MetadataValue>>()
+        });
         let etag = self
             .read_etag(attr.ino)
             .await
@@ -725,6 +950,9 @@ where
 
         // Directory objects are always empty.
         if is_dir_obj {
+            if input.range.is_some() {
+                return Err(s3_error!(InvalidRange, "range not satisfiable"));
+            }
             return Ok(S3Response::new(GetObjectOutput {
                 body: Some(StreamingBlob::from_bytes(Default::default())),
                 content_length: Some(0),
@@ -735,32 +963,48 @@ where
                         .unwrap_or_else(|| DEFAULT_CONTENT_TYPE.to_string()),
                 ),
                 last_modified: Self::mtime_timestamp(&attr),
+                metadata,
                 accept_ranges: Some(AcceptRanges::from("bytes")),
                 ..Default::default()
             }));
         }
 
         // Range handling.
-        let (offset, length) = match input.range.as_ref() {
+        let (offset, length, content_range) = match input.range.as_ref() {
             Some(range) => {
                 let checked = range
                     .check(attr.size)
                     .map_err(|_| s3_error!(InvalidRange, "range not satisfiable"))?;
-                (checked.start, checked.end - checked.start)
+                if checked.is_empty() {
+                    return Err(s3_error!(InvalidRange, "range not satisfiable"));
+                }
+                let length = checked.end - checked.start;
+                (
+                    checked.start,
+                    length,
+                    Some(ContentRange::from(format!(
+                        "bytes {}-{}/{}",
+                        checked.start,
+                        checked.end - 1,
+                        attr.size
+                    ))),
+                )
             }
-            None => (0, attr.size),
+            None => (0, attr.size, None),
         };
 
-        let body = self.read_stream(attr.clone(), offset, length)?;
+        let body = self.read_stream(attr.clone(), offset, length).await?;
         Ok(S3Response::new(GetObjectOutput {
             body: Some(body),
             content_length: Some(length as i64),
+            content_range,
             e_tag: Some(ETag::Strong(etag)),
             content_type: Some(
                 meta.content_type
                     .unwrap_or_else(|| DEFAULT_CONTENT_TYPE.to_string()),
             ),
             last_modified: Self::mtime_timestamp(&attr),
+            metadata,
             accept_ranges: Some(AcceptRanges::from("bytes")),
             ..Default::default()
         }))
@@ -773,8 +1017,10 @@ where
         let input = req.input;
         let bucket = input.bucket.as_str().to_string();
         let key = input.key.as_str().to_string();
+        let lock = self.lock_for(&bucket, &key);
+        let _guard = lock.lock().await;
         let mode = &self.opts.bucket_mode;
-        let (_target, attr, _is_dir_obj) = self.resolve_object(mode, &bucket, &key).await?;
+        let (_target, attr, is_dir_obj) = self.resolve_object(mode, &bucket, &key).await?;
 
         let meta = self.read_object_meta(attr.ino).await;
         let etag = self
@@ -788,7 +1034,7 @@ where
         });
 
         Ok(S3Response::new(HeadObjectOutput {
-            content_length: Some(attr.size as i64),
+            content_length: Some(if is_dir_obj { 0 } else { attr.size as i64 }),
             e_tag: Some(ETag::Strong(etag)),
             content_type: Some(
                 meta.content_type
@@ -880,22 +1126,27 @@ where
         };
 
         self.stat_bucket_root(&dst_bucket).await?;
-        let src_path = path::object_path(mode, &src_bucket, &src_key).map_err(Self::path_err)?;
+        path::object_path(mode, &src_bucket, &src_key).map_err(Self::path_err)?;
         let dst_path = path::object_path(mode, &dst_bucket, &dst_key).map_err(Self::path_err)?;
         if dst_path == "/" {
             return Err(s3_error!(InvalidArgument, "empty destination key"));
         }
 
-        let src_attr = match self.vfs.stat(&src_path).await {
-            Ok(a) => a,
-            Err(_) => return Err(s3_error!(NoSuchKey, "source object not found")),
+        let src_lock_shard = key_lock_shard(&src_bucket, &src_key);
+        let dst_lock_shard = key_lock_shard(&dst_bucket, &dst_key);
+        let (first_lock_shard, second_lock_shard) = if src_lock_shard <= dst_lock_shard {
+            (src_lock_shard, dst_lock_shard)
+        } else {
+            (dst_lock_shard, src_lock_shard)
         };
+        let _first_guard = self.locks[first_lock_shard].lock().await;
+        let _second_guard = if first_lock_shard == second_lock_shard {
+            None
+        } else {
+            Some(self.locks[second_lock_shard].lock().await)
+        };
+        let (_src_path, src_attr, _) = self.resolve_object(mode, &src_bucket, &src_key).await?;
 
-        let lock = self.lock_for(&dst_bucket, &dst_key);
-        let _guard = lock.lock().await;
-        let (size, final_attr) = self.copy_object_data(&src_path, &dst_path).await?;
-
-        // Copy or replace metadata according to the directive (default COPY).
         let replace = matches!(
             input.metadata_directive.as_ref().map(|d| d.as_str()),
             Some("REPLACE")
@@ -915,20 +1166,46 @@ where
         } else {
             self.read_object_meta(src_attr.ino).await
         };
-        let etag = if replace {
-            None
-        } else {
-            self.read_etag(src_attr.ino).await
-        };
-        let etag = etag.unwrap_or_else(|| Self::fallback_etag(&final_attr));
+        let etag = self
+            .read_etag(src_attr.ino)
+            .await
+            .unwrap_or_else(|| Self::fallback_etag(&src_attr));
+        let bucket_lock = self.bucket_lock_for(&dst_bucket);
+        let _bucket_guard = bucket_lock.lock().await;
+        self.stat_bucket_root(&dst_bucket).await?;
 
-        self.set_xattr(final_attr.ino, XATTR_ETAG, &etag).await?;
-        self.set_xattr(
-            final_attr.ino,
-            XATTR_META,
-            &serde_json::to_string(&meta).unwrap(),
-        )
-        .await?;
+        if dst_key.ends_with('/') {
+            if src_attr.size != 0 {
+                return Err(s3_error!(
+                    InvalidArgument,
+                    "directory object source must be empty"
+                ));
+            }
+            if self.vfs.exists(&dst_path).await {
+                let attr = self.vfs.stat(&dst_path).await.map_err(Self::err)?;
+                if attr.kind != FileType::Dir {
+                    return Err(s3_error!(InvalidArgument, "target is not a directory"));
+                }
+            }
+            self.vfs.mkdir_p(&dst_path).await.map_err(Self::err)?;
+            let attr = self.vfs.stat(&dst_path).await.map_err(Self::err)?;
+            self.set_xattr(attr.ino, XATTR_ETAG, &etag).await?;
+            self.set_xattr(attr.ino, XATTR_META, &serde_json::to_string(&meta).unwrap())
+                .await?;
+            self.set_xattr(attr.ino, XATTR_DIROBJ, "").await?;
+            return Ok(S3Response::new(CopyObjectOutput {
+                copy_object_result: Some(CopyObjectResult {
+                    e_tag: Some(ETag::Strong(etag)),
+                    last_modified: Self::mtime_timestamp(&attr),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }));
+        }
+
+        let (size, final_attr, etag) = self
+            .copy_object_data(&src_attr, &dst_path, Some(etag), &meta)
+            .await?;
 
         let last_modified = Self::mtime_timestamp(&final_attr);
         tracing::debug!(bucket = %dst_bucket, key = %dst_key, size, "s3 copy_object");
@@ -964,14 +1241,13 @@ where
                 .max_keys
                 .map(|m| usize::try_from(m).unwrap_or(1000))
                 .unwrap_or(1000),
+            hide_dir_objects: self.opts.hide_dir_objects,
         };
         let result = self.list_keys(&bucket, query).await?;
 
         let contents: Vec<Object> = result
             .objects
             .iter()
-            .filter(|o| !o.is_dir || o.is_dir_object)
-            .filter(|o| !(o.is_dir_object && self.opts.hide_dir_objects))
             .map(|o| Object {
                 key: Some(o.key.clone()),
                 size: Some(if o.is_dir_object { 0 } else { o.size as i64 }),
@@ -1036,14 +1312,13 @@ where
                 .max_keys
                 .map(|m| usize::try_from(m).unwrap_or(1000))
                 .unwrap_or(1000),
+            hide_dir_objects: self.opts.hide_dir_objects,
         };
         let result = self.list_keys(&bucket, query).await?;
 
         let contents: Vec<Object> = result
             .objects
             .iter()
-            .filter(|o| !o.is_dir || o.is_dir_object)
-            .filter(|o| !(o.is_dir_object && self.opts.hide_dir_objects))
             .map(|o| Object {
                 key: Some(o.key.clone()),
                 size: Some(if o.is_dir_object { 0 } else { o.size as i64 }),
@@ -1086,12 +1361,14 @@ where
         let input = req.input;
         let bucket = input.bucket.as_str().to_string();
         let key = input.key.as_str().to_string();
-        if key.ends_with('/') {
+        if key.is_empty() || key.ends_with('/') {
             return Err(s3_error!(
                 InvalidArgument,
-                "multipart key must not end with '/'"
+                "multipart key must not be empty or end with '/'"
             ));
         }
+        let bucket_lock = self.bucket_lock_for(&bucket);
+        let _bucket_guard = bucket_lock.lock().await;
         self.stat_bucket_root(&bucket).await?;
         path::object_path(&self.opts.bucket_mode, &bucket, &key).map_err(Self::path_err)?;
 
@@ -1148,21 +1425,46 @@ where
     ) -> S3Result<S3Response<UploadPartOutput>> {
         let upload_id = req.input.upload_id.clone();
         let part_number = req.input.part_number;
+        if !valid_part_number(part_number) {
+            return Err(s3_error!(
+                InvalidArgument,
+                "part number must be between 1 and {MAX_MULTIPART_PART_NUMBER}"
+            ));
+        }
+        let bucket = req.input.bucket.as_str().to_string();
+        let key = req.input.key.as_str().to_string();
 
-        // Validate the upload exists and belongs to this bucket/key.
-        self.read_upload_meta(&upload_id).await?;
+        {
+            let lock = self.lock_for(&bucket, &key);
+            let _guard = lock.lock().await;
+            self.read_matching_upload_meta(&upload_id, &bucket, &key)
+                .await?;
+        }
 
         let dst = multipart::part_path(&upload_id, i64::from(part_number));
+        let tmp = self.reserve_staging_path();
         let body = req
             .input
             .body
             .take()
             .ok_or_else(|| s3_error!(InvalidArgument, "missing body"))?;
         let mut body = body;
-        let (_size, etag) = self.write_blob(&dst, &mut body).await?;
+        let (_size, etag) = self.write_blob(tmp.path(), &mut body).await?;
 
-        let attr = self.vfs.stat(&dst).await.map_err(Self::err)?;
-        self.set_xattr(attr.ino, XATTR_ETAG, &etag).await?;
+        let publish_result: S3Result<()> = async {
+            let lock = self.lock_for(&bucket, &key);
+            let _guard = lock.lock().await;
+            self.read_matching_upload_meta(&upload_id, &bucket, &key)
+                .await?;
+            let attr = self.vfs.stat(&tmp).await.map_err(Self::err)?;
+            self.set_xattr(attr.ino, XATTR_ETAG, &etag).await?;
+            self.vfs.rename(&tmp, &dst).await.map_err(Self::err)
+        }
+        .await;
+        if let Err(e) = publish_result {
+            let _ = self.vfs.unlink(&tmp).await;
+            return Err(e);
+        }
 
         Ok(S3Response::new(UploadPartOutput {
             e_tag: Some(ETag::Strong(etag)),
@@ -1176,12 +1478,34 @@ where
     ) -> S3Result<S3Response<ListPartsOutput>> {
         let input = req.input;
         let upload_id = input.upload_id.clone();
-        let meta = self.read_upload_meta(&upload_id).await?;
+        let bucket = input.bucket.as_str().to_string();
+        let key = input.key.as_str().to_string();
+        let max_parts = input.max_parts.unwrap_or(1000);
+        if !(0..=1000).contains(&max_parts) {
+            return Err(s3_error!(
+                InvalidArgument,
+                "max-parts must be between 0 and 1000"
+            ));
+        }
+        let part_number_marker = input.part_number_marker.unwrap_or(0);
+        if !(0..=MAX_MULTIPART_PART_NUMBER).contains(&part_number_marker) {
+            return Err(s3_error!(
+                InvalidArgument,
+                "part-number-marker must be between 0 and {MAX_MULTIPART_PART_NUMBER}"
+            ));
+        }
+        let lock = self.lock_for(&bucket, &key);
+        let _guard = lock.lock().await;
+        let meta = self
+            .read_matching_upload_meta(&upload_id, &bucket, &key)
+            .await?;
 
         let dir = multipart::upload_dir(&upload_id);
-        let mut parts: Vec<(i64, u64, i64, Option<String>)> = Vec::new();
+        let mut parts: Vec<(i32, u64, i64, Option<String>)> = Vec::new();
         for entry in self.read_dir_entries(&dir).await? {
             if let Some(n) = parse_part_name(&entry.name)
+                && let Ok(n) = i32::try_from(n)
+                && valid_part_number(n)
                 && let Some(attr) = self.vfs.stat_ino(entry.ino).await
             {
                 let etag = self.read_etag(entry.ino).await;
@@ -1189,16 +1513,33 @@ where
             }
         }
         parts.sort_by_key(|p| p.0);
+        parts.retain(|part| part.0 > part_number_marker);
+        let is_truncated = max_parts > 0 && parts.len() > max_parts as usize;
+        parts.truncate(max_parts as usize);
+        let next_part_number_marker = if is_truncated {
+            Some(
+                parts
+                    .last()
+                    .map(|part| part.0)
+                    .unwrap_or(part_number_marker),
+            )
+        } else {
+            None
+        };
 
         Ok(S3Response::new(ListPartsOutput {
             bucket: Some(input.bucket),
             key: Some(ObjectKey::from(meta.key)),
             upload_id: Some(MultipartUploadId::from(upload_id)),
+            max_parts: Some(max_parts),
+            part_number_marker: Some(part_number_marker),
+            is_truncated: Some(is_truncated),
+            next_part_number_marker,
             parts: Some(
                 parts
                     .into_iter()
                     .map(|(n, size, mtime, etag)| Part {
-                        part_number: Some(n as i32),
+                        part_number: Some(n),
                         size: Some(size as i64),
                         last_modified: Some(Timestamp::from(
                             UNIX_EPOCH + Duration::from_nanos(mtime.max(0) as u64),
@@ -1221,11 +1562,6 @@ where
         let key = input.key.as_str().to_string();
         let upload_id = input.upload_id.clone();
 
-        let meta = self.read_upload_meta(&upload_id).await?;
-        if meta.bucket != bucket || meta.key != key {
-            return Err(s3_error!(NoSuchUpload, "upload does not match bucket/key"));
-        }
-
         let completed = input
             .multipart_upload
             .and_then(|m| m.parts)
@@ -1233,18 +1569,29 @@ where
 
         let lock = self.lock_for(&bucket, &key);
         let _guard = lock.lock().await;
+        let meta = self
+            .read_matching_upload_meta(&upload_id, &bucket, &key)
+            .await?;
 
         // Validate part ordering and etags.
         let mut part_etags: Vec<String> = Vec::with_capacity(completed.len());
-        let mut part_files: Vec<(i64, String)> = Vec::with_capacity(completed.len());
-        for (expected, part) in (1i32..).zip(&completed) {
+        let mut part_attrs: Vec<FileAttr> = Vec::with_capacity(completed.len());
+        let mut previous_part_number = None;
+        for part in &completed {
             let n = part.part_number.unwrap_or(0);
-            if n != expected {
+            if !valid_part_number(n) {
                 return Err(s3_error!(
-                    InvalidPartOrder,
-                    "parts must be ascending starting at 1 (got {n}, expected {expected})"
+                    InvalidArgument,
+                    "part number must be between 1 and {MAX_MULTIPART_PART_NUMBER}"
                 ));
             }
+            if previous_part_number.is_some_and(|previous| n <= previous) {
+                return Err(s3_error!(
+                    InvalidPartOrder,
+                    "parts must be in strictly ascending order"
+                ));
+            }
+            previous_part_number = Some(n);
             let src = multipart::part_path(&upload_id, i64::from(n));
             let attr = match self.vfs.stat(&src).await {
                 Ok(a) => a,
@@ -1255,76 +1602,72 @@ where
             if !is_last && attr.size < 5 * 1024 * 1024 {
                 return Err(s3_error!(EntityTooSmall, "part {n} is smaller than 5 MiB"));
             }
-            let stored = self.read_etag(attr.ino).await;
-            if let (Some(want), Some(have)) = (part.e_tag.as_ref(), stored.as_ref())
-                && want.value() != have
-            {
+            let stored = self
+                .read_etag(attr.ino)
+                .await
+                .ok_or_else(|| s3_error!(InvalidPart, "part {n} has no etag"))?;
+            let requested = part
+                .e_tag
+                .as_ref()
+                .ok_or_else(|| s3_error!(InvalidPart, "part {n} has no etag"))?;
+            if requested.value() != stored {
                 return Err(s3_error!(InvalidPart, "etag mismatch on part {n}"));
             }
-            part_etags.push(stored.unwrap_or_default());
-            part_files.push((i64::from(n), src));
+            part_etags.push(stored);
+            part_attrs.push(attr);
         }
 
         // Concatenate parts into a staging file, then publish atomically.
-        let tmp = format!("{}/{}", multipart::tmp_dir(), new_upload_id());
-        if self.vfs.exists(&tmp).await {
-            self.vfs.unlink(&tmp).await.map_err(Self::err)?;
+        let tmp = self.reserve_staging_path();
+        if self.vfs.exists(tmp.path()).await {
+            self.vfs.unlink(tmp.path()).await.map_err(Self::err)?;
         }
-        let tmp_ino = self.vfs.create_file(&tmp).await.map_err(Self::err)?;
-        let tmp_attr = self.vfs.stat(&tmp).await.map_err(Self::err)?;
-        let out_guard = self
-            .vfs
-            .open_guard(tmp_ino, tmp_attr, false, true)
-            .await
-            .map_err(Self::err)?;
-
-        let mut offset: u64 = 0;
-        for (_, src) in &part_files {
-            let attr = self.vfs.stat(src).await.map_err(Self::err)?;
-            let size = attr.size;
-            let in_guard = self
-                .vfs
-                .open_guard(attr.ino, attr, true, false)
-                .await
-                .map_err(Self::err)?;
-            let mut pos: u64 = 0;
-            while pos < size {
-                let len = (size - pos).min(STREAM_CHUNK) as usize;
-                let chunk = in_guard.read(pos, len).await.map_err(Self::err)?;
-                if chunk.is_empty() {
-                    break;
-                }
-                out_guard.write(offset, &chunk).await.map_err(Self::err)?;
-                offset += chunk.len() as u64;
-                pos += chunk.len() as u64;
-            }
-            in_guard.close().await.map_err(Self::err)?;
-        }
-        out_guard.close().await.map_err(Self::err)?;
-
+        let tmp_ino = self.vfs.create_file(tmp.path()).await.map_err(Self::err)?;
         let target =
             path::object_path(&self.opts.bucket_mode, &bucket, &key).map_err(Self::path_err)?;
-        if let Some(parent) = std::path::Path::new(&target).parent() {
-            let parent = parent.to_string_lossy().to_string();
-            if !parent.is_empty() {
-                self.vfs.mkdir_p(&parent).await.map_err(Self::err)?;
-            }
-        }
-        self.vfs.rename(&tmp, &target).await.map_err(Self::err)?;
-        let final_attr = self.vfs.stat(&target).await.map_err(Self::err)?;
-
         let etag = multipart_etag(&part_etags);
         let object_meta = ObjectMeta {
             content_type: meta.content_type.clone(),
             metadata: meta.metadata.clone(),
         };
-        self.set_xattr(final_attr.ino, XATTR_ETAG, &etag).await?;
-        self.set_xattr(
-            final_attr.ino,
-            XATTR_META,
-            &serde_json::to_string(&object_meta).unwrap(),
-        )
-        .await?;
+
+        let bucket_lock = self.bucket_lock_for(&bucket);
+        let _bucket_guard = bucket_lock.lock().await;
+        let publish_result: S3Result<()> = async {
+            self.stat_bucket_root(&bucket).await?;
+            let mut offset = 0;
+            for attr in &part_attrs {
+                self.copy_range_exact(attr.ino, 0, tmp_ino, offset, attr.size)
+                    .await?;
+                offset += attr.size;
+            }
+            self.set_xattr(tmp_ino, XATTR_ETAG, &etag).await?;
+            self.set_xattr(
+                tmp_ino,
+                XATTR_META,
+                &serde_json::to_string(&object_meta).unwrap(),
+            )
+            .await?;
+
+            if let Some(parent) = std::path::Path::new(&target).parent() {
+                let parent = parent.to_string_lossy().to_string();
+                if !parent.is_empty() {
+                    self.vfs.mkdir_p(&parent).await.map_err(Self::err)?;
+                }
+            }
+            if self.vfs.exists(&target).await {
+                let attr = self.vfs.stat(&target).await.map_err(Self::err)?;
+                if attr.kind == FileType::Dir {
+                    return Err(s3_error!(InvalidArgument, "target is a directory"));
+                }
+            }
+            self.vfs.rename(&tmp, &target).await.map_err(Self::err)
+        }
+        .await;
+        if let Err(e) = publish_result {
+            let _ = self.vfs.unlink(&tmp).await;
+            return Err(e);
+        };
 
         // Drop the upload state.
         let upload_dir = multipart::upload_dir(&upload_id);
@@ -1346,7 +1689,12 @@ where
     ) -> S3Result<S3Response<AbortMultipartUploadOutput>> {
         let input = req.input;
         let upload_id = input.upload_id.clone();
-        self.read_upload_meta(&upload_id).await?;
+        let bucket = input.bucket.as_str().to_string();
+        let key = input.key.as_str().to_string();
+        let lock = self.lock_for(&bucket, &key);
+        let _guard = lock.lock().await;
+        self.read_matching_upload_meta(&upload_id, &bucket, &key)
+            .await?;
         let dir = multipart::upload_dir(&upload_id);
         super::remove_dir_all_rec(&self.vfs, &dir)
             .await
@@ -1365,36 +1713,137 @@ where
             .as_ref()
             .map(|p| p.as_str().to_string())
             .unwrap_or_default();
+        let delimiter = input
+            .delimiter
+            .as_ref()
+            .map(|d| d.as_str().to_string())
+            .filter(|d| !d.is_empty());
+        let key_marker = input
+            .key_marker
+            .as_ref()
+            .map(|marker| marker.as_str().to_string())
+            .unwrap_or_default();
+        let upload_id_marker = input
+            .upload_id_marker
+            .as_ref()
+            .map(|marker| marker.as_str().to_string())
+            .unwrap_or_default();
+        let max_uploads = input.max_uploads.unwrap_or(1000);
+        if !(1..=1000).contains(&max_uploads) {
+            return Err(s3_error!(
+                InvalidArgument,
+                "max-uploads must be between 1 and 1000"
+            ));
+        }
+        path::validate_key_namespace(&self.opts.bucket_mode, &prefix).map_err(Self::path_err)?;
+        self.stat_bucket_root(&bucket).await?;
 
         let mut uploads = Vec::new();
+        let mut common_prefixes = std::collections::BTreeSet::new();
         for hh in self.read_dir_entries(&multipart::uploads_dir()).await? {
             let hh_dir = format!("{}/{}", multipart::uploads_dir(), hh.name);
             for upload in self.read_dir_entries(&hh_dir).await? {
-                let upload_id = upload.name.clone();
-                if let Ok(meta) = self.read_upload_meta(&upload_id).await
-                    && meta.bucket == bucket
-                    && (prefix.is_empty() || meta.key.starts_with(&prefix))
+                let upload_id = upload.name;
+                let Ok(meta) = self.read_upload_meta(&upload_id).await else {
+                    continue;
+                };
+                if meta.bucket != bucket || !meta.key.starts_with(&prefix) {
+                    continue;
+                }
+                if let Some(delimiter) = delimiter.as_deref()
+                    && let Some(relative) = meta.key.strip_prefix(&prefix)
+                    && let Some(index) = relative.find(delimiter)
                 {
-                    uploads.push(MultipartUpload {
-                        key: Some(ObjectKey::from(meta.key)),
-                        upload_id: Some(MultipartUploadId::from(upload_id)),
-                        initiated: Some(Timestamp::from(
-                            UNIX_EPOCH + Duration::from_secs(meta.initiated.max(0) as u64),
-                        )),
-                        storage_class: Some(StorageClass::from_static(StorageClass::STANDARD)),
-                        ..Default::default()
-                    });
+                    let end = prefix.len() + index + delimiter.len();
+                    let common_prefix = meta.key[..end].to_string();
+                    if key_marker.is_empty() || common_prefix > key_marker {
+                        common_prefixes.insert(common_prefix);
+                    }
+                    continue;
+                }
+                let after_marker = key_marker.is_empty()
+                    || meta.key > key_marker
+                    || (meta.key == key_marker
+                        && !upload_id_marker.is_empty()
+                        && upload_id > upload_id_marker);
+                if after_marker {
+                    uploads.push((meta.key, upload_id, meta.initiated));
                 }
             }
         }
-        uploads.sort_by(|a, b| a.key.cmp(&b.key));
+        uploads.sort_by(|a, b| (&a.0, &a.1).cmp(&(&b.0, &b.1)));
+
+        let mut entries = uploads
+            .into_iter()
+            .map(|upload| (upload.0.clone(), Some(upload)))
+            .chain(common_prefixes.into_iter().map(|prefix| (prefix, None)))
+            .collect::<Vec<_>>();
+        entries.sort_by(|a, b| {
+            a.0.cmp(&b.0).then_with(|| match (&a.1, &b.1) {
+                (Some(a), Some(b)) => a.1.cmp(&b.1),
+                (None, Some(_)) => std::cmp::Ordering::Less,
+                (Some(_), None) => std::cmp::Ordering::Greater,
+                (None, None) => std::cmp::Ordering::Equal,
+            })
+        });
+        let is_truncated = entries.len() > max_uploads as usize;
+        entries.truncate(max_uploads as usize);
+
+        let (next_key_marker, next_upload_id_marker) = if is_truncated {
+            entries
+                .last()
+                .map(|entry| {
+                    (
+                        Some(NextKeyMarker::from(entry.0.clone())),
+                        entry
+                            .1
+                            .as_ref()
+                            .map(|upload| NextUploadIdMarker::from(upload.1.clone())),
+                    )
+                })
+                .unwrap_or_default()
+        } else {
+            (None, None)
+        };
+        let mut output_uploads = Vec::new();
+        let mut output_prefixes = Vec::new();
+        for (entry_key, upload) in entries {
+            if let Some((key, upload_id, initiated)) = upload {
+                output_uploads.push(MultipartUpload {
+                    key: Some(ObjectKey::from(key)),
+                    upload_id: Some(MultipartUploadId::from(upload_id)),
+                    initiated: Some(Timestamp::from(
+                        UNIX_EPOCH + Duration::from_secs(initiated.max(0) as u64),
+                    )),
+                    storage_class: Some(StorageClass::from_static(StorageClass::STANDARD)),
+                    ..Default::default()
+                });
+            } else {
+                output_prefixes.push(CommonPrefix {
+                    prefix: Some(Prefix::from(entry_key)),
+                });
+            }
+        }
 
         Ok(S3Response::new(ListMultipartUploadsOutput {
             bucket: Some(input.bucket),
-            uploads: if uploads.is_empty() {
+            delimiter: input.delimiter,
+            prefix: input.prefix,
+            key_marker: input.key_marker,
+            upload_id_marker: input.upload_id_marker,
+            max_uploads: Some(max_uploads),
+            is_truncated: Some(is_truncated),
+            next_key_marker,
+            next_upload_id_marker,
+            common_prefixes: if output_prefixes.is_empty() {
                 None
             } else {
-                Some(uploads)
+                Some(output_prefixes)
+            },
+            uploads: if output_uploads.is_empty() {
+                None
+            } else {
+                Some(output_uploads)
             },
             ..Default::default()
         }))
@@ -1413,4 +1862,35 @@ fn prefixes_to_dto(prefixes: &std::collections::BTreeSet<String>) -> Option<Vec<
             })
             .collect(),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn key_lock_shards_are_bounded_and_stable() {
+        let shard = key_lock_shard("bucket", "key");
+        assert!(shard < KEY_LOCK_SHARDS);
+        assert_eq!(shard, key_lock_shard("bucket", "key"));
+        assert_eq!(
+            key_lock_shard("bucket", "dir"),
+            key_lock_shard("bucket", "dir//")
+        );
+    }
+
+    #[test]
+    fn bucket_lock_shards_are_bounded_and_stable() {
+        let shard = bucket_lock_shard("bucket");
+        assert!(shard < BUCKET_LOCK_SHARDS);
+        assert_eq!(shard, bucket_lock_shard("bucket"));
+    }
+
+    #[test]
+    fn multipart_part_numbers_are_bounded() {
+        assert!(!valid_part_number(0));
+        assert!(valid_part_number(1));
+        assert!(valid_part_number(10_000));
+        assert!(!valid_part_number(10_001));
+    }
 }

--- a/src/gateway/s3/store.rs
+++ b/src/gateway/s3/store.rs
@@ -1,0 +1,1340 @@
+//! S3 object layer on top of the BrewFS VFS.
+//!
+//! Implements the `s3s::S3` trait (see `doc/protocols/s3-gateway.md` §4 for
+//! the mapping table). All object data lives in the volume as regular files;
+//! protocol metadata (etag, content-type, user metadata, directory-object
+//! markers) lives in xattrs; multipart state lives under
+//! `/.brewfs.sys/s3/`.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use async_trait::async_trait;
+use dashmap::DashMap;
+use futures::StreamExt;
+use s3s::dto::*;
+use s3s::{S3, S3Error, S3Request, S3Response, S3Result, s3_error};
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+
+use crate::chunk::store::BlockStore;
+use crate::gateway::s3::list::{ListCollector, ListQuery};
+use crate::gateway::s3::multipart::{
+    self, UploadMeta, multipart_etag, new_upload_id, parse_part_name,
+};
+use crate::gateway::s3::path::{self, BucketMode, PathError};
+use crate::meta::MetaStore;
+use crate::meta::client::MetaClient;
+use crate::meta::store::{DirEntry, FileAttr, FileType};
+use crate::vfs::fs::VFS;
+
+/// Default content type when none is stored or provided.
+const DEFAULT_CONTENT_TYPE: &str = "binary/octet-stream";
+
+/// xattr carrying the object ETag.
+pub const XATTR_ETAG: &str = "brewfs.s3.etag";
+/// xattr carrying content-type + user metadata as JSON.
+pub const XATTR_META: &str = "brewfs.s3.meta";
+/// xattr marking an explicit S3 directory object.
+pub const XATTR_DIROBJ: &str = "brewfs.s3.dirobj";
+
+/// Read chunk size for streaming copies and GET bodies.
+const STREAM_CHUNK: u64 = 4 * 1024 * 1024;
+
+/// Maximum directory recursion depth during listings (defensive bound).
+const MAX_WALK_DEPTH: usize = 64;
+
+/// Name of the hidden system directory at the volume root.
+const SYS_DIR_NAME: &str = ".brewfs.sys";
+
+/// JSON payload stored in the `brewfs.s3.meta` xattr.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct ObjectMeta {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    content_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    metadata: Option<HashMap<String, String>>,
+}
+
+/// Behavior options of the S3 gateway.
+#[derive(Debug, Clone)]
+pub struct S3Options {
+    pub bucket_mode: BucketMode,
+    pub hide_dir_objects: bool,
+}
+
+/// The S3 object layer over one BrewFS volume.
+pub struct BrewFsS3<S: BlockStore + Send + Sync + 'static> {
+    vfs: VFS<S, MetaClient<dyn MetaStore>>,
+    opts: S3Options,
+    /// Per-(bucket,key) write serialization within this gateway instance.
+    locks: DashMap<String, Arc<Mutex<()>>>,
+}
+
+impl<S> BrewFsS3<S>
+where
+    S: BlockStore + Send + Sync + 'static,
+{
+    pub fn new(vfs: VFS<S, MetaClient<dyn MetaStore>>, opts: S3Options) -> Self {
+        Self {
+            vfs,
+            opts,
+            locks: DashMap::new(),
+        }
+    }
+
+    /// Grants access to the underlying VFS (used by the cleanup task).
+    pub fn vfs(&self) -> &VFS<S, MetaClient<dyn MetaStore>> {
+        &self.vfs
+    }
+
+    fn lock_for(&self, bucket: &str, key: &str) -> Arc<Mutex<()>> {
+        let id = format!("{bucket}/{key}");
+        Arc::clone(self.locks.entry(id).or_default().value())
+    }
+
+    // ---- error mapping ----------------------------------------------------
+
+    fn err(e: crate::vfs::error::VfsError) -> S3Error {
+        use crate::vfs::error::VfsError;
+        match e {
+            VfsError::NotFound { .. } => s3_error!(NoSuchKey, "object not found"),
+            VfsError::AlreadyExists { .. } => {
+                s3_error!(BucketAlreadyExists, "target already exists")
+            }
+            VfsError::NotADirectory { .. } => {
+                s3_error!(InvalidArgument, "a path component is not a directory")
+            }
+            VfsError::IsADirectory { .. } => s3_error!(NoSuchKey, "is a directory"),
+            VfsError::DirectoryNotEmpty { .. } => s3_error!(BucketNotEmpty, "not empty"),
+            VfsError::PermissionDenied { .. } => s3_error!(AccessDenied, "permission denied"),
+            VfsError::InvalidInput => s3_error!(InvalidArgument, "invalid input"),
+            VfsError::ReadOnlyFilesystem { .. } => s3_error!(AccessDenied, "read-only"),
+            other => s3_error!(InternalError, "vfs error: {other}"),
+        }
+    }
+
+    fn path_err(e: PathError) -> S3Error {
+        match e {
+            PathError::InvalidBucket(b) => s3_error!(NoSuchBucket, "bucket not found: {b}"),
+            PathError::InvalidKey(k) => s3_error!(InvalidArgument, "invalid object key: {k}"),
+        }
+    }
+
+    // ---- helpers ------------------------------------------------------------
+
+    async fn stat_bucket_root(&self, bucket: &str) -> S3Result<FileAttr> {
+        let root = path::bucket_root(&self.opts.bucket_mode, bucket)
+            .map_err(Self::path_err)?;
+        let attr = self.vfs.stat(&root).await.map_err(Self::err)?;
+        if attr.kind != FileType::Dir {
+            return Err(s3_error!(NoSuchBucket, "bucket not found: {bucket}"));
+        }
+        Ok(attr)
+    }
+
+    async fn read_dir_entries(&self, dir_path: &str) -> S3Result<Vec<DirEntry>> {
+        let attr = match self.vfs.stat(dir_path).await {
+            Ok(a) => a,
+            Err(crate::vfs::error::VfsError::NotFound { .. }) => return Ok(Vec::new()),
+            Err(e) => return Err(Self::err(e)),
+        };
+        if attr.kind != FileType::Dir {
+            return Ok(Vec::new());
+        }
+        let fh = self.vfs.opendir(attr.ino).await.map_err(Self::err)?;
+        let entries = self.vfs.readdir(fh, 0).unwrap_or_default();
+        self.vfs.closedir(fh).map_err(Self::err)?;
+        Ok(entries)
+    }
+
+    async fn get_xattr(&self, ino: i64, name: &str) -> Option<String> {
+        match self.vfs.get_xattr_ino(ino, name).await {
+            Ok(Some(bytes)) => String::from_utf8(bytes).ok(),
+            _ => None,
+        }
+    }
+
+    async fn set_xattr(&self, ino: i64, name: &str, value: &str) -> S3Result<()> {
+        self.vfs
+            .set_xattr_ino(ino, name, value.as_bytes(), 0)
+            .await
+            .map_err(Self::err)
+    }
+
+    async fn read_etag(&self, ino: i64) -> Option<String> {
+        self.get_xattr(ino, XATTR_ETAG).await
+    }
+
+    async fn read_object_meta(&self, ino: i64) -> ObjectMeta {
+        self.get_xattr(ino, XATTR_META)
+            .await
+            .and_then(|raw| serde_json::from_str(&raw).ok())
+            .unwrap_or_default()
+    }
+
+    async fn is_dir_object(&self, ino: i64) -> bool {
+        self.get_xattr(ino, XATTR_DIROBJ).await.is_some()
+    }
+
+    /// ETag reported for objects written outside the gateway (no stored etag).
+    fn fallback_etag(attr: &FileAttr) -> String {
+        format!("{:x}-{:x}", attr.ino, attr.mtime)
+    }
+
+    fn mtime_timestamp(attr: &FileAttr) -> Option<Timestamp> {
+        // VFS file attrs carry mtime in nanoseconds.
+        Some(Timestamp::from(UNIX_EPOCH + Duration::from_nanos(
+            attr.mtime.max(0) as u64,
+        )))
+    }
+
+    /// Streams a blob into `dst` (created/truncated), returning size and MD5.
+    async fn write_blob(
+        &self,
+        dst: &str,
+        body: &mut StreamingBlob,
+    ) -> S3Result<(u64, String)> {
+        if self.vfs.exists(dst).await {
+            self.vfs.unlink(dst).await.map_err(Self::err)?;
+        }
+        let ino = self.vfs.create_file(dst).await.map_err(Self::err)?;
+        let attr = self.vfs.stat(dst).await.map_err(Self::err)?;
+        let guard = self
+            .vfs
+            .open_guard(ino, attr, false, true)
+            .await
+            .map_err(Self::err)?;
+
+        let mut offset: u64 = 0;
+        let mut md = md5::Context::new();
+        while let Some(chunk) = body.next().await {
+            let chunk = chunk.map_err(|e| s3_error!(InternalError, "body read: {e}"))?;
+            if !chunk.is_empty() {
+                guard
+                    .write(offset, &chunk)
+                    .await
+                    .map_err(Self::err)?;
+                md.consume(&chunk);
+                offset += chunk.len() as u64;
+            }
+        }
+        guard.close().await.map_err(Self::err)?;
+        let etag = format!("{:x}", md.compute());
+        Ok((offset, etag))
+    }
+
+    /// Reads a byte range of a file as a streaming blob. Chunks are produced
+    /// by a spawned task and forwarded through an mpsc channel (the channel
+    /// receiver is `Send + Sync`, as required by `StreamingBlob::wrap`).
+    fn read_stream(
+        &self,
+        attr: FileAttr,
+        offset: u64,
+        length: u64,
+    ) -> S3Result<StreamingBlob> {
+        let ino = attr.ino;
+        let vfs = self.vfs.clone();
+        let (mut tx, rx) = futures::channel::mpsc::channel::<
+            Result<bytes::Bytes, std::io::Error>,
+        >(4);
+        tokio::spawn(async move {
+            let mut offset = offset;
+            let mut remaining = length;
+            while remaining > 0 {
+                let len = remaining.min(STREAM_CHUNK) as usize;
+                // Open a short-lived read guard per chunk; the VFS read path
+                // caches open handles, so this stays cheap.
+                let guard = match vfs.stat_ino(ino).await {
+                    Some(a) => vfs.open_guard(ino, a, true, false).await,
+                    None => {
+                        let _ = tx
+                            .try_send(Err(std::io::Error::other(
+                                "object deleted during read",
+                            )));
+                        break;
+                    }
+                };
+                let guard = match guard {
+                    Ok(g) => g,
+                    Err(e) => {
+                        let _ = tx
+                            .try_send(Err(std::io::Error::other(format!("open: {e}"))));
+                        break;
+                    }
+                };
+                match guard.read(offset, len).await {
+                    Ok(data) => {
+                        let n = data.len() as u64;
+                        drop(guard);
+                        if tx
+                            .try_send(Ok(bytes::Bytes::from(data)))
+                            .is_err()
+                        {
+                            break;
+                        }
+                        offset += n;
+                        remaining -= n;
+                    }
+                    Err(e) => {
+                        drop(guard);
+                        let _ = tx
+                            .try_send(Err(std::io::Error::other(format!("read: {e}"))));
+                        break;
+                    }
+                }
+            }
+        });
+        Ok(StreamingBlob::wrap(rx))
+    }
+
+    /// Copies `src` into a fresh tmp file and renames it to `dst` (atomic publish).
+    async fn copy_object_data(&self, src: &str, dst: &str) -> S3Result<(u64, FileAttr)> {
+        let src_attr = self.vfs.stat(src).await.map_err(Self::err)?;
+        let tmp = format!("{}/{}", multipart::tmp_dir(), new_upload_id());
+        if self.vfs.exists(&tmp).await {
+            self.vfs.unlink(&tmp).await.map_err(Self::err)?;
+        }
+        let tmp_ino = self.vfs.create_file(&tmp).await.map_err(Self::err)?;
+        let tmp_attr = self.vfs.stat(&tmp).await.map_err(Self::err)?;
+        let dst_guard = self
+            .vfs
+            .open_guard(tmp_ino, tmp_attr, false, true)
+            .await
+            .map_err(Self::err)?;
+        let src_guard = self
+            .vfs
+            .open_guard(src_attr.ino, src_attr.clone(), true, false)
+            .await
+            .map_err(Self::err)?;
+
+        let mut offset: u64 = 0;
+        while offset < src_attr.size {
+            let len = (src_attr.size - offset).min(STREAM_CHUNK) as usize;
+            let chunk = src_guard.read(offset, len).await.map_err(Self::err)?;
+            if chunk.is_empty() {
+                break;
+            }
+            dst_guard.write(offset, &chunk).await.map_err(Self::err)?;
+            offset += chunk.len() as u64;
+        }
+        src_guard.close().await.map_err(Self::err)?;
+        dst_guard.close().await.map_err(Self::err)?;
+
+        if let Some(parent) = std::path::Path::new(dst).parent() {
+            let parent = parent.to_string_lossy().to_string();
+            if !parent.is_empty() {
+                self.vfs.mkdir_p(&parent).await.map_err(Self::err)?;
+            }
+        }
+        if self.vfs.exists(dst).await {
+            let attr = self.vfs.stat(dst).await.map_err(Self::err)?;
+            if attr.kind == FileType::Dir {
+                let _ = self.vfs.unlink(&tmp).await;
+                return Err(s3_error!(InvalidArgument, "target is a directory"));
+            }
+        }
+        self.vfs.rename(&tmp, dst).await.map_err(Self::err)?;
+        let final_attr = self.vfs.stat(dst).await.map_err(Self::err)?;
+        Ok((final_attr.size, final_attr))
+    }
+
+    /// Removes empty implicit parent directories left behind after a delete,
+    /// stopping at the bucket root, at the volume root, or at the first
+    /// directory object / non-empty directory.
+    async fn prune_empty_parents(&self, key_path: &str, bucket_root: &str) {
+        let mut current = key_path.to_string();
+        while let Some(parent) = std::path::Path::new(&current)
+            .parent()
+            .map(|p| p.to_string_lossy().to_string())
+        {
+            if parent.is_empty() || parent == "/" || parent == bucket_root {
+                return;
+            }
+            if parent.ends_with(SYS_DIR_NAME) || parent.contains(SYS_DIR_NAME) {
+                return;
+            }
+            let Ok(attr) = self.vfs.stat(&parent).await else {
+                return;
+            };
+            if attr.kind != FileType::Dir {
+                return;
+            }
+            if self.is_dir_object(attr.ino).await {
+                return;
+            }
+            let Ok(entries) = self.read_dir_entries(&parent).await else {
+                return;
+            };
+            if !entries.is_empty() {
+                return;
+            }
+            if self.vfs.rmdir(&parent).await.is_err() {
+                return;
+            }
+            current = parent;
+        }
+    }
+
+    /// Deletes one object; shared by DeleteObject and DeleteObjects.
+    async fn delete_object_internal(&self, bucket: &str, key: &str) -> S3Result<()> {
+        let mode = &self.opts.bucket_mode;
+        let bucket_root = path::bucket_root(mode, bucket).map_err(Self::path_err)?;
+        let target = path::object_path(mode, bucket, key).map_err(Self::path_err)?;
+
+        if target == bucket_root || target == "/" {
+            // Deleting the bucket root via the object API is not allowed.
+            return Err(s3_error!(InvalidArgument, "cannot delete bucket root"));
+        }
+
+        let attr = match self.vfs.stat(&target).await {
+            Ok(a) => a,
+            Err(crate::vfs::error::VfsError::NotFound { .. }) => return Ok(()),
+            Err(e) => return Err(Self::err(e)),
+        };
+
+        if attr.kind == FileType::Dir {
+            // Directory object delete: drop the marker; remove the directory
+            // itself only if it is empty.
+            let _ = self.vfs.remove_xattr_ino(attr.ino, XATTR_DIROBJ).await;
+            let entries = self.read_dir_entries(&target).await?;
+            if entries.is_empty() {
+                self.vfs.rmdir(&target).await.map_err(Self::err)?;
+            }
+            return Ok(());
+        }
+
+        self.vfs.unlink(&target).await.map_err(Self::err)?;
+        self.prune_empty_parents(&target, &bucket_root).await;
+        Ok(())
+    }
+
+    /// Resolves an object and decides whether it is visible as an object
+    /// (file, or directory with the dir-object marker when `allow_dir_obj`).
+    async fn resolve_object(
+        &self,
+        mode: &BucketMode,
+        bucket: &str,
+        key: &str,
+    ) -> S3Result<(String, FileAttr, bool)> {
+        self.stat_bucket_root(bucket).await?;
+        let target = path::object_path(mode, bucket, key).map_err(Self::path_err)?;
+        if target == "/" {
+            return Err(s3_error!(NoSuchKey, "no such object"));
+        }
+        let attr = match self.vfs.stat(&target).await {
+            Ok(a) => a,
+            Err(e) => return Err(Self::err(e)),
+        };
+        if attr.kind == FileType::Dir {
+            let dirobj = key.ends_with('/') && self.is_dir_object(attr.ino).await;
+            if !dirobj {
+                return Err(s3_error!(NoSuchKey, "no such object"));
+            }
+            return Ok((target, attr, true));
+        }
+        Ok((target, attr, false))
+    }
+
+    // ---- listing ------------------------------------------------------------
+
+    #[async_recursion::async_recursion]
+    async fn walk_dir(
+        &self,
+        dir_path: &str,
+        parent_key: &str,
+        at_root: bool,
+        collector: &mut ListCollector,
+        depth: usize,
+    ) -> S3Result<()> {
+        if depth > MAX_WALK_DEPTH {
+            return Ok(());
+        }
+        let entries = self.read_dir_entries(dir_path).await?;
+        for entry in entries {
+            if at_root && entry.name == SYS_DIR_NAME {
+                continue;
+            }
+            let child_path = format!("{dir_path}/{}", entry.name);
+            let is_dir = entry.kind == FileType::Dir;
+            let mut dirobj = false;
+            let mut etag = None;
+            let (size, mtime) = match self.vfs.stat_ino(entry.ino).await {
+                Some(a) => (a.size, a.mtime),
+                None => (0, 0),
+            };
+            if is_dir {
+                dirobj = self.is_dir_object(entry.ino).await;
+            } else {
+                etag = self.read_etag(entry.ino).await;
+            }
+            collector.push_entry(parent_key, &entry.name, is_dir, size, mtime, dirobj, etag);
+            if is_dir && collector.should_descend(parent_key, &entry.name) {
+                let child_key = format!("{parent_key}{}/", entry.name);
+                self.walk_dir(&child_path, &child_key, false, collector, depth + 1)
+                    .await?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn list_keys(&self, bucket: &str, query: ListQuery) -> S3Result<crate::gateway::s3::list::ListResult> {
+        let mode = &self.opts.bucket_mode;
+        let root = path::bucket_root(mode, bucket).map_err(Self::path_err)?;
+        self.stat_bucket_root(bucket).await?;
+        let mut collector = ListCollector::new(query);
+        self.walk_dir(&root, "", true, &mut collector, 0).await?;
+        Ok(collector.finish())
+    }
+
+    // ---- multipart ------------------------------------------------------------
+
+    async fn read_upload_meta(&self, upload_id: &str) -> S3Result<UploadMeta> {
+        let target = UploadMeta::target_path(upload_id);
+        match self.vfs.stat(&target).await {
+            Ok(attr) => {
+                let size = attr.size;
+                let guard = self
+                    .vfs
+                    .open_guard(attr.ino, attr, true, false)
+                    .await
+                    .map_err(Self::err)?;
+                let data = guard.read(0, size as usize).await.map_err(Self::err)?;
+                guard.close().await.map_err(Self::err)?;
+                serde_json::from_slice(&data)
+                    .map_err(|e| s3_error!(InternalError, "corrupt upload meta: {e}"))
+            }
+            Err(crate::vfs::error::VfsError::NotFound { .. }) => {
+                Err(s3_error!(NoSuchUpload, "no such upload"))
+            }
+            Err(e) => Err(Self::err(e)),
+        }
+    }
+}
+
+#[async_trait]
+impl<S> S3 for BrewFsS3<S>
+where
+    S: BlockStore + Send + Sync + 'static,
+{
+    async fn create_bucket(&self, req: S3Request<CreateBucketInput>) -> S3Result<S3Response<CreateBucketOutput>> {
+        let input = req.input;
+        let bucket = input.bucket.as_str().to_string();
+        match &self.opts.bucket_mode {
+            BucketMode::Single { bucket: expected } => {
+                if bucket == *expected {
+                    return Err(s3_error!(BucketAlreadyOwnedByYou, "bucket already exists"));
+                }
+                Err(s3_error!(
+                    InvalidBucketName,
+                    "this gateway serves a single bucket"
+                ))
+            }
+            BucketMode::Multi => {
+                if !path::is_valid_bucket_name(&bucket) {
+                    return Err(s3_error!(InvalidBucketName, "invalid bucket name"));
+                }
+                let dir = format!("/{bucket}");
+                match self.vfs.mkdir_err(&dir).await {
+                    Ok(_) => Ok(S3Response::new(CreateBucketOutput::default())),
+                    Err(crate::vfs::error::VfsError::AlreadyExists { .. }) => Err(s3_error!(
+                        BucketAlreadyOwnedByYou,
+                        "bucket already exists"
+                    )),
+                    Err(e) => Err(Self::err(e)),
+                }
+            }
+        }
+    }
+
+    async fn delete_bucket(&self, req: S3Request<DeleteBucketInput>) -> S3Result<S3Response<DeleteBucketOutput>> {
+        let input = req.input;
+        let bucket = input.bucket.as_str().to_string();
+        match &self.opts.bucket_mode {
+            BucketMode::Single { .. } => Err(s3_error!(
+                MethodNotAllowed,
+                "cannot delete the volume bucket in single-bucket mode"
+            )),
+            BucketMode::Multi => {
+                let dir = format!("/{bucket}");
+                match self.vfs.rmdir(&dir).await {
+                    Ok(_) => Ok(S3Response::new(DeleteBucketOutput::default())),
+                    Err(crate::vfs::error::VfsError::NotFound { .. }) => {
+                        Err(s3_error!(NoSuchBucket, "no such bucket"))
+                    }
+                    Err(crate::vfs::error::VfsError::DirectoryNotEmpty { .. }) => {
+                        Err(s3_error!(BucketNotEmpty, "bucket is not empty"))
+                    }
+                    Err(e) => Err(Self::err(e)),
+                }
+            }
+        }
+    }
+
+    async fn head_bucket(&self, req: S3Request<HeadBucketInput>) -> S3Result<S3Response<HeadBucketOutput>> {
+        self.stat_bucket_root(req.input.bucket.as_str()).await?;
+        Ok(S3Response::new(HeadBucketOutput::default()))
+    }
+
+    async fn list_buckets(&self, _req: S3Request<ListBucketsInput>) -> S3Result<S3Response<ListBucketsOutput>> {
+        let owner = Owner::default();
+        let buckets = match &self.opts.bucket_mode {
+            BucketMode::Single { bucket } => vec![Bucket {
+                name: Some(bucket.clone()),
+                creation_date: None,
+                bucket_region: None,
+            }],
+            BucketMode::Multi => {
+                let mut out = Vec::new();
+                for entry in self.read_dir_entries("/").await? {
+                    if entry.name == SYS_DIR_NAME || entry.kind != FileType::Dir {
+                        continue;
+                    }
+                    if path::is_valid_bucket_name(&entry.name) {
+                        out.push(Bucket {
+                            name: Some(entry.name.clone()),
+                            creation_date: None,
+                            bucket_region: None,
+                        });
+                    }
+                }
+                out
+            }
+        };
+        Ok(S3Response::new(ListBucketsOutput {
+            buckets: Some(buckets),
+            owner: Some(owner),
+            ..Default::default()
+        }))
+    }
+
+    async fn get_bucket_location(
+        &self,
+        _req: S3Request<GetBucketLocationInput>,
+    ) -> S3Result<S3Response<GetBucketLocationOutput>> {
+        Ok(S3Response::new(GetBucketLocationOutput::default()))
+    }
+
+    async fn put_object(&self, mut req: S3Request<PutObjectInput>) -> S3Result<S3Response<PutObjectOutput>> {
+        let input = &mut req.input;
+        let bucket = input.bucket.as_str().to_string();
+        let key = input.key.as_str().to_string();
+        let mode = &self.opts.bucket_mode;
+        self.stat_bucket_root(&bucket).await?;
+        let target = path::object_path(mode, &bucket, &key).map_err(Self::path_err)?;
+        if target == "/" {
+            return Err(s3_error!(InvalidArgument, "empty key"));
+        }
+
+        let content_type = input
+            .content_type
+            .as_ref()
+            .map(|ct| ct.as_str().to_string());
+        let metadata: HashMap<String, String> = input
+            .metadata
+            .as_ref()
+            .map(|m| {
+                m.iter()
+                    .map(|(k, v)| (k.to_string(), v.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let lock = self.lock_for(&bucket, &key);
+        let _guard = lock.lock().await;
+
+        // Explicit directory object: PUT with a key ending in '/'.
+        if key.ends_with('/') {
+            self.vfs.mkdir_p(&target).await.map_err(Self::err)?;
+            let attr = self.vfs.stat(&target).await.map_err(Self::err)?;
+            self.set_xattr(attr.ino, XATTR_DIROBJ, "").await?;
+            let meta = ObjectMeta {
+                content_type,
+                metadata: if metadata.is_empty() {
+                    None
+                } else {
+                    Some(metadata)
+                },
+            };
+            self.set_xattr(attr.ino, XATTR_META, &serde_json::to_string(&meta).unwrap())
+                .await?;
+            let etag = format!("{:x}", md5::Context::new().compute());
+            self.set_xattr(attr.ino, XATTR_ETAG, &etag).await?;
+            return Ok(S3Response::new(PutObjectOutput {
+                e_tag: Some(ETag::Strong(etag)),
+                ..Default::default()
+            }));
+        }
+
+        let body = input
+            .body
+            .take()
+            .ok_or_else(|| s3_error!(InvalidArgument, "missing body"))?;
+        let mut body = body;
+
+        let tmp = format!("{}/{}", multipart::tmp_dir(), new_upload_id());
+        let (size, etag) = self.write_blob(&tmp, &mut body).await?;
+
+        if let Some(parent) = std::path::Path::new(&target).parent() {
+            let parent = parent.to_string_lossy().to_string();
+            if !parent.is_empty() {
+                self.vfs.mkdir_p(&parent).await.map_err(Self::err)?;
+            }
+        }
+        if self.vfs.exists(&target).await {
+            let attr = self.vfs.stat(&target).await.map_err(Self::err)?;
+            if attr.kind == FileType::Dir {
+                let _ = self.vfs.unlink(&tmp).await;
+                return Err(s3_error!(InvalidArgument, "key maps to a directory"));
+            }
+        }
+        self.vfs.rename(&tmp, &target).await.map_err(Self::err)?;
+        let attr = self.vfs.stat(&target).await.map_err(Self::err)?;
+        self.set_xattr(attr.ino, XATTR_ETAG, &etag).await?;
+        let meta = ObjectMeta {
+            content_type,
+            metadata: if metadata.is_empty() {
+                None
+            } else {
+                Some(metadata)
+            },
+        };
+        self.set_xattr(attr.ino, XATTR_META, &serde_json::to_string(&meta).unwrap())
+            .await?;
+
+        tracing::debug!(bucket = %bucket, key = %key, size, "s3 put_object");
+        Ok(S3Response::new(PutObjectOutput {
+            e_tag: Some(ETag::Strong(etag)),
+            ..Default::default()
+        }))
+    }
+
+    async fn get_object(&self, req: S3Request<GetObjectInput>) -> S3Result<S3Response<GetObjectOutput>> {
+        let input = req.input;
+        let bucket = input.bucket.as_str().to_string();
+        let key = input.key.as_str().to_string();
+        let mode = &self.opts.bucket_mode;
+        let (_target, attr, is_dir_obj) = self.resolve_object(mode, &bucket, &key).await?;
+
+        let meta = self.read_object_meta(attr.ino).await;
+        let etag = self
+            .read_etag(attr.ino)
+            .await
+            .unwrap_or_else(|| Self::fallback_etag(&attr));
+
+        // Directory objects are always empty.
+        if is_dir_obj {
+            return Ok(S3Response::new(GetObjectOutput {
+                body: Some(StreamingBlob::from_bytes(Default::default())),
+                content_length: Some(0),
+                e_tag: Some(ETag::Strong(etag)),
+                content_type: Some(meta.content_type.clone().map(ContentType::from).unwrap_or_else(|| ContentType::from(DEFAULT_CONTENT_TYPE))),
+                last_modified: Self::mtime_timestamp(&attr),
+                accept_ranges: Some(AcceptRanges::from("bytes")),
+                ..Default::default()
+            }));
+        }
+
+        // Range handling.
+        let (offset, length) = match input.range.as_ref() {
+            Some(range) => {
+                let checked = range
+                    .check(attr.size)
+                    .map_err(|_| s3_error!(InvalidRange, "range not satisfiable"))?;
+                (checked.start, checked.end - checked.start)
+            }
+            None => (0, attr.size),
+        };
+
+        let body = self.read_stream(attr.clone(), offset, length)?;
+        Ok(S3Response::new(GetObjectOutput {
+            body: Some(body),
+            content_length: Some(length as i64),
+            e_tag: Some(ETag::Strong(etag)),
+            content_type: Some(meta.content_type.map(ContentType::from).unwrap_or_else(|| ContentType::from(DEFAULT_CONTENT_TYPE))),
+            last_modified: Self::mtime_timestamp(&attr),
+            accept_ranges: Some(AcceptRanges::from("bytes")),
+            ..Default::default()
+        }))
+    }
+
+    async fn head_object(&self, req: S3Request<HeadObjectInput>) -> S3Result<S3Response<HeadObjectOutput>> {
+        let input = req.input;
+        let bucket = input.bucket.as_str().to_string();
+        let key = input.key.as_str().to_string();
+        let mode = &self.opts.bucket_mode;
+        let (_target, attr, _is_dir_obj) = self.resolve_object(mode, &bucket, &key).await?;
+
+        let meta = self.read_object_meta(attr.ino).await;
+        let etag = self
+            .read_etag(attr.ino)
+            .await
+            .unwrap_or_else(|| Self::fallback_etag(&attr));
+        let metadata = meta.metadata.map(|m| {
+            m.into_iter()
+                .map(|(k, v)| (k, MetadataValue::from(v)))
+                .collect::<HashMap<String, MetadataValue>>()
+        });
+
+        Ok(S3Response::new(HeadObjectOutput {
+            content_length: Some(attr.size as i64),
+            e_tag: Some(ETag::Strong(etag)),
+            content_type: Some(meta.content_type.map(ContentType::from).unwrap_or_else(|| ContentType::from(DEFAULT_CONTENT_TYPE))),
+            last_modified: Self::mtime_timestamp(&attr),
+            metadata,
+            accept_ranges: Some(AcceptRanges::from("bytes")),
+            ..Default::default()
+        }))
+    }
+
+    async fn delete_object(&self, req: S3Request<DeleteObjectInput>) -> S3Result<S3Response<DeleteObjectOutput>> {
+        let input = req.input;
+        let bucket = input.bucket.as_str().to_string();
+        let key = input.key.as_str().to_string();
+        let lock = self.lock_for(&bucket, &key);
+        let _guard = lock.lock().await;
+        self.delete_object_internal(&bucket, &key).await?;
+        Ok(S3Response::with_status(
+            DeleteObjectOutput::default(),
+            axum::http::StatusCode::NO_CONTENT,
+        ))
+    }
+
+    async fn delete_objects(&self, req: S3Request<DeleteObjectsInput>) -> S3Result<S3Response<DeleteObjectsOutput>> {
+        let input = req.input;
+        let bucket = input.bucket.as_str().to_string();
+        let objects = input.delete.objects;
+
+        let mut deleted = Vec::new();
+        let mut errors = Vec::new();
+        for obj in objects {
+            let key = obj.key.as_str().to_string();
+            let lock = self.lock_for(&bucket, &key);
+        let _guard = lock.lock().await;
+            match self.delete_object_internal(&bucket, &key).await {
+                Ok(()) => deleted.push(DeletedObject {
+                    key: Some(obj.key),
+                    ..Default::default()
+                }),
+                Err(e) => errors.push(s3s::dto::Error {
+                    code: Some(e.code().as_str().to_string()),
+                    key: Some(obj.key),
+                    message: e.message().map(|m| m.to_string()),
+                    ..Default::default()
+                }),
+            }
+        }
+        Ok(S3Response::new(DeleteObjectsOutput {
+            deleted: if deleted.is_empty() { None } else { Some(deleted) },
+            errors: if errors.is_empty() { None } else { Some(errors) },
+            ..Default::default()
+        }))
+    }
+
+    async fn copy_object(&self, req: S3Request<CopyObjectInput>) -> S3Result<S3Response<CopyObjectOutput>> {
+        let input = req.input;
+        let dst_bucket = input.bucket.as_str().to_string();
+        let dst_key = input.key.as_str().to_string();
+        let mode = &self.opts.bucket_mode;
+
+        // Parse the copy source (bucket/key form; ARN forms unsupported).
+        let (src_bucket, src_key) = match input.copy_source {
+            CopySource::Bucket { bucket, key, .. } => (bucket.to_string(), key.to_string()),
+            _ => {
+                return Err(s3_error!(
+                    NotImplemented,
+                    "only bucket/key copy sources are supported"
+                ))
+            }
+        };
+
+        self.stat_bucket_root(&dst_bucket).await?;
+        let src_path = path::object_path(mode, &src_bucket, &src_key).map_err(Self::path_err)?;
+        let dst_path = path::object_path(mode, &dst_bucket, &dst_key).map_err(Self::path_err)?;
+        if dst_path == "/" {
+            return Err(s3_error!(InvalidArgument, "empty destination key"));
+        }
+
+        let src_attr = match self.vfs.stat(&src_path).await {
+            Ok(a) => a,
+            Err(_) => return Err(s3_error!(NoSuchKey, "source object not found")),
+        };
+
+        let lock = self.lock_for(&dst_bucket, &dst_key);
+        let _guard = lock.lock().await;
+        let (size, final_attr) = self.copy_object_data(&src_path, &dst_path).await?;
+
+        // Copy or replace metadata according to the directive (default COPY).
+        let replace = matches!(
+            input.metadata_directive.as_ref().map(|d| d.as_str()),
+            Some("REPLACE")
+        );
+        let meta = if replace {
+            ObjectMeta {
+                content_type: input.content_type.as_ref().map(|ct| ct.as_str().to_string()),
+                metadata: input.metadata.as_ref().map(|m| {
+                    m.iter().map(|(k, v)| (k.to_string(), v.to_string())).collect()
+                }),
+            }
+        } else {
+            self.read_object_meta(src_attr.ino).await
+        };
+        let etag = if replace {
+            None
+        } else {
+            self.read_etag(src_attr.ino).await
+        };
+        let etag = etag.unwrap_or_else(|| Self::fallback_etag(&final_attr));
+
+        self.set_xattr(final_attr.ino, XATTR_ETAG, &etag).await?;
+        self.set_xattr(final_attr.ino, XATTR_META, &serde_json::to_string(&meta).unwrap())
+            .await?;
+
+        let last_modified = Self::mtime_timestamp(&final_attr);
+        tracing::debug!(bucket = %dst_bucket, key = %dst_key, size, "s3 copy_object");
+        Ok(S3Response::new(CopyObjectOutput {
+            copy_object_result: Some(CopyObjectResult {
+                e_tag: Some(ETag::Strong(etag)),
+                last_modified,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }))
+    }
+
+    async fn list_objects(&self, req: S3Request<ListObjectsInput>) -> S3Result<S3Response<ListObjectsOutput>> {
+        let input = req.input;
+        let bucket = input.bucket.as_str().to_string();
+        let query = ListQuery {
+            prefix: input.prefix.as_ref().map(|p| p.as_str().to_string()).unwrap_or_default(),
+            delimiter: input.delimiter.as_ref().map(|d| d.as_str().to_string()),
+            start_after: input.marker.as_ref().map(|m| m.as_str().to_string()).unwrap_or_default(),
+            max_keys: input
+                .max_keys
+                .map(|m| usize::try_from(m).unwrap_or(1000))
+                .unwrap_or(1000),
+        };
+        let result = self.list_keys(&bucket, query).await?;
+
+        let contents: Vec<Object> = result
+            .objects
+            .iter()
+            .filter(|o| !o.is_dir || o.is_dir_object)
+            .filter(|o| !(o.is_dir_object && self.opts.hide_dir_objects))
+            .map(|o| Object {
+                key: Some(o.key.clone()),
+                size: Some(if o.is_dir_object { 0 } else { o.size as i64 }),
+                last_modified: Some(Timestamp::from(
+                    UNIX_EPOCH + Duration::from_nanos(o.mtime.max(0) as u64),
+                )),
+                e_tag: o.etag.clone().map(ETag::Strong),
+                ..Default::default()
+            })
+            .collect();
+
+        Ok(S3Response::new(ListObjectsOutput {
+            name: Some(input.bucket),
+            prefix: input.prefix,
+            marker: input.marker,
+            max_keys: input.max_keys,
+            is_truncated: Some(result.is_truncated),
+            next_marker: if result.is_truncated {
+                Some(s3s::dto::NextMarker::from(result.next_marker))
+            } else {
+                None
+            },
+            contents: if contents.is_empty() { None } else { Some(contents) },
+            common_prefixes: prefixes_to_dto(&result.common_prefixes),
+            ..Default::default()
+        }))
+    }
+
+    async fn list_objects_v2(&self, req: S3Request<ListObjectsV2Input>) -> S3Result<S3Response<ListObjectsV2Output>> {
+        let input = req.input;
+        let bucket = input.bucket.as_str().to_string();
+        let start_after = input
+            .start_after
+            .as_ref()
+            .map(|s| s.as_str().to_string())
+            .unwrap_or_default();
+        let continuation = input
+            .continuation_token
+            .as_ref()
+            .map(|t| t.as_str().to_string())
+            .unwrap_or_default();
+        let query = ListQuery {
+            prefix: input.prefix.as_ref().map(|p| p.as_str().to_string()).unwrap_or_default(),
+            delimiter: input.delimiter.as_ref().map(|d| d.as_str().to_string()),
+            start_after: if continuation.is_empty() {
+                start_after
+            } else {
+                continuation
+            },
+            max_keys: input
+                .max_keys
+                .map(|m| usize::try_from(m).unwrap_or(1000))
+                .unwrap_or(1000),
+        };
+        let result = self.list_keys(&bucket, query).await?;
+
+        let contents: Vec<Object> = result
+            .objects
+            .iter()
+            .filter(|o| !o.is_dir || o.is_dir_object)
+            .filter(|o| !(o.is_dir_object && self.opts.hide_dir_objects))
+            .map(|o| Object {
+                key: Some(o.key.clone()),
+                size: Some(if o.is_dir_object { 0 } else { o.size as i64 }),
+                last_modified: Some(Timestamp::from(
+                    UNIX_EPOCH + Duration::from_nanos(o.mtime.max(0) as u64),
+                )),
+                e_tag: o.etag.clone().map(ETag::Strong),
+                ..Default::default()
+            })
+            .collect();
+        let count = contents.len() + result.common_prefixes.len();
+
+        Ok(S3Response::new(ListObjectsV2Output {
+            name: Some(input.bucket),
+            prefix: input.prefix,
+            max_keys: input.max_keys,
+            key_count: Some(s3s::dto::KeyCount::from(count as i32)),
+            continuation_token: input.continuation_token,
+            start_after: input.start_after,
+            is_truncated: Some(result.is_truncated),
+            next_continuation_token: if result.is_truncated {
+                Some(NextToken::from(result.next_marker))
+            } else {
+                None
+            },
+            contents: if contents.is_empty() { None } else { Some(contents) },
+            common_prefixes: prefixes_to_dto(&result.common_prefixes),
+            ..Default::default()
+        }))
+    }
+
+    async fn create_multipart_upload(
+        &self,
+        req: S3Request<CreateMultipartUploadInput>,
+    ) -> S3Result<S3Response<CreateMultipartUploadOutput>> {
+        let input = req.input;
+        let bucket = input.bucket.as_str().to_string();
+        let key = input.key.as_str().to_string();
+        if key.ends_with('/') {
+            return Err(s3_error!(InvalidArgument, "multipart key must not end with '/'"));
+        }
+        self.stat_bucket_root(&bucket).await?;
+        path::object_path(&self.opts.bucket_mode, &bucket, &key).map_err(Self::path_err)?;
+
+        let upload_id = new_upload_id();
+        let dir = multipart::upload_dir(&upload_id);
+        self.vfs.mkdir_p(&dir).await.map_err(Self::err)?;
+
+        let meta = UploadMeta {
+            bucket: bucket.clone(),
+            key: key.clone(),
+            content_type: input
+                .content_type
+                .as_ref()
+                .map(|ct| ct.as_str().to_string()),
+            metadata: input.metadata.as_ref().map(|m| {
+                m.iter().map(|(k, v)| (k.to_string(), v.to_string())).collect()
+            }),
+            initiated: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.as_secs() as i64)
+                .unwrap_or(0),
+        };
+        let target_path = UploadMeta::target_path(&upload_id);
+        let ino = self.vfs.create_file(&target_path).await.map_err(Self::err)?;
+        let attr = self.vfs.stat(&target_path).await.map_err(Self::err)?;
+        let guard = self
+            .vfs
+            .open_guard(ino, attr, false, true)
+            .await
+            .map_err(Self::err)?;
+        guard
+            .write(0, serde_json::to_vec(&meta).unwrap().as_slice())
+            .await
+            .map_err(Self::err)?;
+        guard.close().await.map_err(Self::err)?;
+
+        Ok(S3Response::new(CreateMultipartUploadOutput {
+            bucket: Some(input.bucket),
+            key: Some(input.key),
+            upload_id: Some(MultipartUploadId::from(upload_id)),
+            ..Default::default()
+        }))
+    }
+
+    async fn upload_part(&self, mut req: S3Request<UploadPartInput>) -> S3Result<S3Response<UploadPartOutput>> {
+        let upload_id = req.input.upload_id.clone();
+        let part_number = req.input.part_number;
+
+        // Validate the upload exists and belongs to this bucket/key.
+        self.read_upload_meta(&upload_id).await?;
+
+        let dst = multipart::part_path(&upload_id, i64::from(part_number));
+        let body = req
+            .input
+            .body
+            .take()
+            .ok_or_else(|| s3_error!(InvalidArgument, "missing body"))?;
+        let mut body = body;
+        let (_size, etag) = self.write_blob(&dst, &mut body).await?;
+
+        let attr = self.vfs.stat(&dst).await.map_err(Self::err)?;
+        self.set_xattr(attr.ino, XATTR_ETAG, &etag).await?;
+
+        Ok(S3Response::new(UploadPartOutput {
+            e_tag: Some(ETag::Strong(etag)),
+            ..Default::default()
+        }))
+    }
+
+    async fn list_parts(&self, req: S3Request<ListPartsInput>) -> S3Result<S3Response<ListPartsOutput>> {
+        let input = req.input;
+        let upload_id = input.upload_id.clone();
+        let meta = self.read_upload_meta(&upload_id).await?;
+
+        let dir = multipart::upload_dir(&upload_id);
+        let mut parts: Vec<(i64, u64, i64, Option<String>)> = Vec::new();
+        for entry in self.read_dir_entries(&dir).await? {
+            if let Some(n) = parse_part_name(&entry.name) {
+                if let Some(attr) = self.vfs.stat_ino(entry.ino).await {
+                    let etag = self.read_etag(entry.ino).await;
+                    parts.push((n, attr.size, attr.mtime, etag));
+                }
+            }
+        }
+        parts.sort_by_key(|p| p.0);
+
+        Ok(S3Response::new(ListPartsOutput {
+            bucket: Some(input.bucket),
+            key: Some(ObjectKey::from(meta.key)),
+            upload_id: Some(MultipartUploadId::from(upload_id)),
+            parts: Some(
+                parts
+                    .into_iter()
+                    .map(|(n, size, mtime, etag)| Part {
+                        part_number: Some(n as i32),
+                        size: Some(size as i64),
+                        last_modified: Some(Timestamp::from(
+                            UNIX_EPOCH + Duration::from_nanos(mtime.max(0) as u64),
+                        )),
+                        e_tag: etag.map(ETag::Strong),
+                        ..Default::default()
+                    })
+                    .collect(),
+            ),
+            ..Default::default()
+        }))
+    }
+
+    async fn complete_multipart_upload(
+        &self,
+        req: S3Request<CompleteMultipartUploadInput>,
+    ) -> S3Result<S3Response<CompleteMultipartUploadOutput>> {
+        let input = req.input;
+        let bucket = input.bucket.as_str().to_string();
+        let key = input.key.as_str().to_string();
+        let upload_id = input.upload_id.clone();
+
+        let meta = self.read_upload_meta(&upload_id).await?;
+        if meta.bucket != bucket || meta.key != key {
+            return Err(s3_error!(NoSuchUpload, "upload does not match bucket/key"));
+        }
+
+        let completed = input
+            .multipart_upload
+            .and_then(|m| m.parts)
+            .ok_or_else(|| s3_error!(InvalidArgument, "missing parts list"))?;
+
+        let lock = self.lock_for(&bucket, &key);
+        let _guard = lock.lock().await;
+
+        // Validate part ordering and etags.
+        let mut expected = 1i32;
+        let mut part_etags: Vec<String> = Vec::with_capacity(completed.len());
+        let mut part_files: Vec<(i64, String)> = Vec::with_capacity(completed.len());
+        for part in &completed {
+            let n = part.part_number.unwrap_or(0);
+            if n != expected {
+                return Err(s3_error!(
+                    InvalidPartOrder,
+                    "parts must be ascending starting at 1 (got {n}, expected {expected})"
+                ));
+            }
+            expected += 1;
+            let src = multipart::part_path(&upload_id, i64::from(n));
+            let attr = match self.vfs.stat(&src).await {
+                Ok(a) => a,
+                Err(_) => return Err(s3_error!(InvalidPart, "part {n} not uploaded")),
+            };
+            // Every part except the last must be at least 5 MiB.
+            let is_last = std::ptr::eq(part, completed.last().unwrap());
+            if !is_last && attr.size < 5 * 1024 * 1024 {
+                return Err(s3_error!(EntityTooSmall, "part {n} is smaller than 5 MiB"));
+            }
+            let stored = self.read_etag(attr.ino).await;
+            if let (Some(want), Some(have)) = (part.e_tag.as_ref(), stored.as_ref()) {
+                if want.value() != have {
+                    return Err(s3_error!(InvalidPart, "etag mismatch on part {n}"));
+                }
+            }
+            part_etags.push(stored.unwrap_or_default());
+            part_files.push((i64::from(n), src));
+        }
+
+        // Concatenate parts into a staging file, then publish atomically.
+        let tmp = format!("{}/{}", multipart::tmp_dir(), new_upload_id());
+        if self.vfs.exists(&tmp).await {
+            self.vfs.unlink(&tmp).await.map_err(Self::err)?;
+        }
+        let tmp_ino = self.vfs.create_file(&tmp).await.map_err(Self::err)?;
+        let tmp_attr = self.vfs.stat(&tmp).await.map_err(Self::err)?;
+        let out_guard = self
+            .vfs
+            .open_guard(tmp_ino, tmp_attr, false, true)
+            .await
+            .map_err(Self::err)?;
+
+        let mut offset: u64 = 0;
+        for (_, src) in &part_files {
+            let attr = self.vfs.stat(src).await.map_err(Self::err)?;
+            let size = attr.size;
+            let in_guard = self
+                .vfs
+                .open_guard(attr.ino, attr, true, false)
+                .await
+                .map_err(Self::err)?;
+            let mut pos: u64 = 0;
+            while pos < size {
+                let len = (size - pos).min(STREAM_CHUNK) as usize;
+                let chunk = in_guard.read(pos, len).await.map_err(Self::err)?;
+                if chunk.is_empty() {
+                    break;
+                }
+                out_guard.write(offset, &chunk).await.map_err(Self::err)?;
+                offset += chunk.len() as u64;
+                pos += chunk.len() as u64;
+            }
+            in_guard.close().await.map_err(Self::err)?;
+        }
+        out_guard.close().await.map_err(Self::err)?;
+
+        let target = path::object_path(&self.opts.bucket_mode, &bucket, &key)
+            .map_err(Self::path_err)?;
+        if let Some(parent) = std::path::Path::new(&target).parent() {
+            let parent = parent.to_string_lossy().to_string();
+            if !parent.is_empty() {
+                self.vfs.mkdir_p(&parent).await.map_err(Self::err)?;
+            }
+        }
+        self.vfs.rename(&tmp, &target).await.map_err(Self::err)?;
+        let final_attr = self.vfs.stat(&target).await.map_err(Self::err)?;
+
+        let etag = multipart_etag(&part_etags);
+        let object_meta = ObjectMeta {
+            content_type: meta.content_type.clone(),
+            metadata: meta.metadata.clone(),
+        };
+        self.set_xattr(final_attr.ino, XATTR_ETAG, &etag).await?;
+        self.set_xattr(
+            final_attr.ino,
+            XATTR_META,
+            &serde_json::to_string(&object_meta).unwrap(),
+        )
+        .await?;
+
+        // Drop the upload state.
+        let upload_dir = multipart::upload_dir(&upload_id);
+        let _ = super::remove_dir_all_rec(&self.vfs, &upload_dir).await;
+
+        let location = format!("/{bucket}/{key}");
+        Ok(S3Response::new(CompleteMultipartUploadOutput {
+            bucket: Some(BucketName::from(bucket)),
+            key: Some(ObjectKey::from(key)),
+            e_tag: Some(ETag::Strong(etag)),
+            location: Some(Location::from(location)),
+            ..Default::default()
+        }))
+    }
+
+    async fn abort_multipart_upload(
+        &self,
+        req: S3Request<AbortMultipartUploadInput>,
+    ) -> S3Result<S3Response<AbortMultipartUploadOutput>> {
+        let input = req.input;
+        let upload_id = input.upload_id.clone();
+        self.read_upload_meta(&upload_id).await?;
+        let dir = multipart::upload_dir(&upload_id);
+        super::remove_dir_all_rec(&self.vfs, &dir)
+            .await
+            .map_err(Self::err)?;
+        Ok(S3Response::new(AbortMultipartUploadOutput::default()))
+    }
+
+    async fn list_multipart_uploads(
+        &self,
+        req: S3Request<ListMultipartUploadsInput>,
+    ) -> S3Result<S3Response<ListMultipartUploadsOutput>> {
+        let input = req.input;
+        let bucket = input.bucket.as_str().to_string();
+        let prefix = input
+            .prefix
+            .as_ref()
+            .map(|p| p.as_str().to_string())
+            .unwrap_or_default();
+
+        let mut uploads = Vec::new();
+        for hh in self.read_dir_entries(&multipart::uploads_dir()).await? {
+            let hh_dir = format!("{}/{}", multipart::uploads_dir(), hh.name);
+            for upload in self.read_dir_entries(&hh_dir).await? {
+                let target = format!("{}/{}", hh_dir, upload.name);
+                // Reconstruct the upload id from the directory name.
+                let upload_id = upload.name.clone();
+                if let Ok(meta) = self.read_upload_meta(&upload_id).await {
+                    if meta.bucket == bucket
+                        && (prefix.is_empty() || meta.key.starts_with(&prefix))
+                    {
+                        uploads.push(MultipartUpload {
+                            key: Some(ObjectKey::from(meta.key)),
+                            upload_id: Some(MultipartUploadId::from(upload_id)),
+                            initiated: Some(Timestamp::from(
+                                UNIX_EPOCH + Duration::from_secs(meta.initiated.max(0) as u64),
+                            )),
+                            storage_class: Some(StorageClass::from_static(
+                                StorageClass::STANDARD,
+                            )),
+                            ..Default::default()
+                        });
+                    }
+                }
+                let _ = target;
+            }
+        }
+        uploads.sort_by(|a, b| a.key.cmp(&b.key));
+
+        Ok(S3Response::new(ListMultipartUploadsOutput {
+            bucket: Some(input.bucket),
+            uploads: if uploads.is_empty() { None } else { Some(uploads) },
+            ..Default::default()
+        }))
+    }
+}
+
+fn prefixes_to_dto(prefixes: &std::collections::BTreeSet<String>) -> Option<Vec<CommonPrefix>> {
+    if prefixes.is_empty() {
+        return None;
+    }
+    Some(
+        prefixes
+            .iter()
+            .map(|p| CommonPrefix {
+                prefix: Some(s3s::dto::Prefix::from(p.as_str())),
+            })
+            .collect(),
+    )
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@
 
 pub mod cadapter;
 pub mod chunk;
+#[cfg(feature = "gateway-s3")]
+pub mod gateway;
 pub(crate) mod control;
 pub mod daemon;
 pub(crate) mod fs;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,12 +4,12 @@
 
 pub mod cadapter;
 pub mod chunk;
-#[cfg(feature = "gateway-s3")]
-pub mod gateway;
 pub(crate) mod control;
 pub mod daemon;
 pub(crate) mod fs;
 pub mod fuse;
+#[cfg(feature = "gateway-s3")]
+pub mod gateway;
 // Expose meta for E2E testing - tests should rely on design contracts, not impl details
 pub mod meta;
 pub(crate) mod posix;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,8 @@ mod control;
 mod daemon;
 #[allow(dead_code)]
 mod fs;
+#[cfg(feature = "gateway-s3")]
+mod gateway;
 mod fuse;
 mod meta;
 mod posix;
@@ -104,6 +106,8 @@ async fn main() -> anyhow::Result<()> {
         Command::Gc(args) => gc_cmd(args).await,
         Command::Info(args) => info_cmd(args).await,
         Command::Console(args) => console::serve_cmd(args).await,
+        #[cfg(feature = "gateway-s3")]
+        Command::Gateway(args) => gateway_cmd(*args).await,
         Command::ObjectPutBench(args) => object_put_bench_cmd(args).await,
     };
     shutdown_flame();
@@ -393,8 +397,87 @@ async fn mount_cmd(args: MountConfig) -> anyhow::Result<()> {
     }
 }
 
-fn validate_volume_format_support(format: VolumeFormat) -> anyhow::Result<()> {
-    match format {
+#[cfg(feature = "gateway-s3")]
+async fn gateway_cmd(args: GatewayArgs) -> anyhow::Result<()> {
+    match args.protocol {
+        GatewayProtocol::S3(s3) => gateway_s3_cmd(s3).await,
+    }
+}
+
+#[cfg(feature = "gateway-s3")]
+async fn gateway_s3_cmd(args: S3GatewayArgs) -> anyhow::Result<()> {
+    use crate::gateway::s3::{S3GatewayOptions, serve};
+    use crate::gateway::s3::path::BucketMode;
+
+    // The gateway does not own a FUSE mount point; use a placeholder so
+    // MountConfig::from_sources validation passes.
+    let mut mount_args = args.mount;
+    if mount_args.mount_point.is_none() {
+        mount_args.mount_point = Some(std::path::PathBuf::from("/brewfs-s3-gateway"));
+    }
+    let cfg = MountConfig::from_sources(mount_args)?;
+    if cfg.volume_format != VolumeFormat::FlatV1 {
+        anyhow::bail!("s3 gateway only supports volume_format=flat-v1");
+    }
+    validate_volume_format_support(cfg.volume_format)?;
+
+    if cfg.chunk_size < cfg.block_size as u64 {
+        anyhow::bail!("chunk_size must be >= block_size");
+    }
+    let layout = ChunkLayout {
+        chunk_size: cfg.chunk_size,
+        block_size: cfg.block_size,
+    };
+
+    let access_key = match args.access_key.as_deref() {
+        Some(k) if !k.is_empty() => k.to_string(),
+        _ => anyhow::bail!(
+            "s3 gateway requires an access key (--access-key or BREWFS_S3_ACCESS_KEY)"
+        ),
+    };
+    let secret_key = match args.secret_key.as_deref() {
+        Some(k) if !k.is_empty() => k.to_string(),
+        _ => anyhow::bail!(
+            "s3 gateway requires a secret key (--secret-key or BREWFS_S3_SECRET_KEY)"
+        ),
+    };
+
+    let bucket_mode = if args.multi_buckets {
+        BucketMode::Multi
+    } else {
+        BucketMode::Single {
+            bucket: args.bucket,
+        }
+    };
+    let opts = S3GatewayOptions {
+        listen_addr: args.listen,
+        access_key,
+        secret_key,
+        bucket_mode,
+        hide_dir_objects: args.hide_dir_objects,
+    };
+
+    tracing::info!(
+        listen = %opts.listen_addr,
+        data_backend = ?cfg.data_backend,
+        meta_backend = ?cfg.meta_backend,
+        "s3 gateway startup begin"
+    );
+    match cfg.data_backend {
+        DataBackendKind::LocalFs => {
+            let client = create_localfs_client(&cfg)?;
+            let store = create_object_store(client, layout, &cfg.cache).await?;
+            serve(store, create_meta_store(&cfg).await?, layout, cfg.compact.clone(), cfg.cache.clone(), opts).await
+        }
+        DataBackendKind::S3 => {
+            let client = create_s3_client(&cfg).await?;
+            let store = create_object_store(client, layout, &cfg.cache).await?;
+            serve(store, create_meta_store(&cfg).await?, layout, cfg.compact.clone(), cfg.cache.clone(), opts).await
+        }
+    }
+}
+
+fn validate_volume_format_support(format: VolumeFormat) -> anyhow::Result<()> {    match format {
         VolumeFormat::FlatV1 => Ok(()),
         #[cfg(feature = "workspace-overlay")]
         VolumeFormat::WorkspaceV1 => Ok(()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -406,7 +406,7 @@ async fn gateway_cmd(args: GatewayArgs) -> anyhow::Result<()> {
 
 #[cfg(feature = "gateway-s3")]
 async fn gateway_s3_cmd(args: S3GatewayArgs) -> anyhow::Result<()> {
-    use crate::gateway::s3::path::BucketMode;
+    use crate::gateway::s3::path::{BucketMode, is_valid_bucket_name};
     use crate::gateway::s3::{S3GatewayOptions, serve};
 
     // The gateway does not own a FUSE mount point; use a placeholder so
@@ -445,6 +445,9 @@ async fn gateway_s3_cmd(args: S3GatewayArgs) -> anyhow::Result<()> {
     let bucket_mode = if args.multi_buckets {
         BucketMode::Multi
     } else {
+        if !is_valid_bucket_name(&args.bucket) {
+            anyhow::bail!("invalid S3 bucket name: {}", args.bucket);
+        }
         BucketMode::Single {
             bucket: args.bucket,
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,9 +5,9 @@ mod control;
 mod daemon;
 #[allow(dead_code)]
 mod fs;
+mod fuse;
 #[cfg(feature = "gateway-s3")]
 mod gateway;
-mod fuse;
 mod meta;
 mod posix;
 mod utils;
@@ -406,8 +406,8 @@ async fn gateway_cmd(args: GatewayArgs) -> anyhow::Result<()> {
 
 #[cfg(feature = "gateway-s3")]
 async fn gateway_s3_cmd(args: S3GatewayArgs) -> anyhow::Result<()> {
-    use crate::gateway::s3::{S3GatewayOptions, serve};
     use crate::gateway::s3::path::BucketMode;
+    use crate::gateway::s3::{S3GatewayOptions, serve};
 
     // The gateway does not own a FUSE mount point; use a placeholder so
     // MountConfig::from_sources validation passes.
@@ -437,9 +437,9 @@ async fn gateway_s3_cmd(args: S3GatewayArgs) -> anyhow::Result<()> {
     };
     let secret_key = match args.secret_key.as_deref() {
         Some(k) if !k.is_empty() => k.to_string(),
-        _ => anyhow::bail!(
-            "s3 gateway requires a secret key (--secret-key or BREWFS_S3_SECRET_KEY)"
-        ),
+        _ => {
+            anyhow::bail!("s3 gateway requires a secret key (--secret-key or BREWFS_S3_SECRET_KEY)")
+        }
     };
 
     let bucket_mode = if args.multi_buckets {
@@ -467,17 +467,34 @@ async fn gateway_s3_cmd(args: S3GatewayArgs) -> anyhow::Result<()> {
         DataBackendKind::LocalFs => {
             let client = create_localfs_client(&cfg)?;
             let store = create_object_store(client, layout, &cfg.cache).await?;
-            serve(store, create_meta_store(&cfg).await?, layout, cfg.compact.clone(), cfg.cache.clone(), opts).await
+            serve(
+                store,
+                create_meta_store(&cfg).await?,
+                layout,
+                cfg.compact.clone(),
+                cfg.cache.clone(),
+                opts,
+            )
+            .await
         }
         DataBackendKind::S3 => {
             let client = create_s3_client(&cfg).await?;
             let store = create_object_store(client, layout, &cfg.cache).await?;
-            serve(store, create_meta_store(&cfg).await?, layout, cfg.compact.clone(), cfg.cache.clone(), opts).await
+            serve(
+                store,
+                create_meta_store(&cfg).await?,
+                layout,
+                cfg.compact.clone(),
+                cfg.cache.clone(),
+                opts,
+            )
+            .await
         }
     }
 }
 
-fn validate_volume_format_support(format: VolumeFormat) -> anyhow::Result<()> {    match format {
+fn validate_volume_format_support(format: VolumeFormat) -> anyhow::Result<()> {
+    match format {
         VolumeFormat::FlatV1 => Ok(()),
         #[cfg(feature = "workspace-overlay")]
         VolumeFormat::WorkspaceV1 => Ok(()),


### PR DESCRIPTION
## Summary
Implements the S3 gateway spec from #82 (`doc/protocols/s3-gateway.md`) as the first protocol gateway (milestone M1):

- **New subcommand** `brewfs gateway s3` — serves one BrewFS volume over the S3 API using the s3s 0.15 framework with SigV4 static-key auth (`--access-key`/`--secret-key`, or `BREWFS_S3_ACCESS_KEY`/`BREWFS_S3_SECRET_KEY`).
- **Object layer** (`src/gateway/s3/`) maps bucket/key onto the VFS path space:
  - bucket modes: single fixed bucket (`--bucket`, default `brewfs`) or multi-bucket (`--multi-buckets`, top-level dirs = buckets)
  - directory objects via `brewfs.s3.dirobj` xattr; ETag plus content-type/user metadata in `brewfs.s3.etag` / `brewfs.s3.meta` xattrs
  - atomic publication through internal staging files and rename; empty-parent pruning on delete
- **Listings** implement prefix, delimiter, max-keys and continuation pagination over a VFS directory walk; implicit directories are invisible, while explicit directory objects surface as `key/` with size 0 unless hidden by configuration.
- **Multipart uploads** stage under `/.brewfs.sys/s3/uploads/<fan-out>/<id>/` with `.target` metadata and per-part ETag xattrs; hourly cleanup removes state older than 24 hours; merged ETags follow the S3 `md5(...)-N` convention.
- **Implemented operations**: Create/Delete/Head/List Buckets, GetBucketLocation, Put/Get/Head/Delete Object(s), CopyObject, ListObjects(V2), CreateMultipartUpload, UploadPart, ListParts, CompleteMultipartUpload, AbortMultipartUpload and ListMultipartUploads.

## Consistency and boundary hardening

- GET uses bounded-channel backpressure and holds a VFS read guard so slow consumers receive a complete, fixed-inode snapshot during concurrent overwrite.
- PUT, COPY, UploadPart and multipart completion publish atomically; failure paths remove staging state.
- Fixed key-lock shards serialize conflicting object mutations, with deterministic two-key lock ordering for COPY.
- Bucket lifecycle lock shards serialize Create/DeleteBucket against multipart creation and destination publication. Destination existence is revalidated before publication, and active multipart uploads make DeleteBucket return `BucketNotEmpty`.
- Multipart upload IDs are validated before path derivation, and every operation verifies upload ID + bucket + key ownership.
- Single-bucket access to the volume-level `.brewfs.sys` namespace is rejected; unsafe aliases, escaping components and invalid configured bucket names are rejected at the boundary.
- Listing filters invisible directory entries before page accounting, including correct zero-capacity and continuation behavior.
- Cleanup and recursive directory traversal consume every VFS page and revalidate stale state before deletion.

## Verification

- `scripts/e2e_s3_gateway.py`: **76 passed, 0 failed** on a fresh LocalFS + SQLite volume under WSL Ubuntu-22.04.
  - Covers object metadata and ranges, slow large GET, concurrent overwrite snapshots, namespace/path rejection, listing pagination, self-copy, multipart ownership/order/pagination and directory-object isolation.
- **22 gateway unit tests** cover path mapping, reserved namespaces, aliases, list visibility/pagination, multipart paths and lock sharding.
- Fresh multi-bucket checks verify namespace boundaries, active multipart deletion blocking, abort followed by empty-bucket deletion and persistent absence after deletion.
- A real SigV4 partial-body race verifies an in-flight PUT returns `NoSuchBucket` after successful bucket deletion and cannot recreate the bucket.
- Final local matrix passed:
  - `cargo test --workspace --all-features -- --test-threads=1`
  - `cargo test --workspace --lib --bins -- --test-threads=1`
  - both workspace `--all-targets` Clippy variants with `-D warnings`
  - default workspace build and all four tokio/io-uring + workspace-overlay runtime feature checks
  - rustfmt, diff whitespace and Python syntax checks
- Runbook: `doc/protocols/s3-gateway-verification.md`.

## Design notes

- The gateway builds its own `VFS` stack beside FUSE using the same metadata and data backends, so S3 objects and POSIX files share one namespace.
- VFS `FileAttr.mtime` is nanoseconds and is converted to S3 `LastModified` accordingly.
- `s3s::S3Service` fails with `HttpError` while axum routers require infallible services; a small `S3Fallback` tower adapter bridges them.
- Feature-gated as `gateway-s3` and included in `default`; existing FUSE-only builds can disable it.

## Out of scope (MVP)

ACL, versioning, encryption, CORS, lifecycle, ARN-form copy sources, cross-instance write/lifecycle locking, and full `encoding-type`/`fetch-owner` list semantics.

Closes the S3 item of the roadmap in #82 (docs PR; specs land separately).