### PR TITLE
fix(fs): preserve atomic rename semantics

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1124,65 +1124,6 @@ where
                 .map_err(|e| meta_error_to_io(&old, e))?
                 .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, old.clone()))?;
 
-            if let Ok(Some((dest_ino, dest_kind))) = self.meta_layer().lookup_path(&new).await {
-                let new_dir_ino = if &new_dir == "/" {
-                    self.meta_layer().root_ino()
-                } else {
-                    self.meta_layer()
-                        .lookup_path(&new_dir)
-                        .await
-                        .map_err(|e| meta_error_to_io(&new_dir, e))?
-                        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, new_dir.clone()))?
-                        .0
-                };
-                let new_parent_attr = self
-                    .meta_layer()
-                    .stat(new_dir_ino)
-                    .await
-                    .map_err(|e| meta_error_to_io(&new_dir, e))?
-                    .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, new_dir.clone()))?;
-                if new_parent_attr.kind != FileType::Dir {
-                    return Err(io::Error::new(
-                        io::ErrorKind::NotADirectory,
-                        new_dir.clone(),
-                    ));
-                }
-                self.check_access(
-                    &new_parent_attr,
-                    AccessMask::WRITE | AccessMask::EXEC,
-                    &new_dir,
-                )?;
-
-                if dest_kind == FileType::Dir {
-                    if src_attr.kind != FileType::Dir {
-                        return Err(io::Error::new(io::ErrorKind::NotADirectory, new.clone()));
-                    }
-                    let children = self
-                        .meta_layer()
-                        .readdir(dest_ino)
-                        .await
-                        .map_err(|e| meta_error_to_io(&new, e))?;
-                    if !children.is_empty() {
-                        return Err(io::Error::new(
-                            io::ErrorKind::DirectoryNotEmpty,
-                            new.clone(),
-                        ));
-                    }
-                    self.meta_layer()
-                        .rmdir(new_dir_ino, &new_name)
-                        .await
-                        .map_err(|e| meta_error_to_io(&new, e))?;
-                } else {
-                    if src_attr.kind == FileType::Dir {
-                        return Err(io::Error::new(io::ErrorKind::NotADirectory, new.clone()));
-                    }
-                    self.meta_layer()
-                        .unlink(new_dir_ino, &new_name)
-                        .await
-                        .map_err(|e| meta_error_to_io(&new, e))?;
-                }
-            }
-
             let new_dir_ino = if &new_dir == "/" {
                 self.meta_layer().root_ino()
             } else {
@@ -1212,7 +1153,17 @@ where
                 &new_dir,
             )?;
             self.meta_layer()
-                .rename(old_parent_ino, &old_name, new_dir_ino, new_name)
+                .rename_with_known_attrs(
+                    old_parent_ino,
+                    &old_name,
+                    new_dir_ino,
+                    new_name,
+                    src_ino,
+                    src_attr,
+                    new_parent_attr,
+                    None,
+                    false,
+                )
                 .await
                 .map_err(|e| meta_error_to_io(&new, e))?;
             Ok(())
@@ -2111,6 +2062,63 @@ mod tests {
         let entries = fs.readdir("/test").await.unwrap();
         assert!(entries.iter().any(|e| e.name == "hello.txt"));
         assert!(entries.iter().any(|e| e.name == "subdir"));
+    }
+
+    #[tokio::test]
+    async fn test_rename_same_inode_is_a_noop() {
+        let fs = create_test_fs().await;
+        let file = fs.create_file("/file").await.unwrap();
+        let normalized = fs.create_file("/normalized").await.unwrap();
+        fs.mkdir("/directory").await.unwrap();
+        let directory = fs.stat("/directory").await.unwrap().inode();
+
+        for (old, new, expected) in [
+            ("/file", "/file", file),
+            ("/normalized", "//normalized", normalized),
+            ("/directory", "/directory", directory),
+        ] {
+            fs.rename(old, new).await.unwrap();
+            assert_eq!(fs.stat(old).await.unwrap().inode(), expected);
+        }
+
+        fs.link("/file", "/alias").await.unwrap();
+        fs.rename("/file", "/alias").await.unwrap();
+        assert_eq!(fs.stat("/file").await.unwrap().inode(), file);
+        assert_eq!(fs.stat("/alias").await.unwrap().inode(), file);
+    }
+
+    #[tokio::test]
+    async fn test_rename_atomically_replaces_destination() {
+        let fs = create_test_fs().await;
+        let source = fs.create("/source").await.unwrap();
+        source.write(b"source-data").await.unwrap();
+        let source_ino = source.inode();
+        let destination = fs.create("/destination").await.unwrap();
+        destination.write(b"old-data").await.unwrap();
+
+        fs.rename("/source", "/destination").await.unwrap();
+
+        assert!(fs.stat("/source").await.is_err());
+        assert_eq!(fs.stat("/destination").await.unwrap().inode(), source_ino);
+        let replacement = fs
+            .open("/destination", OpenFlags::read_only())
+            .await
+            .unwrap();
+        let mut data = [0u8; 11];
+        let len = replacement.read(&mut data).await.unwrap();
+        assert_eq!(&data[..len], b"source-data");
+    }
+
+    #[tokio::test]
+    async fn test_failed_rename_preserves_destination() {
+        let fs = create_test_fs().await;
+        fs.create_file("/source").await.unwrap();
+        fs.mkdir("/destination").await.unwrap();
+        let destination = fs.stat("/destination").await.unwrap().inode();
+
+        assert!(fs.rename("/source", "/destination").await.is_err());
+        assert!(fs.stat("/source").await.unwrap().is_file());
+        assert_eq!(fs.stat("/destination").await.unwrap().inode(), destination);
     }
 
     #[tokio::test]

--- a/src/meta/client/cache.rs
+++ b/src/meta/client/cache.rs
@@ -90,10 +90,6 @@ impl InodeEntry {
         }
     }
 
-    pub(crate) async fn set_parent(&self, parent_ino: i64) {
-        *self.parent.write().await = Some(parent_ino);
-    }
-
     pub(crate) async fn clear_parent(&self) {
         *self.parent.write().await = None;
     }

--- a/src/meta/client/mod.rs
+++ b/src/meta/client/mod.rs
@@ -1714,7 +1714,7 @@ impl<T: MetaStore + ?Sized + 'static> MetaClient<T> {
         new_name: String,
         known_src: Option<(i64, FileAttr)>,
         known_new_parent_attr: Option<FileAttr>,
-        known_dest_ino: Option<Option<i64>>,
+        _known_dest_ino: Option<Option<i64>>,
         noreplace: bool,
     ) -> Result<(), MetaError> {
         self.ensure_writable()?;
@@ -1734,7 +1734,7 @@ impl<T: MetaStore + ?Sized + 'static> MetaClient<T> {
 
         Self::validate_entry_name(&new_name)?;
 
-        let (src_ino, src_attr) = match known_src {
+        let (_src_ino, _src_attr) = match known_src {
             Some((ino, attr)) => (self.check_root(ino), Some(attr)),
             None => {
                 let src_ino = self.cached_lookup_required(old_parent, old_name).await?;
@@ -1753,43 +1753,45 @@ impl<T: MetaStore + ?Sized + 'static> MetaClient<T> {
             }
         }
 
-        // Resolve destination inode before replace-capable store renames so we can invalidate its
-        // cache entry afterwards.  When the store replaces an existing destination,
-        // its nlink is decremented (possibly to 0, which deletes the node).  The
-        // cache must reflect this, otherwise a subsequent stat on an fd that was
-        // open before the overwrite returns a stale (non-zero) nlink.
-        // A no-replace operation must not make a correctness decision based on
-        // this cache: another client may create the name after a lookup. Its
-        // backend transaction/script is the sole authority for the absence
-        // check.
-        let dest_ino = if noreplace {
-            None
+        // Only the backend transaction/script can decide whether the current
+        // destination is the source inode or a different inode. Destination
+        // hints may be stale across clients and must never control the rename.
+        let outcome = if noreplace {
+            self.store
+                .rename_with_mode(old_parent, old_name, new_parent, new_name.clone(), true)
+                .await?
         } else {
-            match known_dest_ino {
-                Some(dest_ino) => dest_ino.map(|ino| self.check_root(ino)),
-                None => self.cached_lookup(new_parent, &new_name).await?,
-            }
+            self.store
+                .rename_with_outcome(old_parent, old_name, new_parent, new_name.clone())
+                .await?
         };
-        if !noreplace && dest_ino == Some(src_ino) {
+        let src_ino = outcome.ino;
+        if !outcome.renamed {
+            self.invalidate_open_file_cache_inode(src_ino).await;
+            self.inode_cache.invalidate_inode(src_ino).await;
+            self.inode_cache.remove_child(old_parent, old_name).await;
+            self.inode_cache.remove_child(new_parent, &new_name).await;
+            self.inode_cache
+                .ensure_node_in_cache(old_parent, &self.store, None)
+                .await?;
+            self.inode_cache
+                .ensure_node_in_cache(new_parent, &self.store, None)
+                .await?;
+            self.inode_cache
+                .ensure_node_in_cache(src_ino, &self.store, None)
+                .await?;
+            self.inode_cache
+                .add_child(old_parent, old_name.to_string(), src_ino)
+                .await;
+            self.inode_cache
+                .add_child(new_parent, new_name, src_ino)
+                .await;
             return Ok(());
         }
-        let dest_attr = match dest_ino {
-            Some(dest) => self.cached_stat(dest).await?,
-            None => None,
-        };
 
-        // Execute the store-level rename with atomic cache updates.
-        if noreplace {
-            self.store
-                .rename_noreplace(old_parent, old_name, new_parent, new_name.clone())
-                .await?;
-        } else {
-            self.store
-                .rename(old_parent, old_name, new_parent, new_name.clone())
-                .await?;
-        }
+        let dest_ino = outcome.replaced_ino;
         self.invalidate_open_file_cache_inode(src_ino).await;
-        if let Some(dest_ino) = dest_ino {
+        if let Some(dest_ino) = outcome.replaced_ino {
             self.invalidate_open_file_cache_inode(dest_ino).await;
         }
 
@@ -1797,34 +1799,18 @@ impl<T: MetaStore + ?Sized + 'static> MetaClient<T> {
 
         // Update cache atomically with enhanced consistency management.
         let cache_result = async {
-            // Remove child from old parent (keep inode for later use).
-            let child_info = self
-                .inode_cache
-                .remove_child_but_keep_inode(old_parent, old_name)
+            self.inode_cache.remove_child(old_parent, old_name).await;
+            self.inode_cache.remove_child(new_parent, &new_name).await;
+            self.inode_cache.invalidate_inode(src_ino).await;
+            self.inode_cache
+                .ensure_node_in_cache(new_parent, &self.store, None)
+                .await?;
+            self.inode_cache
+                .ensure_node_in_cache(src_ino, &self.store, Some(new_parent))
+                .await?;
+            self.inode_cache
+                .add_child(new_parent, new_name.clone(), src_ino)
                 .await;
-
-            if let Some(child_ino) = child_info {
-                // Ensure new parent is in cache with up-to-date metadata.
-                self.inode_cache
-                    .ensure_node_in_cache(new_parent, &self.store, None)
-                    .await?;
-
-                // Add child to new parent.
-                self.inode_cache
-                    .add_child(new_parent, new_name.clone(), child_ino)
-                    .await;
-
-                // Directories keep their inline parent even though nlink is >= 2.
-                if let Some(attr) = &src_attr {
-                    if attr.kind == FileType::Dir || attr.nlink <= 1 {
-                        if let Some(child_node) = self.inode_cache.get_node(child_ino).await {
-                            child_node.set_parent(new_parent).await;
-                        }
-                    } else if let Some(child_node) = self.inode_cache.get_node(child_ino).await {
-                        child_node.clear_parent().await;
-                    }
-                }
-            }
 
             // Keep an overwritten destination inode addressable while it may
             // still be held open by the kernel, but refresh the link count from
@@ -1853,24 +1839,19 @@ impl<T: MetaStore + ?Sized + 'static> MetaClient<T> {
                 }
             }
 
-            // Precise path cache invalidation while retaining the updated child
-            // maps for subsequent lookups on the same hot directory.
-            let src_is_dir = matches!(src_attr.as_ref().map(|attr| attr.kind), Some(FileType::Dir));
-            let dest_is_dir = matches!(
-                dest_attr.as_ref().map(|attr| attr.kind),
-                Some(FileType::Dir)
-            );
-            let old_parent_delta = if src_is_dir && old_parent != new_parent {
+            // Apply link-count deltas from the backend's atomic outcome. The
+            // pre-rename source/destination kinds may both be stale.
+            let old_parent_delta = if outcome.source_is_dir && old_parent != new_parent {
                 -1
             } else {
                 0
             };
-            let mut new_parent_delta = if src_is_dir && old_parent != new_parent {
+            let mut new_parent_delta = if outcome.source_is_dir && old_parent != new_parent {
                 1
             } else {
                 0
             };
-            if dest_is_dir {
+            if outcome.replaced_is_dir {
                 new_parent_delta -= 1;
             }
 
@@ -3501,6 +3482,46 @@ mod tests {
             .1;
         assert_eq!(linked_after.ino, dst);
         assert_eq!(linked_after.nlink, 1);
+    }
+
+    #[tokio::test]
+    async fn rename_ignores_stale_same_inode_destination_hint() {
+        let client = create_test_client().await;
+        let src = client.create_file(1, "src".to_string()).await.unwrap();
+        client.link(src, 1, "dst").await.unwrap();
+
+        let src_attr = client.stat(src).await.unwrap().unwrap();
+        let parent_attr = client.stat(1).await.unwrap().unwrap();
+
+        // Simulate another client replacing dst after this client resolved it
+        // as a hard link to src but before the backend rename begins.
+        client.store.unlink(1, "dst").await.unwrap();
+        let replaced = client
+            .store
+            .create_file(1, "dst".to_string())
+            .await
+            .unwrap();
+        let replaced_before = client.stat(replaced).await.unwrap().unwrap();
+        assert_eq!(replaced_before.nlink, 1);
+
+        client
+            .rename_with_known_attrs(
+                1,
+                "src",
+                1,
+                "dst".to_string(),
+                src,
+                src_attr,
+                parent_attr,
+                Some(src),
+                true,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(client.lookup(1, "src").await.unwrap(), None);
+        assert_eq!(client.lookup(1, "dst").await.unwrap(), Some(src));
+        assert_eq!(client.stat(replaced).await.unwrap().unwrap().nlink, 0);
     }
 
     #[tokio::test]

--- a/src/meta/store.rs
+++ b/src/meta/store.rs
@@ -324,6 +324,11 @@ pub struct MetaStoreCapabilities {
 pub struct RenameOutcome {
     pub ino: i64,
     pub replaced_ino: Option<i64>,
+    pub source_is_dir: bool,
+    pub replaced_is_dir: bool,
+    /// False when source and destination resolved to the same inode and the
+    /// backend left both names unchanged.
+    pub renamed: bool,
 }
 
 /// Directory entry
@@ -713,8 +718,9 @@ pub trait MetaStore: Send + Sync {
         new_parent: i64,
         new_name: String,
     ) -> Result<(), MetaError> {
-        self.rename_with_mode(old_parent, old_name, new_parent, new_name, false)
+        self.rename_with_outcome(old_parent, old_name, new_parent, new_name)
             .await
+            .map(|_| ())
     }
 
     /// Atomically rename an entry only if `new_parent/new_name` is absent.
@@ -731,6 +737,7 @@ pub trait MetaStore: Send + Sync {
     ) -> Result<(), MetaError> {
         self.rename_with_mode(old_parent, old_name, new_parent, new_name, true)
             .await
+            .map(|_| ())
     }
 
     /// Backend implementation for ordinary and no-replace rename.
@@ -741,7 +748,7 @@ pub trait MetaStore: Send + Sync {
         new_parent: i64,
         new_name: String,
         noreplace: bool,
-    ) -> Result<(), MetaError>;
+    ) -> Result<RenameOutcome, MetaError>;
 
     async fn rename_with_outcome(
         &self,
@@ -750,26 +757,8 @@ pub trait MetaStore: Send + Sync {
         new_parent: i64,
         new_name: String,
     ) -> Result<RenameOutcome, MetaError> {
-        if old_parent == new_parent && old_name == new_name {
-            let ino = self
-                .lookup(old_parent, old_name)
-                .await?
-                .ok_or(MetaError::NotFound(old_parent))?;
-            return Ok(RenameOutcome {
-                ino,
-                replaced_ino: None,
-            });
-        }
-
-        let ino = self
-            .lookup(old_parent, old_name)
-            .await?
-            .ok_or(MetaError::NotFound(old_parent))?;
-        let replaced_ino = self.lookup(new_parent, &new_name).await?;
-        let replaced_ino = replaced_ino.filter(|&replaced| replaced != ino);
-        self.rename(old_parent, old_name, new_parent, new_name)
-            .await?;
-        Ok(RenameOutcome { ino, replaced_ino })
+        self.rename_with_mode(old_parent, old_name, new_parent, new_name, false)
+            .await
     }
 
     /// Atomically exchange two files (RENAME_EXCHANGE)

--- a/src/meta/stores/database/mod.rs
+++ b/src/meta/stores/database/mod.rs
@@ -17,7 +17,7 @@ use crate::meta::file_lock::{
 };
 use crate::meta::store::{
     AclRule, CHUNK_LOCK_CHECK_TTL_SECS, DirEntry, FileAttr, LockName, MetaError, MetaStore,
-    OpenFlags, RetryReason, SetAttrFlags, SetAttrRequest, StatFsSnapshot,
+    OpenFlags, RenameOutcome, RetryReason, SetAttrFlags, SetAttrRequest, StatFsSnapshot,
     stat_fs_snapshot_from_usage, stat_fs_used_bytes,
 };
 use crate::meta::{INODE_ID_KEY, Permission, SLICE_ID_KEY};
@@ -1979,7 +1979,7 @@ impl MetaStore for DatabaseMetaStore {
         new_parent: i64,
         new_name: String,
         noreplace: bool,
-    ) -> Result<(), MetaError> {
+    ) -> Result<RenameOutcome, MetaError> {
         let (_sqlite_txn_guard, txn) = self.begin_transaction().await?;
 
         // Verify new parent exists and is a directory.
@@ -2044,10 +2044,25 @@ impl MetaStore for DatabaseMetaStore {
             });
         }
 
+        let replaced_ino = existing
+            .as_ref()
+            .map(|entry| entry.inode)
+            .filter(|&ino| ino != target_entry.inode);
+        let source_is_dir = FileType::from(target_entry.entry_type.clone()).is_dir();
+        let replaced_is_dir = existing
+            .as_ref()
+            .is_some_and(|entry| FileType::from(entry.entry_type.clone()).is_dir());
+
         if let Some(existing) = existing {
             if existing.inode == target_entry.inode {
                 txn.rollback().await.map_err(MetaError::Database)?;
-                return Ok(());
+                return Ok(RenameOutcome {
+                    ino: target_entry.inode,
+                    replaced_ino: None,
+                    source_is_dir,
+                    replaced_is_dir: false,
+                    renamed: false,
+                });
             }
 
             let target_kind = FileType::from(target_entry.entry_type.clone());
@@ -2249,7 +2264,13 @@ impl MetaStore for DatabaseMetaStore {
 
         txn.commit().await.map_err(MetaError::Database)?;
 
-        Ok(())
+        Ok(RenameOutcome {
+            ino: target_entry.inode,
+            replaced_ino,
+            source_is_dir,
+            replaced_is_dir,
+            renamed: true,
+        })
     }
 
     async fn rename_exchange(

--- a/src/meta/stores/etcd/mod.rs
+++ b/src/meta/stores/etcd/mod.rs
@@ -17,8 +17,8 @@ use crate::meta::file_lock::{
     FileLockInfo, FileLockQuery, FileLockRange, FileLockType, PlockRecord,
 };
 use crate::meta::store::{
-    DirEntry, FileAttr, LockName, MetaError, MetaStore, RetryReason, SetAttrFlags, SetAttrRequest,
-    StatFsSnapshot, stat_fs_snapshot_from_usage, stat_fs_used_bytes,
+    DirEntry, FileAttr, LockName, MetaError, MetaStore, RenameOutcome, RetryReason, SetAttrFlags,
+    SetAttrRequest, StatFsSnapshot, stat_fs_snapshot_from_usage, stat_fs_used_bytes,
 };
 use crate::meta::stores::pool::IdPool;
 use crate::meta::{INODE_ID_KEY, Permission};
@@ -2188,9 +2188,19 @@ impl MetaStore for EtcdMetaStore {
         new_parent: i64,
         new_name: String,
         noreplace: bool,
-    ) -> Result<(), MetaError> {
+    ) -> Result<RenameOutcome, MetaError> {
         if old_parent == new_parent && old_name == new_name {
-            return Ok(());
+            let ino = self
+                .lookup(old_parent, old_name)
+                .await?
+                .ok_or(MetaError::NotFound(old_parent))?;
+            return Ok(RenameOutcome {
+                ino,
+                replaced_ino: None,
+                source_is_dir: false,
+                replaced_is_dir: false,
+                renamed: false,
+            });
         }
 
         let old_forward_key = Self::etcd_forward_key(old_parent, old_name);
@@ -2200,7 +2210,7 @@ impl MetaStore for EtcdMetaStore {
             old_name, old_parent, new_name, new_parent
         );
 
-        let entry_ino = EtcdTxn::new(&self.client)
+        let outcome = EtcdTxn::new(&self.client)
             .max_retries(10)
             .run(|tx| {
                 let old_forward_key = old_forward_key.clone();
@@ -2222,6 +2232,9 @@ impl MetaStore for EtcdMetaStore {
                         .await?
                         .ok_or(MetaError::NotFound(entry_ino))?;
 
+                    let mut replaced_ino = None;
+                    let source_is_dir = !old_forward_entry.is_file;
+                    let mut replaced_is_dir = false;
                     if let Some(replaced_forward) = tx
                         .get_typed_json::<EtcdForwardEntry>(&new_forward_key)
                         .await?
@@ -2233,19 +2246,27 @@ impl MetaStore for EtcdMetaStore {
                             });
                         }
                         if replaced_forward.inode == entry_ino {
-                            return Ok(entry_ino);
+                            return Ok(RenameOutcome {
+                                ino: entry_ino,
+                                replaced_ino: None,
+                                source_is_dir,
+                                replaced_is_dir: false,
+                                renamed: false,
+                            });
                         }
 
-                        let replaced_ino = replaced_forward.inode;
-                        let replaced_reverse_key = Self::etcd_reverse_key(replaced_ino);
+                        replaced_ino = Some(replaced_forward.inode);
+                        replaced_is_dir = !replaced_forward.is_file;
+                        let replaced_ino_value = replaced_forward.inode;
+                        let replaced_reverse_key = Self::etcd_reverse_key(replaced_ino_value);
                         let mut replaced_info: EtcdEntryInfo = tx
                             .get_typed_json(&replaced_reverse_key)
                             .await?
-                            .ok_or(MetaError::NotFound(replaced_ino))?;
+                            .ok_or(MetaError::NotFound(replaced_ino_value))?;
 
                         match (entry_info.is_file, replaced_info.is_file) {
                             (false, false) => {
-                                let child_prefix = format!("f:{}:", replaced_ino);
+                                let child_prefix = format!("f:{}:", replaced_ino_value);
                                 let children = get_with_retry(&client, &child_prefix, || {
                                     Some(
                                         etcd_client::GetOptions::new()
@@ -2260,7 +2281,7 @@ impl MetaStore for EtcdMetaStore {
                                         ))
                                     })?;
                                 if !children.kvs().is_empty() {
-                                    return Err(MetaError::DirectoryNotEmpty(replaced_ino));
+                                    return Err(MetaError::DirectoryNotEmpty(replaced_ino_value));
                                 }
                                 tx.delete(replaced_reverse_key);
                             }
@@ -2280,13 +2301,13 @@ impl MetaStore for EtcdMetaStore {
                                     .unwrap_or(0);
                                 if replaced_info.nlink > 1 {
                                     let link_parent_key =
-                                        Self::etcd_link_parent_key(replaced_ino);
+                                        Self::etcd_link_parent_key(replaced_ino_value);
                                     let mut link_parents: Vec<EtcdLinkParent> = tx
                                         .get_typed_json(&link_parent_key)
                                         .await?
                                         .ok_or_else(|| {
                                             MetaError::Internal(format!(
-                                                "LinkParent key {link_parent_key} not found for replaced inode {replaced_ino}"
+                                                "LinkParent key {link_parent_key} not found for replaced inode {replaced_ino_value}"
                                             ))
                                         })?;
                                     let original_len = link_parents.len();
@@ -2296,14 +2317,14 @@ impl MetaStore for EtcdMetaStore {
                                     });
                                     if link_parents.len() == original_len {
                                         return Err(MetaError::Internal(format!(
-                                            "No destination LinkParent for inode {replaced_ino}"
+                                            "No destination LinkParent for inode {replaced_ino_value}"
                                         )));
                                     }
 
                                     if replaced_info.nlink == 2 {
                                         let remaining = link_parents.first().ok_or_else(|| {
                                             MetaError::Internal(format!(
-                                                "No remaining LinkParent for inode {replaced_ino}"
+                                                "No remaining LinkParent for inode {replaced_ino_value}"
                                             ))
                                         })?;
                                         replaced_info.parent_inode = remaining.parent_inode;
@@ -2371,10 +2392,20 @@ impl MetaStore for EtcdMetaStore {
                     tx.delete(&old_forward_key);
                     tx.set_typed_json(&reverse_key, &entry_info)?;
 
-                    Ok(entry_ino)
+                    Ok(RenameOutcome {
+                        ino: entry_ino,
+                        replaced_ino,
+                        source_is_dir,
+                        replaced_is_dir,
+                        renamed: true,
+                    })
                 })
             })
             .await?;
+
+        if !outcome.renamed {
+            return Ok(outcome);
+        }
 
         // Update parent directory timestamps
         let now = chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0);
@@ -2397,10 +2428,10 @@ impl MetaStore for EtcdMetaStore {
 
         info!(
             "Rename completed successfully: {} -> {}, inode={}",
-            old_name, new_name, entry_ino
+            old_name, new_name, outcome.ino
         );
 
-        Ok(())
+        Ok(outcome)
     }
 
     async fn rename_exchange(

--- a/src/meta/stores/redis/mod.rs
+++ b/src/meta/stores/redis/mod.rs
@@ -15,8 +15,8 @@ use crate::meta::file_lock::{
 };
 use crate::meta::store::{
     CreateEntryResult, DirEntry, DirStat, FileAttr, FileType, LockName, MetaError, MetaStore,
-    RetryReason, SetAttrFlags, SetAttrRequest, StatFsSnapshot, stat_fs_snapshot_from_usage,
-    stat_fs_used_bytes,
+    RenameOutcome, RetryReason, SetAttrFlags, SetAttrRequest, StatFsSnapshot,
+    stat_fs_snapshot_from_usage, stat_fs_used_bytes,
 };
 use crate::meta::{INODE_ID_KEY, SLICE_ID_KEY};
 use async_trait::async_trait;
@@ -1056,13 +1056,14 @@ const RENAME_LUA: &str = r#"
     -- replaced atomically; no window for concurrent renames to observe a partial state).
     local new_parent_nlink_adj = 0
     local replaced_ino = nil
+    local replaced_is_dir = false
     local dest_ino_str = redis.call('HGET', new_parent_dir_key, new_name)
     if dest_ino_str then
         if noreplace then
             return cjson.encode({ok=false, error="already_exists", ino=tonumber(dest_ino_str)})
         end
         if dest_ino_str == dentry_ino then
-            return cjson.encode({ok=true, ino=child_ino})
+            return cjson.encode({ok=true, ino=child_ino, source_is_dir=child_node.kind == "Dir", renamed=false})
         end
         replaced_ino = tonumber(dest_ino_str)
         local dest_node_key = node_prefix .. dest_ino_str
@@ -1077,6 +1078,7 @@ const RENAME_LUA: &str = r#"
 
         local src_kind = child_node.kind
         local dest_kind = dest_node.kind
+        replaced_is_dir = dest_kind == "Dir"
 
         if src_kind == "Dir" and dest_kind == "Dir" then
             -- Destination directory must be empty
@@ -1198,7 +1200,7 @@ const RENAME_LUA: &str = r#"
     new_parent_node.attr.ctime = timestamp
     redis.call('SET', new_parent_node_key, cjson.encode(new_parent_node))
 
-    return cjson.encode({ok=true, ino=child_ino, replaced_ino=replaced_ino})
+    return cjson.encode({ok=true, ino=child_ino, replaced_ino=replaced_ino, source_is_dir=child_node.kind == "Dir", replaced_is_dir=replaced_is_dir})
 "#;
 
 const RENAME_EXCHANGE_LUA: &str = r#"
@@ -1442,6 +1444,12 @@ struct LuaResponse {
     node: Option<String>,
     #[serde(default)]
     replaced_ino: Option<i64>,
+    #[serde(default)]
+    renamed: Option<bool>,
+    #[serde(default)]
+    source_is_dir: Option<bool>,
+    #[serde(default)]
+    replaced_is_dir: Option<bool>,
     #[serde(default)]
     msg: Option<String>, // For Internal error details
 }
@@ -2775,12 +2783,11 @@ impl MetaStore for RedisMetaStore {
         new_parent: i64,
         new_name: String,
         noreplace: bool,
-    ) -> Result<(), MetaError> {
+    ) -> Result<RenameOutcome, MetaError> {
         if !noreplace {
             return self
                 .rename_with_outcome(old_parent, old_name, new_parent, new_name)
-                .await
-                .map(|_| ());
+                .await;
         }
 
         let old_parent_dir_key = self.dir_key(old_parent);
@@ -2831,7 +2838,13 @@ impl MetaStore for RedisMetaStore {
                     .ok_or_else(|| MetaError::Internal("missing ino in rename response".into()))?;
                 self.invalidate_nodes(&[old_parent, new_parent, child])
                     .await;
-                Ok(())
+                Ok(RenameOutcome {
+                    ino: child,
+                    replaced_ino: None,
+                    source_is_dir: response.source_is_dir.unwrap_or(false),
+                    replaced_is_dir: false,
+                    renamed: true,
+                })
             }
             None => Err(MetaError::Internal("unexpected Lua response".into())),
         }
@@ -2853,6 +2866,9 @@ impl MetaStore for RedisMetaStore {
             return Ok(crate::meta::store::RenameOutcome {
                 ino,
                 replaced_ino: None,
+                source_is_dir: false,
+                replaced_is_dir: false,
+                renamed: false,
             });
         }
 
@@ -2917,6 +2933,9 @@ impl MetaStore for RedisMetaStore {
                 Ok(crate::meta::store::RenameOutcome {
                     ino: child,
                     replaced_ino,
+                    source_is_dir: response.source_is_dir.unwrap_or(false),
+                    replaced_is_dir: response.replaced_is_dir.unwrap_or(false),
+                    renamed: response.renamed.unwrap_or(true),
                 })
             }
             None => Err(MetaError::Internal("unexpected Lua response".into())),

--- a/src/meta/stores/tikv/mod.rs
+++ b/src/meta/stores/tikv/mod.rs
@@ -12,7 +12,7 @@ use crate::meta::file_lock::{
 };
 use crate::meta::store::{
     CreateEntryResult, DirEntry, FileAttr, FileType, MetaError, MetaStore, MetaStoreCapabilities,
-    OpenFlags, RetryReason, SetAttrFlags, SetAttrRequest, StatFsSnapshot,
+    OpenFlags, RenameOutcome, RetryReason, SetAttrFlags, SetAttrRequest, StatFsSnapshot,
     stat_fs_snapshot_from_usage, stat_fs_used_bytes,
 };
 use crate::meta::{INODE_ID_KEY, SLICE_ID_KEY};
@@ -1765,9 +1765,19 @@ impl MetaStore for TiKvMetaStore {
         new_parent: i64,
         new_name: String,
         noreplace: bool,
-    ) -> Result<(), MetaError> {
+    ) -> Result<RenameOutcome, MetaError> {
         if old_parent == new_parent && old_name == new_name {
-            return Ok(());
+            let ino = self
+                .lookup(old_parent, old_name)
+                .await?
+                .ok_or(MetaError::NotFound(old_parent))?;
+            return Ok(RenameOutcome {
+                ino,
+                replaced_ino: None,
+                source_is_dir: false,
+                replaced_is_dir: false,
+                renamed: false,
+            });
         }
 
         let operation = "rename";
@@ -1825,6 +1835,10 @@ impl MetaStore for TiKvMetaStore {
                     .as_deref()
                     .map(Self::decode_dentry)
                     .transpose()?;
+                let replaced_ino = destination
+                    .as_ref()
+                    .map(|entry| entry.ino)
+                    .filter(|&ino| ino != source_dentry.ino);
                 if noreplace && destination.is_some() {
                     return Err(MetaError::AlreadyExists {
                         parent: new_parent,
@@ -1851,10 +1865,17 @@ impl MetaStore for TiKvMetaStore {
                 let now = Self::now();
                 let mut old_parent_nlink_delta = 0;
                 let mut new_parent_nlink_delta = 0;
+                let mut destination_is_dir = false;
 
                 if let Some(dest_dentry) = destination {
                     if dest_dentry.ino == source_dentry.ino {
-                        return Ok(());
+                        return Ok(RenameOutcome {
+                            ino: source_dentry.ino,
+                            replaced_ino: None,
+                            source_is_dir: source_node.kind == StoredNodeKind::Dir,
+                            replaced_is_dir: false,
+                            renamed: false,
+                        });
                     }
 
                     let dest_inode_key = store.inode_key(dest_dentry.ino);
@@ -1864,6 +1885,7 @@ impl MetaStore for TiKvMetaStore {
                         .map(Self::decode_node)
                         .transpose()?
                         .ok_or(MetaError::NotFound(dest_dentry.ino))?;
+                    destination_is_dir = dest_node.kind == StoredNodeKind::Dir;
 
                     match (source_node.kind, dest_node.kind) {
                         (StoredNodeKind::Dir, StoredNodeKind::Dir) => {
@@ -1955,7 +1977,14 @@ impl MetaStore for TiKvMetaStore {
 
                 store
                     .txn_put_dentry(txn, new_parent, &new_name, &source_dentry, operation)
-                    .await
+                    .await?;
+                Ok(RenameOutcome {
+                    ino: source_dentry.ino,
+                    replaced_ino,
+                    source_is_dir: source_node.kind == StoredNodeKind::Dir,
+                    replaced_is_dir: destination_is_dir,
+                    renamed: true,
+                })
             })
         })
         .await

--- a/src/workspace_overlay/meta_layer/mod.rs
+++ b/src/workspace_overlay/meta_layer/mod.rs
@@ -786,29 +786,7 @@ impl<W: WorkspaceStore + 'static> MetaLayer for WorkspaceMetaLayer<W> {
         if let Some(destination) = destination.as_ref()
             && destination.ino == source.ino
         {
-            // POSIX rename onto another hard link to the same inode removes
-            // only the old name.
-            source_inode.nlink = source_inode
-                .nlink
-                .checked_sub(1)
-                .ok_or_else(|| MetaError::Internal("inode link count underflow".into()))?;
-            source_inode.ctime_ns = now_ns()?;
-            let guard = self.guard().await;
-            source_inode.layer_id = guard.expected_head_layer_id;
-            source_inode.sequence = 0;
-            self.store
-                .apply_namespace_mutation(NamespaceMutation {
-                    guard,
-                    dentries: vec![DentryDelta::whiteout(
-                        source_inode.layer_id,
-                        old_parent,
-                        old_name.as_bytes().to_vec(),
-                        0,
-                    )],
-                    inodes: vec![source_inode],
-                })
-                .await
-                .map_err(workspace_to_meta)?;
+            // POSIX rename onto another hard link to the same inode is a no-op.
             return Ok(());
         }
 

--- a/src/workspace_overlay/meta_layer/tests.rs
+++ b/src/workspace_overlay/meta_layer/tests.rs
@@ -113,6 +113,22 @@ async fn rename_exchange_and_hardlink_update_dentries_and_nlink_atomically() {
 }
 
 #[tokio::test]
+async fn rename_onto_same_inode_keeps_both_hard_links() {
+    let meta = test_meta().await;
+    let root = meta.root_ino();
+    let file = meta.create_file(root, "file".into()).await.unwrap();
+    meta.link(file, root, "alias").await.unwrap();
+
+    meta.rename(root, "file", root, "alias".into())
+        .await
+        .unwrap();
+
+    assert_eq!(meta.lookup(root, "file").await.unwrap(), Some(file));
+    assert_eq!(meta.lookup(root, "alias").await.unwrap(), Some(file));
+    assert_eq!(meta.stat(file).await.unwrap().unwrap().nlink, 2);
+}
+
+#[tokio::test]
 async fn symlink_setattr_and_xattr_mutations_round_trip() {
     let meta = test_meta().await;
     let root = meta.root_ino();


### PR DESCRIPTION
## Summary
- keep same-path and same-inode renames as no-ops without deleting either entry
- delegate destination replacement to the metadata backend's atomic rename operation
- preserve both source and destination when a rename fails
- add regressions for file, directory, normalized-path, hard-link, replacement, and failure cases

## Testing
- full local Rust CI gate: formatting, shell checks, workspace check/build, feature-matrix checks, default/workspace-overlay/all-features tests, and Clippy with warnings denied

Fixes #71