### PR TITLE
fix(test): pass create-only mode to object store helpers

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -616,6 +616,7 @@ mod flat_cache_namespace_tests {
             ObjectClient::new(LocalFsBackend::new(&first.data_dir)),
             layout,
             &first.cache,
+            false,
         )
         .await
         .unwrap();
@@ -623,6 +624,7 @@ mod flat_cache_namespace_tests {
             ObjectClient::new(LocalFsBackend::new(&second.data_dir)),
             layout,
             &second.cache,
+            false,
         )
         .await
         .unwrap();
@@ -644,6 +646,7 @@ mod flat_cache_namespace_tests {
             ObjectClient::new(LocalFsBackend::new(&first.data_dir)),
             layout,
             &first.cache,
+            false,
         )
         .await
         .unwrap();
@@ -651,6 +654,7 @@ mod flat_cache_namespace_tests {
             ObjectClient::new(LocalFsBackend::new(&second.data_dir)),
             layout,
             &second.cache,
+            false,
         )
         .await
         .unwrap();


### PR DESCRIPTION
## Summary

- Pass the explicit create-only mode to flat-layout object-store helpers used by binary tests.
- Keep the existing flat-layout behavior by selecting `false`.

## Why

The helper gained a required `create_only_writes` argument, but four test-only call sites were not updated. As a result, the Rust job on `main` could not compile the binary test target.

## Validation

- `cargo fmt --all --check`
- Focused flat cache namespace test: 1 passed
- `cargo test --workspace --lib --bins -- --test-threads=1`: 1285 passed, 0 failed, 350 ignored
- `cargo clippy --workspace --all-targets -- -D warnings`

## Risk

Low. This only updates test call sites and does not change production behavior.