### PR TITLE
fix(cache): namespace flat-volume cache and writeback state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1232,6 +1232,7 @@ dependencies = [
  "tracing-chrome",
  "tracing-flame",
  "tracing-subscriber",
+ "url",
  "uuid",
  "zstd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -296,6 +296,7 @@ redis = { workspace = true }
 bincode = { workspace = true, optional = true }
 if-addrs = { workspace = true }
 uuid = { workspace = true, features = ["v7"] }
+url = { workspace = true }
 parking_lot = { workspace = true }
 tikv-jemallocator = { workspace = true, optional = true }
 tikv-client = { workspace = true }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,8 @@
 use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
 use serde::Deserialize;
+use sha2::{Digest, Sha256};
 use std::path::PathBuf;
+use url::Url;
 
 use crate::chunk::bandwidth::BandwidthConfig;
 use crate::chunk::cache_integrity::CacheIntegrityMode;
@@ -732,6 +734,157 @@ impl MountConfig {
             compact,
         })
     }
+
+    /// Derive a stable, non-secret identity for the persistent state owned by
+    /// a flat volume. Both halves are required: metadata identifies the inode
+    /// and slice namespace, while the data backend identifies the objects to
+    /// which those slice IDs refer.
+    pub(crate) fn flat_volume_cache_scope(&self) -> anyhow::Result<String> {
+        let mut parts = vec!["flat-v1".to_string()];
+
+        match self.meta_backend {
+            MetaBackendKind::Sqlx => {
+                parts.push("meta:sqlx".to_string());
+                if crate::meta::stores::database::is_sqlite_memory_url(&self.meta_url) {
+                    // In-memory metadata has no identity that survives a
+                    // restart, so it must never recover persistent cache state
+                    // produced by an earlier mount.
+                    parts.push(format!("ephemeral:{}", uuid::Uuid::new_v4()));
+                } else {
+                    parts.push(scrubbed_url_identity(&self.meta_url));
+                }
+            }
+            MetaBackendKind::Redis => {
+                parts.push("meta:redis".to_string());
+                parts.push(scrubbed_url_identity(&self.meta_url));
+            }
+            MetaBackendKind::Etcd => {
+                parts.push("meta:etcd".to_string());
+                let mut endpoints = self
+                    .meta_etcd_urls
+                    .iter()
+                    .map(|endpoint| scrubbed_url_identity(endpoint))
+                    .collect::<Vec<_>>();
+                endpoints.sort_unstable();
+                parts.extend(endpoints);
+            }
+            MetaBackendKind::TiKv => {
+                parts.push("meta:tikv".to_string());
+                let mut endpoints = self
+                    .meta_tikv_pd_endpoints
+                    .iter()
+                    .map(|endpoint| scrubbed_url_identity(endpoint))
+                    .collect::<Vec<_>>();
+                endpoints.sort_unstable();
+                parts.extend(endpoints);
+                parts.push(format!("namespace:{}", self.meta_tikv_namespace));
+            }
+        }
+
+        match self.data_backend {
+            DataBackendKind::LocalFs => {
+                parts.push("data:localfs".to_string());
+                // Keep this lexical rather than canonical: the identity must
+                // not change merely because the directory is created between
+                // two mounts, and treating symlink aliases as separate cache
+                // owners is safe.
+                let identity = std::path::absolute(&self.data_dir)?;
+                parts.push(identity.to_string_lossy().into_owned());
+            }
+            DataBackendKind::S3 => {
+                parts.push("data:s3".to_string());
+                parts.push(format!(
+                    "endpoint:{}",
+                    self.s3_endpoint
+                        .as_deref()
+                        .map(scrubbed_url_identity)
+                        // Without an explicit endpoint the AWS SDK may resolve
+                        // a different service from the environment or active
+                        // profile. Do not persistently reuse cache state when
+                        // that identity cannot be derived from MountConfig.
+                        .unwrap_or_else(|| format!("ephemeral:{}", uuid::Uuid::new_v4()))
+                ));
+                parts.push(format!(
+                    "bucket:{}",
+                    self.s3_bucket.as_deref().unwrap_or_default()
+                ));
+                parts.push(format!(
+                    "region:{}",
+                    self.s3_region.as_deref().unwrap_or_default()
+                ));
+            }
+        }
+
+        let mut hasher = Sha256::new();
+        for part in parts {
+            hasher.update((part.len() as u64).to_be_bytes());
+            hasher.update(part.as_bytes());
+        }
+        Ok(hex::encode(hasher.finalize()))
+    }
+}
+
+fn scrubbed_url_identity(raw: &str) -> String {
+    fn is_secret_query_key(key: &str) -> bool {
+        let key = key.to_ascii_lowercase().replace('-', "_");
+        key.contains("password")
+            || key.contains("passwd")
+            || key.contains("secret")
+            || key.contains("credential")
+            || key == "token"
+            || key.starts_with("token_")
+            || key.ends_with("_token")
+            || key == "api_key"
+            || key == "access_key"
+            || key == "access_key_id"
+            || key == "signature"
+            || key.ends_with("_signature")
+            || key == "authorization"
+    }
+
+    fn scrub(mut url: Url) -> String {
+        let _ = url.set_username("");
+        let _ = url.set_password(None);
+        let mut query = url
+            .query_pairs()
+            .map(|(key, value)| {
+                let key = key.into_owned();
+                let value = if is_secret_query_key(&key) {
+                    "<redacted>".to_string()
+                } else {
+                    value.into_owned()
+                };
+                (key, value)
+            })
+            .collect::<Vec<_>>();
+        query.sort_unstable();
+        url.set_query(None);
+        if !query.is_empty() {
+            url.query_pairs_mut().extend_pairs(
+                query
+                    .iter()
+                    .map(|(key, value)| (key.as_str(), value.as_str())),
+            );
+        }
+        url.set_fragment(None);
+        url.to_string()
+    }
+
+    let raw = raw.trim();
+    if let Ok(url) = Url::parse(raw)
+        && url.has_host()
+    {
+        return scrub(url);
+    }
+    if let Ok(url) = Url::parse(&format!("http://{raw}"))
+        && url.has_host()
+    {
+        return scrub(url)
+            .strip_prefix("http://")
+            .unwrap_or(raw)
+            .to_string();
+    }
+    raw.to_string()
 }
 
 impl CacheFileConfig {
@@ -1434,6 +1587,132 @@ cache:
         let _ = std::fs::remove_file(path);
 
         assert!(err.to_string().contains("requires data.backend=s3"));
+    }
+
+    #[test]
+    fn flat_cache_scope_is_stable_across_credential_rotation() {
+        let data_dir = std::env::temp_dir().join("brewfs-flat-cache-scope-data");
+        let mut first = empty_mount_args(None, Some(PathBuf::from("/mnt/first")));
+        first.data_backend = Some(DataBackendKind::S3);
+        first.s3_bucket = Some("volume-bucket".to_string());
+        first.s3_region = Some("us-test-1".to_string());
+        first.s3_endpoint =
+            Some("https://alice:old-secret@objects.example.test?token=old".to_string());
+        first.meta_url = Some(
+            "postgres://alice:old-secret@metadata.example.test/brewfs?password=old".to_string(),
+        );
+        first.data_dir = Some(data_dir.clone());
+
+        let mut second = first.clone();
+        second.s3_endpoint =
+            Some("https://bob:new-secret@objects.example.test?token=new".to_string());
+        second.meta_url =
+            Some("postgres://bob:new-secret@metadata.example.test/brewfs?password=new".to_string());
+
+        let first = MountConfig::from_sources(first).unwrap();
+        let second = MountConfig::from_sources(second).unwrap();
+        assert_eq!(
+            first.flat_volume_cache_scope().unwrap(),
+            second.flat_volume_cache_scope().unwrap()
+        );
+    }
+
+    #[test]
+    fn flat_cache_scope_changes_with_either_volume_identity() {
+        let mut base = empty_mount_args(None, Some(PathBuf::from("/mnt/base")));
+        base.data_dir = Some(PathBuf::from("/var/lib/brewfs/objects-a"));
+        base.meta_url = Some("postgres://metadata.example.test/volume-a".to_string());
+
+        let mut other_metadata = base.clone();
+        other_metadata.meta_url = Some("postgres://metadata.example.test/volume-b".to_string());
+        let mut other_objects = base.clone();
+        other_objects.data_dir = Some(PathBuf::from("/var/lib/brewfs/objects-b"));
+
+        let base = MountConfig::from_sources(base).unwrap();
+        let other_metadata = MountConfig::from_sources(other_metadata).unwrap();
+        let other_objects = MountConfig::from_sources(other_objects).unwrap();
+        let base_scope = base.flat_volume_cache_scope().unwrap();
+
+        assert_ne!(
+            base_scope,
+            other_metadata.flat_volume_cache_scope().unwrap()
+        );
+        assert_ne!(base_scope, other_objects.flat_volume_cache_scope().unwrap());
+    }
+
+    #[test]
+    fn flat_cache_scope_preserves_non_secret_metadata_query_identity() {
+        let mut first = empty_mount_args(None, Some(PathBuf::from("/mnt/first")));
+        first.data_dir = Some(PathBuf::from("/var/lib/brewfs/objects"));
+        first.meta_url = Some(
+            "postgres://metadata.example.test/brewfs?options=-csearch_path%3Dvolume_a&password=old"
+                .to_string(),
+        );
+
+        let mut second = first.clone();
+        second.meta_url = Some(
+            "postgres://metadata.example.test/brewfs?password=new&options=-csearch_path%3Dvolume_b"
+                .to_string(),
+        );
+        let mut reordered = first.clone();
+        reordered.meta_url = Some(
+            "postgres://metadata.example.test/brewfs?password=rotated&options=-csearch_path%3Dvolume_a"
+                .to_string(),
+        );
+
+        let first = MountConfig::from_sources(first).unwrap();
+        let second = MountConfig::from_sources(second).unwrap();
+        let reordered = MountConfig::from_sources(reordered).unwrap();
+        assert_eq!(
+            first.flat_volume_cache_scope().unwrap(),
+            reordered.flat_volume_cache_scope().unwrap()
+        );
+        assert_ne!(
+            first.flat_volume_cache_scope().unwrap(),
+            second.flat_volume_cache_scope().unwrap()
+        );
+    }
+
+    #[test]
+    fn implicit_s3_endpoint_never_reuses_persistent_cache_scope() {
+        let mut args = empty_mount_args(None, Some(PathBuf::from("/mnt/first")));
+        args.data_backend = Some(DataBackendKind::S3);
+        args.s3_bucket = Some("volume-bucket".to_string());
+        args.s3_region = Some("us-test-1".to_string());
+        args.meta_url = Some("postgres://metadata.example.test/brewfs".to_string());
+
+        let first = MountConfig::from_sources(args).unwrap();
+        let second = first.clone();
+        assert_ne!(
+            first.flat_volume_cache_scope().unwrap(),
+            second.flat_volume_cache_scope().unwrap()
+        );
+    }
+
+    #[test]
+    fn in_memory_metadata_never_reuses_persistent_cache_scope() {
+        let first =
+            MountConfig::from_sources(empty_mount_args(None, Some(PathBuf::from("/mnt/first"))))
+                .unwrap();
+        let second = first.clone();
+
+        assert_ne!(
+            first.flat_volume_cache_scope().unwrap(),
+            second.flat_volume_cache_scope().unwrap()
+        );
+    }
+
+    #[test]
+    fn sqlite_file_memory_metadata_never_reuses_persistent_cache_scope() {
+        let mut args = empty_mount_args(None, Some(PathBuf::from("/mnt/first")));
+        args.meta_url = Some("sqlite:file::memory:?cache=shared".to_string());
+
+        let first = MountConfig::from_sources(args).unwrap();
+        let second = first.clone();
+        assert_ne!(
+            first.flat_volume_cache_scope().unwrap(),
+            second.flat_volume_cache_scope().unwrap()
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -357,7 +357,7 @@ fn init_tracing() {
     }
 }
 
-async fn mount_cmd(args: MountConfig) -> anyhow::Result<()> {
+async fn mount_cmd(mut args: MountConfig) -> anyhow::Result<()> {
     validate_volume_format_support(args.volume_format)?;
     if !args.mount_point.exists() {
         std::fs::create_dir_all(&args.mount_point)?;
@@ -369,6 +369,8 @@ async fn mount_cmd(args: MountConfig) -> anyhow::Result<()> {
     if args.chunk_size < args.block_size as u64 {
         anyhow::bail!("chunk_size must be >= block_size");
     }
+
+    namespace_flat_volume_cache(&mut args)?;
 
     let layout = ChunkLayout {
         chunk_size: args.chunk_size,
@@ -415,7 +417,7 @@ async fn gateway_s3_cmd(args: S3GatewayArgs) -> anyhow::Result<()> {
     if mount_args.mount_point.is_none() {
         mount_args.mount_point = Some(std::path::PathBuf::from("/brewfs-s3-gateway"));
     }
-    let cfg = MountConfig::from_sources(mount_args)?;
+    let mut cfg = MountConfig::from_sources(mount_args)?;
     if cfg.volume_format != VolumeFormat::FlatV1 {
         anyhow::bail!("s3 gateway only supports volume_format=flat-v1");
     }
@@ -424,6 +426,7 @@ async fn gateway_s3_cmd(args: S3GatewayArgs) -> anyhow::Result<()> {
     if cfg.chunk_size < cfg.block_size as u64 {
         anyhow::bail!("chunk_size must be >= block_size");
     }
+    namespace_flat_volume_cache(&mut cfg)?;
     let layout = ChunkLayout {
         chunk_size: cfg.chunk_size,
         block_size: cfg.block_size,
@@ -493,6 +496,169 @@ async fn gateway_s3_cmd(args: S3GatewayArgs) -> anyhow::Result<()> {
             )
             .await
         }
+    }
+}
+
+fn namespace_flat_volume_cache(args: &mut MountConfig) -> anyhow::Result<()> {
+    if args.volume_format != VolumeFormat::FlatV1 {
+        return Ok(());
+    }
+
+    let unscoped_root = args.cache.cache_root.clone();
+    let scope = args.flat_volume_cache_scope()?;
+    for legacy_path in [
+        unscoped_root.join("chunks"),
+        unscoped_root.join("writeback"),
+    ] {
+        if legacy_path.exists() {
+            tracing::warn!(
+                path = %legacy_path.display(),
+                "ignoring legacy unscoped flat-volume cache state"
+            );
+        }
+    }
+    args.cache.cache_root = unscoped_root.join("flat-v1").join(&scope);
+    args.cache.volume_scope = Some(scope.clone());
+    tracing::info!(
+        volume_scope = %scope,
+        cache_root = %args.cache.cache_root.display(),
+        "flat-volume cache namespace selected"
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod flat_cache_namespace_tests {
+    use super::*;
+
+    fn flat_config(
+        mount_point: &std::path::Path,
+        data_dir: &std::path::Path,
+        meta_url: &str,
+        shared_cache_root: &std::path::Path,
+    ) -> MountConfig {
+        let cli = Cli::parse_from([
+            "brewfs",
+            "mount",
+            "--data-dir",
+            data_dir.to_str().unwrap(),
+            "--meta-url",
+            meta_url,
+            mount_point.to_str().unwrap(),
+        ]);
+        let Command::Mount(args) = cli.cmd else {
+            unreachable!()
+        };
+        let mut config = MountConfig::from_sources(*args).unwrap();
+        config.block_size = 16;
+        config.chunk_size = 64;
+        config.cache.cache_root = shared_cache_root.to_path_buf();
+        config.cache.read_memory_bytes = 1024 * 1024;
+        config.cache.read_ssd_bytes = 1024 * 1024;
+        config.cache.persist_write_cache_after_upload = true;
+        namespace_flat_volume_cache(&mut config).unwrap();
+        config
+    }
+
+    #[tokio::test]
+    async fn flat_volumes_isolate_clean_cache_for_overlapping_slice_ids() {
+        let temp = tempfile::tempdir().unwrap();
+        let cache_root = temp.path().join("cache");
+        let legacy_chunks = cache_root.join("chunks");
+        std::fs::create_dir_all(&legacy_chunks).unwrap();
+        std::fs::write(legacy_chunks.join("legacy-entry"), b"untouched").unwrap();
+
+        let first = flat_config(
+            &temp.path().join("mount-a"),
+            &temp.path().join("objects-a"),
+            "postgres://metadata.example.test/volume-a",
+            &cache_root,
+        );
+        let second = flat_config(
+            &temp.path().join("mount-b"),
+            &temp.path().join("objects-b"),
+            "postgres://metadata.example.test/volume-b",
+            &cache_root,
+        );
+        assert_ne!(first.cache.cache_root, second.cache.cache_root);
+        assert!(
+            first
+                .cache
+                .cache_root
+                .starts_with(cache_root.join("flat-v1"))
+        );
+        assert!(
+            second
+                .cache
+                .cache_root
+                .starts_with(cache_root.join("flat-v1"))
+        );
+
+        std::fs::create_dir_all(&first.data_dir).unwrap();
+        std::fs::create_dir_all(&second.data_dir).unwrap();
+        let layout = ChunkLayout {
+            chunk_size: 64,
+            block_size: 16,
+        };
+        let first_writer = create_object_store(
+            ObjectClient::new(LocalFsBackend::new(&first.data_dir)),
+            layout,
+            &first.cache,
+        )
+        .await
+        .unwrap();
+        let second_writer = create_object_store(
+            ObjectClient::new(LocalFsBackend::new(&second.data_dir)),
+            layout,
+            &second.cache,
+        )
+        .await
+        .unwrap();
+        first_writer
+            .write_fresh_range((77, 0), 0, b"first-volume-123")
+            .await
+            .unwrap();
+        second_writer
+            .write_fresh_range((77, 0), 0, b"second-volume-12")
+            .await
+            .unwrap();
+        drop(first_writer);
+        drop(second_writer);
+
+        // Force both remounts to rely on their persistent clean-cache trees.
+        std::fs::remove_dir_all(&first.data_dir).unwrap();
+        std::fs::remove_dir_all(&second.data_dir).unwrap();
+        let first_reader = create_object_store(
+            ObjectClient::new(LocalFsBackend::new(&first.data_dir)),
+            layout,
+            &first.cache,
+        )
+        .await
+        .unwrap();
+        let second_reader = create_object_store(
+            ObjectClient::new(LocalFsBackend::new(&second.data_dir)),
+            layout,
+            &second.cache,
+        )
+        .await
+        .unwrap();
+        let mut first_out = [0_u8; 16];
+        let mut second_out = [0_u8; 16];
+        first_reader
+            .read_range((77, 0), 0, &mut first_out)
+            .await
+            .unwrap();
+        second_reader
+            .read_range((77, 0), 0, &mut second_out)
+            .await
+            .unwrap();
+
+        assert_eq!(&first_out, b"first-volume-123");
+        assert_eq!(&second_out, b"second-volume-12");
+        assert_eq!(
+            std::fs::read(legacy_chunks.join("legacy-entry")).unwrap(),
+            b"untouched"
+        );
     }
 }
 

--- a/src/meta/stores/database/mod.rs
+++ b/src/meta/stores/database/mod.rs
@@ -21,7 +21,6 @@ use crate::meta::store::{
     stat_fs_snapshot_from_usage, stat_fs_used_bytes,
 };
 use crate::meta::{INODE_ID_KEY, Permission, SLICE_ID_KEY};
-
 use crate::utils::NumCastExt;
 use crate::vfs::chunk_id_for;
 use crate::vfs::fs::FileType;
@@ -45,6 +44,10 @@ use tokio::select;
 use tokio::sync::{Mutex, OwnedMutexGuard};
 use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, debug, error, warn};
+
+pub(crate) fn is_sqlite_memory_url(url: &str) -> bool {
+    url.contains("file::memory:") || url.contains("::memory:")
+}
 
 const DATABASE_ACL_RULES_XATTR_NAME: &str = "system.brewfs.acl.rules";
 
@@ -276,7 +279,7 @@ impl DatabaseMetaStore {
                 let mut opts = ConnectOptions::new(url.clone());
                 if url.contains("file::memory:") {
                     opts.max_connections(1).min_connections(1);
-                } else if url.contains("::memory:") {
+                } else if is_sqlite_memory_url(url) {
                     opts.max_connections(5).min_connections(1);
                 } else {
                     // Reads and standalone writes may use the pool concurrently. Deferred

--- a/src/vfs/cache/config.rs
+++ b/src/vfs/cache/config.rs
@@ -45,6 +45,10 @@ pub enum WriteBackMode {
 #[derive(Debug, Clone)]
 pub struct CacheConfig {
     pub cache_root: PathBuf,
+    /// Runtime-only identity of the flat volume that owns this cache tree.
+    /// Configuration parsing leaves this unset; mount startup derives it from
+    /// the metadata and object-store identities before constructing the VFS.
+    pub volume_scope: Option<String>,
 
     // Read cache budgets
     pub read_memory_bytes: u64,
@@ -96,6 +100,7 @@ impl Default for CacheConfig {
     fn default() -> Self {
         Self {
             cache_root: default_cache_root(),
+            volume_scope: None,
             read_memory_bytes: 4096 * 1024 * 1024,
             read_ssd_bytes: 20 * 1024 * 1024 * 1024,
             write_memory_bytes: 384 * 1024 * 1024,

--- a/src/vfs/cache/keys.rs
+++ b/src/vfs/cache/keys.rs
@@ -50,12 +50,17 @@ impl DirtySliceKey {
         root: &std::path::Path,
         chunk_offset: u64,
         length: u64,
+        volume_scope_fingerprint: Option<&str>,
     ) -> std::path::PathBuf {
+        let scope_suffix = volume_scope_fingerprint
+            .map(|scope| format!("_{scope}"))
+            .unwrap_or_default();
         self.dir_path(root).join(format!(
-            "{}_{}_{}.sealed",
+            "{}_{}_{}{}.sealed",
             self.file_stem(),
             chunk_offset,
-            length
+            length,
+            scope_suffix
         ))
     }
 
@@ -63,10 +68,10 @@ impl DirtySliceKey {
         format!("{}_", self.file_stem())
     }
 
-    pub(crate) fn parse_sealed_file_name(name: &str) -> Option<(Self, u64, u64)> {
+    pub(crate) fn parse_sealed_file_name(name: &str) -> Option<(Self, u64, u64, Option<String>)> {
         let stem = name.strip_suffix(".sealed")?;
         let parts: Vec<&str> = stem.split('_').collect();
-        if parts.len() != 6 {
+        if !matches!(parts.len(), 6 | 7) {
             return None;
         }
         Some((
@@ -78,6 +83,7 @@ impl DirtySliceKey {
             },
             parts[4].parse().ok()?,
             parts[5].parse().ok()?,
+            parts.get(6).map(|scope| (*scope).to_string()),
         ))
     }
 
@@ -157,14 +163,24 @@ mod tests {
             epoch: 3,
         };
 
-        let path = key.sealed_slice_path(root, 4096, 8192);
+        let path = key.sealed_slice_path(root, 4096, 8192, None);
         let file_name = path.file_name().unwrap().to_str().unwrap();
-        let (parsed_key, chunk_offset, length) =
+        let (parsed_key, chunk_offset, length, volume_scope) =
             DirtySliceKey::parse_sealed_file_name(file_name).unwrap();
 
         assert_eq!(parsed_key, key);
         assert_eq!(chunk_offset, 4096);
         assert_eq!(length, 8192);
+        assert!(volume_scope.is_none());
+
+        let scoped_path = key.sealed_slice_path(root, 4096, 8192, Some("abc123"));
+        let scoped_name = scoped_path.file_name().unwrap().to_str().unwrap();
+        let (parsed_key, chunk_offset, length, volume_scope) =
+            DirtySliceKey::parse_sealed_file_name(scoped_name).unwrap();
+        assert_eq!(parsed_key, key);
+        assert_eq!(chunk_offset, 4096);
+        assert_eq!(length, 8192);
+        assert_eq!(volume_scope.as_deref(), Some("abc123"));
     }
 }
 

--- a/src/vfs/cache/write_back.rs
+++ b/src/vfs/cache/write_back.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use bytes::Bytes;
 use dashmap::DashSet;
+use sha2::{Digest, Sha256};
 use tokio::fs;
 use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 
@@ -13,6 +14,8 @@ use super::keys::{DirtySliceKey, DirtySliceState};
 /// Record describing a dirty slice persisted to local SSD.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct DirtySliceRecord {
+    #[serde(default)]
+    pub volume_scope: Option<String>,
     pub key: DirtySliceKey,
     pub ino: i64,
     pub chunk_id: u64,
@@ -80,6 +83,7 @@ pub trait WriteBackCache: Send + Sync {
 ///     — sealed data and record for high-throughput unsynced writeback
 pub struct FsWriteBackCache {
     root: PathBuf,
+    volume_scope: Option<String>,
     seq: AtomicU64,
     sync_on_persist: bool,
     read_cache_root: Option<PathBuf>,
@@ -96,6 +100,7 @@ impl FsWriteBackCache {
     pub fn new_with_sync(root: PathBuf, sync_on_persist: bool) -> Self {
         Self {
             root,
+            volume_scope: None,
             seq: AtomicU64::new(0),
             sync_on_persist,
             read_cache_root: None,
@@ -113,6 +118,7 @@ impl FsWriteBackCache {
     ) -> Self {
         Self {
             root,
+            volume_scope: None,
             seq: AtomicU64::new(0),
             sync_on_persist,
             read_cache_root: Some(read_cache_root),
@@ -122,8 +128,19 @@ impl FsWriteBackCache {
         }
     }
 
+    pub fn with_volume_scope(mut self, volume_scope: Option<String>) -> Self {
+        self.volume_scope = volume_scope;
+        self
+    }
+
     pub fn next_seq(&self) -> u64 {
         self.seq.fetch_add(1, Ordering::Relaxed)
+    }
+
+    fn volume_scope_fingerprint(&self) -> Option<String> {
+        self.volume_scope
+            .as_ref()
+            .map(|scope| hex::encode(Sha256::digest(scope.as_bytes())))
     }
 
     async fn write_meta_at(
@@ -161,6 +178,13 @@ impl FsWriteBackCache {
     async fn read_meta(&self, meta_path: &Path) -> anyhow::Result<DirtySliceRecord> {
         let data = fs::read(meta_path).await?;
         let record: DirtySliceRecord = serde_json::from_slice(&data)?;
+        anyhow::ensure!(
+            record.volume_scope == self.volume_scope,
+            "writeback volume scope mismatch at {}: expected {:?}, found {:?}",
+            meta_path.display(),
+            self.volume_scope,
+            record.volume_scope
+        );
         Ok(record)
     }
 
@@ -172,10 +196,15 @@ impl FsWriteBackCache {
         path.extension().and_then(|e| e.to_str()) == Some("sealed")
     }
 
-    fn sealed_record_from_path(path: PathBuf) -> Option<DirtySliceRecord> {
+    fn sealed_record_from_path(&self, path: PathBuf) -> Option<DirtySliceRecord> {
         let file_name = path.file_name()?.to_str()?;
-        let (key, chunk_offset, length) = DirtySliceKey::parse_sealed_file_name(file_name)?;
+        let (key, chunk_offset, length, record_scope) =
+            DirtySliceKey::parse_sealed_file_name(file_name)?;
+        if record_scope != self.volume_scope_fingerprint() {
+            return None;
+        }
         Some(DirtySliceRecord {
+            volume_scope: self.volume_scope.clone(),
             key,
             ino: key.ino,
             chunk_id: key.chunk_id,
@@ -211,8 +240,8 @@ impl FsWriteBackCache {
         Ok(())
     }
 
-    fn push_recoverable_sealed(path: PathBuf, records: &mut Vec<DirtySliceRecord>) {
-        match Self::sealed_record_from_path(path.clone()) {
+    fn push_recoverable_sealed(&self, path: PathBuf, records: &mut Vec<DirtySliceRecord>) {
+        match self.sealed_record_from_path(path.clone()) {
             Some(record) => records.push(record),
             None => {
                 tracing::warn!(path = ?path, "invalid sealed writeback record name");
@@ -234,7 +263,7 @@ impl FsWriteBackCache {
             if Self::is_meta_path(&path) {
                 self.push_recoverable_meta(&path, records).await?;
             } else if Self::is_sealed_path(&path) {
-                Self::push_recoverable_sealed(path, records);
+                self.push_recoverable_sealed(path, records);
             }
         }
         Ok(())
@@ -256,7 +285,9 @@ impl FsWriteBackCache {
             let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
                 continue;
             };
-            if file_name.starts_with(&prefix) {
+            if file_name.starts_with(&prefix)
+                && self.sealed_record_from_path(path.clone()).is_some()
+            {
                 return Ok(Some(path));
             }
         }
@@ -279,7 +310,9 @@ impl FsWriteBackCache {
             let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
                 continue;
             };
-            if file_name.starts_with(&prefix) {
+            if file_name.starts_with(&prefix)
+                && self.sealed_record_from_path(path.clone()).is_some()
+            {
                 let _ = fs::remove_file(path).await;
             }
         }
@@ -307,7 +340,7 @@ impl FsWriteBackCache {
                     Ok(_) | Err(_) => continue,
                 }
             } else if Self::is_sealed_path(&path) {
-                match Self::sealed_record_from_path(path) {
+                match self.sealed_record_from_path(path) {
                     Some(record) if record.ino == ino && record.chunk_id == chunk_id => record,
                     Some(_) | None => continue,
                 }
@@ -364,7 +397,7 @@ impl FsWriteBackCache {
                     Ok(_) | Err(_) => continue,
                 }
             } else if Self::is_sealed_path(&path) {
-                match Self::sealed_record_from_path(path) {
+                match self.sealed_record_from_path(path) {
                     Some(record) if record.ino == ino && record.chunk_id == chunk_id => record,
                     Some(_) | None => continue,
                 }
@@ -406,6 +439,7 @@ impl FsWriteBackCache {
         path: PathBuf,
     ) -> anyhow::Result<()> {
         let record = DirtySliceRecord {
+            volume_scope: self.volume_scope.clone(),
             key,
             ino: key.ino,
             chunk_id: key.chunk_id,
@@ -427,7 +461,13 @@ impl FsWriteBackCache {
         length: u64,
         slice_path: PathBuf,
     ) -> anyhow::Result<()> {
-        let sealed_path = key.sealed_slice_path(&self.root, chunk_offset, length);
+        let scope_fingerprint = self.volume_scope_fingerprint();
+        let sealed_path = key.sealed_slice_path(
+            &self.root,
+            chunk_offset,
+            length,
+            scope_fingerprint.as_deref(),
+        );
         fs::rename(&slice_path, &sealed_path).await?;
         Ok(())
     }
@@ -593,7 +633,7 @@ impl WriteBackCache for FsWriteBackCache {
                 if Self::is_meta_path(&path) {
                     self.push_recoverable_meta(&path, &mut records).await?;
                 } else if Self::is_sealed_path(&path) {
-                    Self::push_recoverable_sealed(path, &mut records);
+                    self.push_recoverable_sealed(path, &mut records);
                 }
                 continue;
             }
@@ -834,6 +874,99 @@ mod tests {
         let records = cache.recover().await.unwrap();
         assert_eq!(records.len(), 1);
         assert_eq!(records[0].path, path);
+    }
+
+    #[tokio::test]
+    async fn volume_scopes_isolate_overlapping_dirty_slice_ids() {
+        let temp = tempfile::tempdir().unwrap();
+        let key = DirtySliceKey {
+            ino: 7,
+            chunk_id: 11,
+            local_seq: 13,
+            epoch: 0,
+        };
+        let first =
+            FsWriteBackCache::new_with_sync(temp.path().join("flat-v1/first/writeback"), true)
+                .with_volume_scope(Some("first".to_string()));
+        let second =
+            FsWriteBackCache::new_with_sync(temp.path().join("flat-v1/second/writeback"), true)
+                .with_volume_scope(Some("second".to_string()));
+
+        first
+            .persist_slice_data(key, vec![Bytes::from_static(b"first-volume")], 0)
+            .await
+            .unwrap();
+        first.seal_slice_record(key, 0, 12).await.unwrap();
+        second
+            .persist_slice_data(key, vec![Bytes::from_static(b"second-volume")], 0)
+            .await
+            .unwrap();
+        second.seal_slice_record(key, 0, 13).await.unwrap();
+
+        let first_records = first.recover().await.unwrap();
+        let second_records = second.recover().await.unwrap();
+        assert_eq!(first_records[0].volume_scope.as_deref(), Some("first"));
+        assert_eq!(second_records[0].volume_scope.as_deref(), Some("second"));
+        assert_eq!(
+            tokio::fs::read(&first_records[0].path).await.unwrap(),
+            b"first-volume"
+        );
+        assert_eq!(
+            tokio::fs::read(&second_records[0].path).await.unwrap(),
+            b"second-volume"
+        );
+    }
+
+    #[tokio::test]
+    async fn recovery_rejects_json_record_from_another_volume_scope() {
+        let temp = tempfile::tempdir().unwrap();
+        let key = DirtySliceKey {
+            ino: 7,
+            chunk_id: 11,
+            local_seq: 13,
+            epoch: 0,
+        };
+        let writer = FsWriteBackCache::new_with_sync(temp.path().to_path_buf(), true)
+            .with_volume_scope(Some("first".to_string()));
+        writer
+            .persist_slice_data(key, vec![Bytes::from_static(b"payload")], 0)
+            .await
+            .unwrap();
+        writer.seal_slice_record(key, 0, 7).await.unwrap();
+
+        let wrong_volume = FsWriteBackCache::new_with_sync(temp.path().to_path_buf(), true)
+            .with_volume_scope(Some("second".to_string()));
+        assert!(wrong_volume.recover().await.unwrap().is_empty());
+        assert!(
+            wrong_volume
+                .read_meta(&key.meta_path(temp.path()))
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn recovery_rejects_compact_record_from_another_volume_scope() {
+        let temp = tempfile::tempdir().unwrap();
+        let key = DirtySliceKey {
+            ino: 7,
+            chunk_id: 11,
+            local_seq: 13,
+            epoch: 0,
+        };
+        let writer = FsWriteBackCache::new_with_sync(temp.path().to_path_buf(), false)
+            .with_volume_scope(Some("first".to_string()));
+        writer
+            .persist_slice_data(key, vec![Bytes::from_static(b"payload")], 0)
+            .await
+            .unwrap();
+        writer.seal_slice_record(key, 0, 7).await.unwrap();
+        assert_eq!(writer.recover().await.unwrap().len(), 1);
+
+        let wrong_volume = FsWriteBackCache::new_with_sync(temp.path().to_path_buf(), false)
+            .with_volume_scope(Some("second".to_string()));
+        assert!(wrong_volume.recover().await.unwrap().is_empty());
+        assert!(wrong_volume.open_slice(&key).await.is_err());
     }
 
     #[tokio::test]

--- a/src/vfs/fs/mod.rs
+++ b/src/vfs/fs/mod.rs
@@ -498,7 +498,7 @@ where
             #[cfg(not(feature = "workspace-overlay"))]
             let cache_root = config.cache.cache_root.join("writeback");
             let _ = std::fs::create_dir_all(&cache_root);
-            let wb = Arc::new(if config.cache.persist_write_cache_after_upload {
+            let wb = if config.cache.persist_write_cache_after_upload {
                 crate::vfs::cache::write_back::FsWriteBackCache::new_with_sync_and_read_cache(
                     cache_root,
                     config.cache.writeback_persist_sync,
@@ -510,7 +510,8 @@ where
                     cache_root,
                     config.cache.writeback_persist_sync,
                 )
-            });
+            };
+            let wb = Arc::new(wb.with_volume_scope(config.cache.volume_scope.clone()));
 
             // Crash recovery is only needed when metadata can be committed
             // before object upload completes.


### PR DESCRIPTION
## Summary
- derive a stable credential-scrubbed scope from each flat volume's metadata and object-store identities
- isolate clean cache and writeback state under cache_root/flat-v1/<scope>, leaving legacy unscoped state untouched
- stamp JSON and compact sealed recovery records with the volume scope and reject mismatches
- cover overlapping slice/block IDs across independent volumes and credential rotation

## Tests
- full Rust CI workflow locally: formatting, script checks, workspace check/build, all FUSE feature checks, default/overlay/all-features tests, and both clippy passes

Closes #69